### PR TITLE
HandleClient should try to open the m_queue in WRITE mode instead of READ

### DIFF
--- a/src/remoted/syslogtcp.c
+++ b/src/remoted/syslogtcp.c
@@ -143,7 +143,7 @@ static void HandleClient(int client_socket, char *srcip)
         if(SendMSG(logr.m_queue, buffer_pt, srcip,SYSLOG_MQ) < 0)
         {
             merror(QUEUE_ERROR,ARGV0,DEFAULTQUEUE, strerror(errno));
-            if((logr.m_queue = StartMQ(DEFAULTQUEUE,READ)) < 0)
+            if((logr.m_queue = StartMQ(DEFAULTQUEUE,WRITE)) < 0)
             {
                 ErrorExit(QUEUE_FATAL,ARGV0,DEFAULTQUEUE);
             }


### PR DESCRIPTION
HandleClient does not ever exit after ossec is stopped or restarted
because the call to StartMQ on line 146 is for READ mode instead of
WRITE. When changed to WRITE, the StartMQ call fails and ossec-remoted
exits.

Original Pull REquest: https://bitbucket.org/jbcheng/ossec-hids/pull-request/27/handleclient-should-try-to-open-the/diff
