### PR TITLE
rename global agent struct

### DIFF
--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -73,7 +73,7 @@ void run_notify();
 int available_server;
 int run_foreground;
 keystore keys;
-agent *logr;
+agent *agt;
 
 
 #endif

--- a/src/client-agent/config.c
+++ b/src/client-agent/config.c
@@ -30,16 +30,16 @@
 int ClientConf(char *cfgfile)
 {
     int modules = 0;
-    logr->port = DEFAULT_SECURE;
-    logr->rip = NULL;
-    logr->lip = NULL;
-    logr->rip_id = 0;
-    logr->execdq = 0;
-    logr->profile = NULL;   /*cmoraes*/
+    agt->port = DEFAULT_SECURE;
+    agt->rip = NULL;
+    agt->lip = NULL;
+    agt->rip_id = 0;
+    agt->execdq = 0;
+    agt->profile = NULL;   /*cmoraes*/
 
     modules|= CCLIENT;
 
-    if(ReadConfig(modules, cfgfile, logr, NULL) < 0)
+    if(ReadConfig(modules, cfgfile, agt, NULL) < 0)
     {
         return(OS_INVALID);
     }

--- a/src/client-agent/event-forward.c
+++ b/src/client-agent/event-forward.c
@@ -38,7 +38,7 @@ void *EventForward()
     msg[OS_MAXSTR] = '\0';
 
 
-    while((recv_b = recv(logr->m_queue, msg, OS_MAXSTR, MSG_DONTWAIT)) > 0)
+    while((recv_b = recv(agt->m_queue, msg, OS_MAXSTR, MSG_DONTWAIT)) > 0)
     {
         msg[recv_b] = '\0';
 

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
                 if(!optarg)
                     ErrorExit("%s: -g needs an argument",ARGV0);
                 group = optarg;
-                break;		
+                break;
             case 't':
                 test_config = 1;
                 break;
@@ -90,15 +90,15 @@ int main(int argc, char **argv)
 
     debug1(STARTED_MSG, ARGV0);
 
-    logr = (agent *)calloc(1, sizeof(agent));
-    if(!logr)
+    agt = (agent *)calloc(1, sizeof(agent));
+    if(!agt)
     {
         ErrorExit(MEM_ERROR, ARGV0);
     }
 
 
     /* Check current debug_level
-     * Command line setting takes precedence 
+     * Command line setting takes precedence
      */
     if (debug_level == 0)
     {
@@ -118,26 +118,26 @@ int main(int argc, char **argv)
         ErrorExit(CLIENT_ERROR,ARGV0);
     }
 
-    if(!logr->rip)
+    if(!agt->rip)
     {
         merror(AG_INV_IP, ARGV0);
         ErrorExit(CLIENT_ERROR,ARGV0);
     }
 
-    if(logr->notify_time == 0)
+    if(agt->notify_time == 0)
     {
-        logr->notify_time = NOTIFY_TIME;
+        agt->notify_time = NOTIFY_TIME;
     }
-    if(logr->max_time_reconnect_try == 0 )
+    if(agt->max_time_reconnect_try == 0 )
     {
-      	logr->max_time_reconnect_try = NOTIFY_TIME * 3;
+      	agt->max_time_reconnect_try = NOTIFY_TIME * 3;
     }
-    if(logr->max_time_reconnect_try <= logr->notify_time)
+    if(agt->max_time_reconnect_try <= agt->notify_time)
     {
-      	logr->max_time_reconnect_try = (logr->notify_time * 3);
-      	verbose("%s: INFO: Max time to reconnect can't be less than notify_time(%d), using notify_time*3 (%d)",ARGV0,logr->notify_time,logr->max_time_reconnect_try);
+      	agt->max_time_reconnect_try = (agt->notify_time * 3);
+      	verbose("%s: INFO: Max time to reconnect can't be less than notify_time(%d), using notify_time*3 (%d)",ARGV0,agt->notify_time,agt->max_time_reconnect_try);
     }
-    verbose("%s: INFO: Using notify time: %d and max time to reconnect: %d",ARGV0,logr->notify_time,logr->max_time_reconnect_try);
+    verbose("%s: INFO: Using notify time: %d and max time to reconnect: %d",ARGV0,agt->notify_time,agt->max_time_reconnect_try);
 
 
     /* Checking auth keys */
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
 
 
     /* Starting the signal manipulation */
-    StartSIG(ARGV0);	
+    StartSIG(ARGV0);
 
 
     /* Agentd Start */

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -90,7 +90,7 @@ void run_notify()
 
     #ifndef ONEWAY
     /* Check if the server has responded */
-    if((curr_time - available_server) > logr->max_time_reconnect_try)
+    if((curr_time - available_server) > agt->max_time_reconnect_try)
     {
         /* If response is not available, set lock and
          * wait for it.
@@ -108,7 +108,7 @@ void run_notify()
 
 
     /* Check if time has elapsed */
-    if((curr_time - g_saved_time) < logr->notify_time)
+    if((curr_time - g_saved_time) < agt->notify_time)
     {
         return;
     }

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -53,14 +53,14 @@ void *receiver_thread(void *none)
     while(1)
     {
         /* sock must be set. */
-        if(logr->sock == -1)
+        if(agt->sock == -1)
         {
             sleep(5);
             continue;
         }
 
         FD_ZERO(&fdset);
-        FD_SET(logr->sock, &fdset);
+        FD_SET(agt->sock, &fdset);
 
 
         /* Wait for 30 seconds. */
@@ -82,13 +82,13 @@ void *receiver_thread(void *none)
         }
 
         /* Read until no more messages are available */
-        while((recv_b = recv(logr->sock,buffer,OS_SIZE_1024, 0))>0)
+        while((recv_b = recv(agt->sock,buffer,OS_SIZE_1024, 0))>0)
         {
             /* Id of zero -- only one key allowed */
             tmp_msg = ReadSecMSG(&keys, buffer, cleartext, 0, recv_b -1);
             if(tmp_msg == NULL)
             {
-                merror(MSG_ERROR,ARGV0,logr->rip[logr->rip_id]);
+                merror(MSG_ERROR,ARGV0,agt->rip[agt->rip_id]);
                 continue;
             }
 
@@ -101,7 +101,7 @@ void *receiver_thread(void *none)
 
 
                 /* Run timeout commands. */
-                if(logr->execdq >= 0)
+                if(agt->execdq >= 0)
                     WinTimeoutRun(available_server);
 
                 /* If it is an active response message */
@@ -111,7 +111,7 @@ void *receiver_thread(void *none)
 
 
                     /* Run on windows. */
-                    if(logr->execdq >= 0)
+                    if(agt->execdq >= 0)
                     {
                         WinExecdRun(tmp_msg);
                     }

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -49,14 +49,14 @@ void *receive_msg()
 
 
     /* Read until no more messages are available */
-    while((recv_b = recv(logr->sock, buffer, OS_SIZE_1024, MSG_DONTWAIT)) > 0)
+    while((recv_b = recv(agt->sock, buffer, OS_SIZE_1024, MSG_DONTWAIT)) > 0)
     {
         buffer[recv_b] = '\0';
 
         tmp_msg = ReadSecMSG(&keys, buffer, cleartext, 0, recv_b -1);
         if(tmp_msg == NULL)
         {
-            merror(MSG_ERROR,ARGV0,logr->rip[logr->rip_id]);
+            merror(MSG_ERROR,ARGV0,agt->rip[agt->rip_id]);
             continue;
         }
 
@@ -69,7 +69,7 @@ void *receive_msg()
 
             #ifdef WIN32
             /* Run timeout commands. */
-            if(logr->execdq >= 0)
+            if(agt->execdq >= 0)
                 WinTimeoutRun(available_server);
             #endif
 
@@ -80,9 +80,9 @@ void *receive_msg()
                 tmp_msg+=strlen(EXECD_HEADER);
 
                 #ifndef WIN32
-                if(logr->execdq >= 0)
+                if(agt->execdq >= 0)
                 {
-                    if(OS_SendUnix(logr->execdq, tmp_msg, 0) < 0)
+                    if(OS_SendUnix(agt->execdq, tmp_msg, 0) < 0)
                     {
                         merror("%s: Error communicating with execd",
                                 ARGV0);
@@ -93,7 +93,7 @@ void *receive_msg()
 
 
                 /* Run on windows. */
-                if(logr->execdq >= 0)
+                if(agt->execdq >= 0)
                 {
                     WinExecdRun(tmp_msg);
                 }

--- a/src/client-agent/sendmsg.c
+++ b/src/client-agent/sendmsg.c
@@ -31,7 +31,7 @@ int send_msg(int agentid, char *msg)
     }
 
     /* Send msg_size of crypt_msg */
-    if(OS_SendUDPbySize(logr->sock, msg_size, crypt_msg) < 0)
+    if(OS_SendUDPbySize(agt->sock, msg_size, crypt_msg) < 0)
     {
         merror(SEND_ERROR,ARGV0, "server");
         sleep(1);


### PR DESCRIPTION
rename global agent struct from logr to agt due to naming conflict to global remoted struct logr
