### PR TITLE
Validate if a file is readable text when report_changes is set

### DIFF
--- a/src/Config.Make
+++ b/src/Config.Make
@@ -8,7 +8,7 @@ include ${PT}LOCATION
 include ${PT}Config.OS
 
 
-CFLAGS = -g -Wall -I${PT} -I${PT}headers ${CPATH} ${CEXTRA} ${DEXTRA} ${EEXTRA} ${FEXTRA} ${GEXTRA} ${HEXTRA} ${CGEOIP} -DARGV0=\"${NAME}\" -DXML_VAR=\"var\" -DOSSECHIDS
+CFLAGS = -g -Wall -I${PT} -I${PT}headers ${CPATH} ${CEXTRA} ${DEXTRA} ${EEXTRA} ${FEXTRA} ${GEXTRA} ${HEXTRA} ${MEXTRA} ${CGEOIP} -DARGV0=\"${NAME}\" -DXML_VAR=\"var\" -DOSSECHIDS
 
 SOURCES = *.c
 OBJECTS = *.o 

--- a/src/Makeall
+++ b/src/Makeall
@@ -75,6 +75,17 @@ if [ "X${ARGV}" = "Xall" -o "X${ARGV}" = "Xrootcheck" -o "X${ARGV}" = "Xlibs" ];
         fi
     fi    
 
+    # Checking for libmagic
+    if [ "X$SYSCHECK" = "Xyes" ]; then
+        if [ -e /usr/include/linux/magic.h ]; then
+            echo "MEXTRA=-DUSE_MAGIC" >> Config.OS
+            echo "MAGICCMD=-lmagic" >> Config.OS
+        elif [ -e /usr/include/magic.h ]; then
+            echo "MEXTRA=-DUSE_MAGIC" >> Config.OS
+            echo "MAGICCMD=-lmagic" >> Config.OS
+        fi
+    fi
+
     if [ "X$OS" = "XAIX" ]; then
         echo "EEXTRA=-DAIX -DHIGHFIRST" >> Config.OS
         PATH=$PATH:/usr/vac/bin

--- a/src/syscheckd/Makefile
+++ b/src/syscheckd/Makefile
@@ -12,7 +12,7 @@ OBJS = syscheck.c config.c seechanges.c run_realtime.c create_db.c run_check.c $
 OBJS2 = syscheck-baseline.c config.c create_db.c run_check.c ${OS_CONFIG} ${OS_ROOTCHECK} ${OS_SHARED} ${OS_XML} ${OS_REGEX} ${OS_NET} ${OS_CRYPTO}
 
 syscheck:
-		$(CC) $(CFLAGS) ${OS_LINK} $(OBJS) -o ${NAME}
+		$(CC) $(CFLAGS) ${MAGICCMD} ${OS_LINK} $(OBJS) -o ${NAME}
 clean:
 		${CLEAN}
 build:

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -15,7 +15,28 @@
 #include "shared.h"
 #include "os_crypto/md5/md5_op.h"
 
+#ifdef USE_MAGIC
+#include <magic.h>
+extern magic_t magic_cookie;
 
+int is_text(magic_t cookie, const void* buf, size_t len)
+{
+    const char* magic = magic_buffer(cookie, buf, len);
+
+    if(!magic)
+    {
+        const char* err = magic_error(cookie);
+        merror("%s: ERROR: magic_buffer: %s", ARGV0, err ? err : "unknown");
+        return(1); // TODO default to true?
+    }
+    else
+    {
+        if(strncmp(magic, "text/", 5) == 0) return(1);
+    }
+
+    return(0);
+}
+#endif
 
 /* Generate diffs alerts. */
 char *gen_diff_alert(char *filename, int alert_diff_time)
@@ -115,13 +136,22 @@ int seechanges_dupfile(char *old, char *new)
         return(0);
     }
 
-    while((n = fread(buf, 1, 2048, fpr)) > 0)
+    n = fread(buf, 1, 2048, fpr);
+    #ifdef USE_MAGIC
+    if(is_text(magic_cookie, buf, n) == 0)
+    {
+        goto cleanup;
+    }
+    #endif
+
+    do
     {
         buf[n] = '\0';
         fwrite(buf, n, 1, fpw);
-
     }
+    while((n = fread(buf, 1, 2048, fpr)) > 0);
 
+cleanup:
     fclose(fpr);
     fclose(fpw);
     return(1);


### PR DESCRIPTION
Syscheckd will save (in <ossec>/queue/diff/) any file with report_changes
option, e.g. /chroot/dev/urandom (yes it really happened to me), iso, mp3. This patch integrates libmagic
to validate mime type. Only mime type beginning with 'text/', e.g. text/html,
text/plain, will be copied and reported by diff. 

This should pave the way for binary diff. ;)

Reviewers: I'm not quite sure about the build process (e.g. MEXTRA, MAGICCMD) so please advice.
