### PR TITLE
Fix potential infinite loop when adding new agent using file input

### DIFF
--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -198,7 +198,7 @@ int add_agent()
     do
     {
         /* Default ID */
-        i = MAX_AGENTS + 768;
+        i = MAX_AGENTS + 32512;
         snprintf(id, 8, "%03d", i);
         while(!IDExist(id))
         {

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -100,6 +100,7 @@ fpos_t fp_pos;
 #define NO_KEY          "\n** Invalid authentication key. Starting over again.\n"
 #define INVALID_ID      "\n** Invalid ID '%s' given. ID must be numeric (max 8 digits).\n\n"
 #define INVALID_NAME    "\n** Invalid name '%s' given. Name must contain only alphanumeric characters (min=2, max=32).\n\n"
+#define NO_DEFAULT      "\n** Could not get default ID. Ran out of IDs to try with a max of '%d'. Either need to raise max agents or clean out client.keys.\n\n"
 
 /* Remove agent */
 #define REMOVE_ID       "Provide the ID of the agent to be removed (or '\\q' to quit): "

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -350,33 +350,35 @@ int k_bulkload(char *cmdbulk)
           		continue;
       		}
 
-    		do
-    		{
-        		/* Default ID */
-        		i = 1024;
-        		snprintf(id, 8, "%03d", i);
-        		while(!IDExist(id))
-        		{
-            		i--;
-            		snprintf(id, 8, "%03d", i);
+		/* Default ID */
+		i = MAX_AGENTS + 32512;
+		snprintf(id, 8, "%03d", i);
+		while(!IDExist(id))
+		{
+		i--;
+		snprintf(id, 8, "%03d", i);
 
-            		/* No key present, use id 0 */
-            		if(i <= 0)
-            		{
-                		i = 0;
-                		break;
-            		}
-        		}
-        		snprintf(id, 8, "%03d", i+1);
+		/* No key present, use id 0 */
+		if(i <= 0)
+		{
+			i = 0;
+			break;
+		}
+		}
+		snprintf(id, 8, "%03d", i+1);
 
-        		if(!OS_IsValidID(id))
-            		printf(INVALID_ID, id);
+		if(!OS_IsValidID(id)) 
+		{
+		printf(INVALID_ID, id);
+		continue;
+		}
 
-        		/* Search for ID KEY  -- no duplicates */
-        		if(IDExist(id))
-            		printf(ADD_ERROR_ID, id);
-
-    		} while(IDExist(id) || !OS_IsValidID(id));
+		/* Search for ID KEY  -- no duplicates */
+		if(IDExist(id))
+		{
+		printf(NO_DEFAULT, i+1);
+		continue;
+		}
 
     		printf(AGENT_INFO, id, name, ip);
     		fflush(stdout);


### PR DESCRIPTION
When adding a new agent using the -f option provided by manage_agents
there is a possibility that it loops infinitely if you have used up all
of the potential IDs. It will say that the ID needs to be unique since
the last ID checked is already in use. This commit adds a new message
stating the problem and prevents the infinite loop. It also increases
the amount of IDs manage_agents will look at when adding new agents both
in the interactive mode and when using the -f option.

Original  pull request: https://bitbucket.org/jbcheng/ossec-hids/pull-request/21/fix-potential-infinite-loop-when-adding
