### PR TITLE
Make remoted.debug in internal_options.conf work

### DIFF
--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -35,6 +35,7 @@
 int main(int argc, char **argv)
 {
     int c = 0;
+    int debug_level = 0;
     int test_config = 0;
 
     char *dir = DEFAULTDIR;
@@ -59,6 +60,7 @@ int main(int argc, char **argv)
                 break;
             case 'd':
                 nowDebug();
+                debug_level = 1;
                 break;
             case 'u':
                 if(!optarg)
@@ -80,6 +82,21 @@ int main(int argc, char **argv)
                 break;
         }
     }
+
+    /* Check current debug_level
+     * Command line setting takes precedence
+     */
+    if (debug_level == 0)
+    {
+        /* Getting debug level */
+        debug_level = getDefine_Int("remoted", "debug", 0, 2);
+        while(debug_level != 0)
+        {
+            nowDebug();
+            debug_level--;
+        }
+    }
+
 
     debug1(STARTED_MSG, ARGV0);
 


### PR DESCRIPTION
This should allow the user to specify a debug level for the remoted
daemon the remoted.debug option in the internal_options.conf. The debug
level specified on the command line takes precedence

Original Pull Request: https://bitbucket.org/jbcheng/ossec-hids/pull-request/37/make-remoteddebug-in-internal_optionsconf/diff
