### PR TITLE
Removed keepalive message from win_agent.c when not in debug

### DIFF
--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -588,7 +588,6 @@ void send_win32_info(time_t curr_time)
 
 
     debug1("%s: DEBUG: Sending keep alive message.", ARGV0);
-    verbose("%s: Sending keep alive message....", ARGV0);
 
     /* fixing time */
     __win32_curr_time = curr_time;


### PR DESCRIPTION
Seems a bit excessive to have this message in the logs when not in any kind of debug mode. That is what I am observing on some of the windows agents we are running as of right now.
