### PR TITLE
agent_config profiles for windows

### DIFF
--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -255,7 +255,7 @@ int local_start()
 
     OS_ReadKeys(&keys);
     OS_StartCounter(&keys);
-    os_write_agent_info(keys.keyentries[0]->name, NULL, keys.keyentries[0]->id, NULL);
+    os_write_agent_info(keys.keyentries[0]->name, NULL, keys.keyentries[0]->id, logr->profile);
 
 
     /* Initial random numbers */


### PR DESCRIPTION
Current version of OSSEC's windows agent ignores every <config-profile> in its configuration. This PR corrects this bug so that config profiles also work on windows.

Original Pull Request: https://bitbucket.org/jbcheng/ossec-hids/pull-request/20/agent_config-profiles-for-windows/diff
