### PR TITLE
Make analysisd.debug in internal_options.conf work

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -133,6 +133,7 @@ int main_analysisd(int argc, char **argv)
 #endif
 {
     int c = 0, m_queue = 0, test_config = 0,run_foreground = 0;
+    int debug_level = 0;
     char *dir = DEFAULTDIR;
     char *user = USER;
     char *group = GROUPGLOBAL;
@@ -162,6 +163,7 @@ int main_analysisd(int argc, char **argv)
                 break;
             case 'd':
                 nowDebug();
+                debug_level = 1;
                 break;
             case 'f':
                 run_foreground = 1;
@@ -194,6 +196,20 @@ int main_analysisd(int argc, char **argv)
                 break;
         }
 
+    }
+
+    /* Check current debug_level
+     * Command line setting takes precedence 
+     */
+    if (debug_level == 0)
+    {
+        /* Getting debug level */
+        debug_level = getDefine_Int("analysisd", "debug", 0, 2);
+        while(debug_level != 0)
+        {
+            nowDebug();
+            debug_level--;
+        }
     }
 
 


### PR DESCRIPTION
This should allow the user to specify a debug level for the analysisd
daemon using the analysisd.debug option in the internal_options.conf.
The debug level specified on the command line takes precedence.

Original Pull Request: https://bitbucket.org/jbcheng/ossec-hids/pull-request/38/make-analysisddebug-in/diff
