### PR TITLE
Allow NIX agent to use "-f" option and run in foreground

### DIFF
--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -36,11 +36,16 @@ void AgentdStart(char *dir, int uid, int gid, char *user, char *group)
     struct timeval fdtimeout;
 
 
-    /* Going daemon */
     pid = getpid();
     available_server = 0;
-    nowDaemon();
-    goDaemon();
+
+
+    /* Going Daemon */
+    if (!run_foreground)
+    {
+       nowDaemon();
+       goDaemon();
+    }
 
 
     /* Setting group ID */

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -71,6 +71,7 @@ void run_notify();
 #include "sec.h"
 
 int available_server;
+int run_foreground;
 keystore keys;
 agent *logr;
 

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -44,12 +44,13 @@ int main(int argc, char **argv)
     int uid = 0;
     int gid = 0;
 
+    run_foreground = 0;
 
     /* Setting the name */
     OS_SetName(ARGV0);
 
 
-    while((c = getopt(argc, argv, "Vtdhu:g:D:")) != -1){
+    while((c = getopt(argc, argv, "Vtdfhu:g:D:")) != -1){
         switch(c){
             case 'V':
                 print_version();
@@ -59,6 +60,9 @@ int main(int argc, char **argv)
                 break;
             case 'd':
                 nowDebug();
+                break;
+            case 'f':
+                run_foreground = 1;
                 break;
             case 'u':
                 if(!optarg)


### PR DESCRIPTION
```
While this works I'm not sure I fully understand how it affects this code when the agent is actually run in the foreground:

srandom( time(0) + getpid()+ pid + getppid());

My guess is this is why the foreground option was never implemented for this daemon in the first place. Seems like the random stuff is only used with keep_alive messages and might not be that big of a deal but I'd appreciate someone double checking.
```

Original Pull Request: https://bitbucket.org/jbcheng/ossec-hids/pull-request/35/allow-nix-agent-to-use-f-option-and-run-in/diff
