### PR TITLE
Make remoted.debug in internal_options.conf work

### DIFF
--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -20,6 +20,7 @@ int main(int argc, char **argv)
 {
     int i = 0,c = 0;
     int uid = 0, gid = 0;
+    int debug_level = 0;
     int test_config = 0,run_foreground = 0;
 
     char *cfg = DEFAULTCPATH;
@@ -42,6 +43,7 @@ int main(int argc, char **argv)
                 break;
             case 'd':
                 nowDebug();
+                debug_level = 1;
                 break;
             case 'f':
                 run_foreground = 1;
@@ -70,6 +72,21 @@ int main(int argc, char **argv)
                 dir = optarg;
         }
     }
+
+    /* Check current debug_level
+     * Command line setting takes precedence 
+     */
+    if (debug_level == 0)
+    {
+        /* Getting debug level */
+        debug_level = getDefine_Int("remoted", "debug", 0, 2);
+        while(debug_level != 0)
+        {
+            nowDebug();
+            debug_level--;
+        }
+    }
+
 
     debug1(STARTED_MSG,ARGV0);
 


### PR DESCRIPTION
This should allow the user to specify a debug level for the remoted
daemon using the remoted.debug option in the internal_options.conf.
The debug level specified on the command line takes precedence.
