### PR TITLE
Output unformatted JSON and include the file path for syscheck alerts in ZeroMQ JSON output

### DIFF
--- a/src/analysisd/zeromq_output.c
+++ b/src/analysisd/zeromq_output.c
@@ -88,6 +88,8 @@ char *Eventinfo_to_jsonstr(Eventinfo *lf) {
     if (lf->filename) {
         cJSON_AddItemToObject(root, "file", file_diff=cJSON_CreateObject());
 
+        cJSON_AddStringToObject(file_diff, "path", lf->filename);
+
         if (lf->md5_before && lf->md5_after && strcmp(lf->md5_before, lf->md5_after) != 0  ) {
             cJSON_AddStringToObject(file_diff,"md5_before", lf->md5_before);
             cJSON_AddStringToObject(file_diff,"md5_after", lf->md5_after);


### PR DESCRIPTION
Unformatted JSON should be used rather than formatted JSON since it would typically be used by  other programs and not read directly by users.

The file path should be included in syscheck alerts so a receiving program doesn't have to scrape it from the log message.
