### PR TITLE
better install for eventchannel support (now only 1 installer)

### DIFF
--- a/src/win32/make.sh
+++ b/src/win32/make.sh
@@ -2,6 +2,7 @@ echo Making windows agent
 
 i686-w64-mingw32-windres -i icofile.rc -o icon.o
 i686-w64-mingw32-gcc -o ossec-agent.exe -Wall  -DARGV0=\"ossec-agent\" -DCLIENT -DWIN32 -DOSSECHIDS icon.o os_regex/*.c os_net/*.c os_xml/*.c zlib-1.2.3/*.c config/*.c shared/*.c os_execd/*.c os_crypto/blowfish/*.c os_crypto/md5/*.c os_crypto/sha1/*.c os_crypto/md5_sha1/*.c os_crypto/shared/*.c rootcheck/*.c *.c -Iheaders/ -I./ -lwsock32
+i686-w64-mingw32-gcc -o ossec-agent-eventchannel.exe -Wall  -DARGV0=\"ossec-agent\" -DCLIENT -DWIN32 -DOSSECHIDS -DEVENTCHANNEL_SUPPORT icon.o os_regex/*.c os_net/*.c os_xml/*.c zlib-1.2.3/*.c config/*.c shared/*.c os_execd/*.c os_crypto/blowfish/*.c os_crypto/md5/*.c os_crypto/sha1/*.c os_crypto/md5_sha1/*.c os_crypto/shared/*.c rootcheck/*.c *.c -Iheaders/ -I./ -lwsock32 -lwevtapi
 i686-w64-mingw32-gcc -o ossec-rootcheck.exe -Wall  -DARGV0=\"ossec-rootcheck\" -DCLIENT -DWIN32 icon.o os_regex/*.c os_net/*.c os_xml/*.c config/*.c shared/*.c win_service.c rootcheck/*.c -Iheaders/ -I./ -lwsock32
 i686-w64-mingw32-gcc -o manage_agents.exe -Wall  -DARGV0=\"ossec-agent\" -DCLIENT -DWIN32 -DMA os_regex/*.c zlib-1.2.3/*.c os_zlib.c shared/*.c os_crypto/blowfish/*.c os_crypto/md5/*.c os_crypto/shared/*.c addagent/*.c -Iheaders/ -I./ -lwsock32
 i686-w64-mingw32-gcc -o setup-windows.exe -Wall os_regex/*.c -DARGV0=\"setup-windows\" -DCLIENT -DWIN32 win_service.c shared/file_op.c shared/debug_op.c setup/setup-win.c setup/setup-shared.c -Iheaders/ -I./ -lwsock32
@@ -17,9 +18,3 @@ cd ../
 
 makensis ui.nsi
 makensis ossec-installer.nsi
-
-echo Making windows agent with eventchannel support
-
-i686-w64-mingw32-gcc -o ossec-agent.exe -Wall  -DARGV0=\"ossec-agent\" -DCLIENT -DWIN32 -DOSSECHIDS -DEVENTCHANNEL_SUPPORT icon.o os_regex/*.c os_net/*.c os_xml/*.c zlib-1.2.3/*.c config/*.c shared/*.c os_execd/*.c os_crypto/blowfish/*.c os_crypto/md5/*.c os_crypto/sha1/*.c os_crypto/md5_sha1/*.c os_crypto/shared/*.c rootcheck/*.c *.c -Iheaders/ -I./ -lwsock32 -lwevtapi
-
-makensis -DOutFile=ossec-win32-agent-with-eventchannel.exe ossec-installer.nsi

--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -2,6 +2,8 @@
 ;Include Modern UI
 
 !include "MUI.nsh"
+!include "LogicLib.nsh"
+!include "WinVer.nsh"
 
 ;--------------------------------
 ;General
@@ -85,6 +87,7 @@ ClearErrors
 
 File \
 ossec-agent.exe \
+ossec-agent-eventchannel.exe \
 default-ossec.conf \
 manage_agents.exe \
 os_win32ui.exe \
@@ -108,6 +111,15 @@ help.txt \
 vista_sec.csv \
 route-null.cmd \
 restart-ossec.cmd
+
+; Use appropriate version of "ossec-agent.exe"
+${If} ${AtLeastWinVista}
+  Delete "$INSTDIR\ossec-agent.exe"
+  Rename "$INSTDIR\ossec-agent-eventchannel.exe" "$INSTDIR\ossec-agent.exe"
+${Else}
+  Delete "$INSTDIR\ossec-agent-eventchannel.exe"
+${Endif}
+
 
 WriteRegStr HKLM SOFTWARE\ossec "Install_Dir" "$INSTDIR"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "DisplayName" "${NAME} ${VERSION}"


### PR DESCRIPTION
This follows this commit: ossec/ossec-hids@75a91043c3d64cd2a7e5dcbb077755bf2aa85760

This commit modifies the build process of the Windows installer in order to have only one installer handle two cases:
- Deploy ossec-agent-eventchannel.exe on Vista or greater
- Deploy ossec-agent.exe otherwise

The installer packages the two executables and checks Windows version at runtime in order to decide which version of "ossec-agent.exe" should be used.
