### PR TITLE
Labrown remoted child pid

### DIFF
--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -58,6 +58,11 @@ static void HandleClient(int client_socket, char *srcip)
 
     char *buffer_pt = NULL;
 
+    /* Create PID file */
+    if(CreatePID(ARGV0, getpid()) < 0)
+    {
+        ErrorExit(PID_ERROR,ARGV0);
+    }
 
     /* Initializing some variables */
     memset(buffer, '\0', OS_MAXSTR +2);
@@ -71,6 +76,7 @@ static void HandleClient(int client_socket, char *srcip)
         if((r_sz = OS_RecvTCPBuffer(client_socket, buffer, OS_MAXSTR -2)) < 0)
         {
             close(client_socket);
+            DeletePID(ARGV0);
             return;
         }
 


### PR DESCRIPTION
This patch adds creation of PID files for ossec-remoted children so they get properly killed when the ossec service is stopped or restarted.

Original Pull Request: https://bitbucket.org/jbcheng/ossec-hids/pull-request/28/create-pid-files-for-ossec-remoted/diff
