### PR TITLE
rename syscheck config struct 

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -17,7 +17,7 @@
 
 
 
-int dump_syscheck_entry(config *syscheck, char *entry, int vals, int reg, char *restrictfile)
+int dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int reg, char *restrictfile)
 {
     int pl = 0;
 
@@ -107,7 +107,7 @@ int dump_syscheck_entry(config *syscheck, char *entry, int vals, int reg, char *
 
 /* Read Windows registry configuration */
 #ifdef WIN32
-int read_reg(config *syscheck, char *entries)
+int read_reg(syscheck_config *syscheck, char *entries)
 {
     int i;
     char **entry;
@@ -193,7 +193,7 @@ int read_reg(config *syscheck, char *entries)
 
 
 /* Read directories attributes */
-int read_attr(config *syscheck, char *dirs, char **g_attrs, char **g_values)
+int read_attr(syscheck_config *syscheck, char *dirs, char **g_attrs, char **g_values)
 {
     char *xml_check_all = "check_all";
     char *xml_check_sum = "check_sum";
@@ -584,9 +584,9 @@ int Read_Syscheck(XML_NODE node, void *configp, void *mailp)
     check_sum="yes">/var/log</directories>
     */
 
-    config *syscheck;
+    syscheck_config *syscheck;
 
-    syscheck = (config *)configp;
+    syscheck = (syscheck_config *)configp;
 
 
     while(node[i])

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -82,7 +82,7 @@ typedef struct _config
 
     char *prefilter_cmd;
 
-}config;
+}syscheck_config;
 
 #endif
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -30,7 +30,7 @@
 
 #include "rootcheck/rootcheck.h"
 
-int dump_syscheck_entry(config *syscheck, char *entry, int vals, int reg, char *restrictfile);
+int dump_syscheck_entry(syscheck_config *syscheck, char *entry, int vals, int reg, char *restrictfile);
 
 #ifdef USE_MAGIC
 #include <magic.h>
@@ -67,7 +67,7 @@ void read_internal(int debug_level)
     syscheck.sleep_after = getDefine_Int("syscheck","sleep_after",1,9999);
 
     /* Check current debug_level
-     * Command line setting takes precedence 
+     * Command line setting takes precedence
      */
     if (debug_level == 0)
     {

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -23,7 +23,7 @@
 
 
 /* Global config */
-config syscheck;
+syscheck_config syscheck;
 
 
 /** Function Prototypes **/


### PR DESCRIPTION
rename syscheck config struct from config to syscheck_config due to naming conflict to struct config in zlib
