### PR TITLE
Fix timeout comment in receiver-win.c

### DIFF
--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -68,7 +68,7 @@ void *receiver_thread(void *none)
         selecttime.tv_usec = 0;
 
 
-        /* Wait for 120 seconds at a maximum for any descriptor */
+        /* Wait with a timeout for any descriptor */
         recv_b = select(0, &fdset, NULL, NULL, &selecttime);
         if(recv_b == -1)
         {


### PR DESCRIPTION
Original Pull Request: https://bitbucket.org/jbcheng/ossec-hids/pull-request/30/fix-timeout-comment-in-receiver-winc/diff
