### PR TITLE
rootcheck: don't traverse NFS/CIFS mounts

### DIFF
--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -13,6 +13,7 @@
 
 #include "shared.h"
 #include "rootcheck.h"
+#include <sys/statfs.h>
 
 int _sys_errors;
 int _sys_total;
@@ -174,8 +175,9 @@ int read_sys_dir(char *dir_name, int do_read)
     int did_changed = 0;
     DIR *dp;
 
-	struct dirent *entry;
-    struct stat statbuf;	
+    struct dirent *entry;
+    struct stat statbuf;
+    struct statfs stfs;
 
     #ifndef WIN32
     char *(dirs_to_doread[]) = { "/bin", "/sbin", "/usr/bin",
@@ -204,6 +206,15 @@ int read_sys_dir(char *dir_name, int do_read)
         i = 0;
     }
 
+
+    /* ignore NFS (0x6969) or CIFS (0xFF534D42) mounts */
+    if ( ! statfs(dir_name, &stfs) ) {
+      if ( (stfs.f_type == 0x6969) || (stfs.f_type == 0xFF534D42) ) {
+        return(1); /* NFS/CIFS path */
+      }
+    } else {
+      /* do something with the error? */
+    }
 
 
     /* Getting the number of nodes. The total number on opendir


### PR DESCRIPTION
This prevents every node with a network mounted filesystem from scanning the share.  You will need to run OSSEC-HIDS on the share point if you want the same protection.  However, having 2,000 nodes running intensive scans on an NFS share at the same time results in less than ideal performance for everything that uses that share.
