### PR TITLE
Add TimeGenerated to the output of Windows Event Logs

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1720,10 +1720,11 @@
     Logon Type: 2       Logon Process:  User32          Authentication 
     Package: Negotiate       Workstation Name:   ad
   - WinEvtLog: Security: AUDIT_SUCCESS(538): Security: lac: OSSEC-HM: OSSEC-HM: User Logoff:        User Name:      lac     Domain:         OSSEC-HM        Logon ID:               (0x0,0x7C966E)          Logon Type:     2  
+  - 2013 Oct 09 17:09:04 WinEvtLog: Application: INFORMATION(1): My Script: (no user): no domain: demo1.foo.example.com: test
   -->
 <decoder name="windows">
   <type>windows</type>
-  <prematch>^WinEvtLog: </prematch>
+  <prematch>^\d\d\d\d \w\w\w \d\d \d\d:\d\d:\d\d WinEvtLog: |^WinEvtLog: </prematch>
   <regex offset="after_prematch">^\.+: (\w+)\((\d+)\): (\.+): </regex>
   <regex>(\.+): \.+: (\S+): </regex>
   <order>status, id, extra_data, user, system_name</order>

--- a/src/logcollector/read_win_el.c
+++ b/src/logcollector/read_win_el.c
@@ -89,6 +89,21 @@ int startEL(char *app, os_el *el)
 
 
 
+/** char epoch_to_human(int time)
+ * Returns a string that is a human readable 
+ * datetime from an epoch int.
+ */
+char *epoch_to_human(time_t epoch)
+{
+    struct tm   *ts;
+    static char buf[80];
+
+    ts = localtime(&epoch);
+    strftime(buf, sizeof(buf), "%Y %b %d %H:%M:%S", ts);
+    return(buf);
+}
+
+
 /** char *el_getCategory(int category_id)
  * Returns a string related to the category id of the log.
  */
@@ -561,7 +576,8 @@ void readel(os_el *el, int printit)
                 final_msg[OS_MAXSTR - OS_LOG_HEADER -1] = '\0';
 
                 snprintf(final_msg, OS_MAXSTR - OS_LOG_HEADER -1,
-                        "WinEvtLog: %s: %s(%d): %s: %s: %s: %s: %s",
+                        "%s WinEvtLog: %s: %s(%d): %s: %s: %s: %s: %s",
+                        epoch_to_human((int)el->er->TimeGenerated),
                         el->name,
                         category,
                         id,


### PR DESCRIPTION
Updated read_win_el.c to include TimeGenerated from an EVENTLOGRECORD
formatted into a human readable format for better logging. Also updated
the decoder to handle this change.

Original Pull Request: https://bitbucket.org/jbcheng/ossec-hids/pull-request/23/add-timegenerated-to-the-output-of-windows/diff
