### PR TITLE
Fix the client status exit code

### DIFF
--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -101,14 +101,17 @@ help()
 # Status function
 status()
 {
+    RETVAL=0
     for i in ${DAEMONS}; do
         pstatus ${i};
         if [ $? = 0 ]; then
+            RETVAL=1
             echo "${i} not running..."
         else
             echo "${i} is running..."
         fi
     done             
+    exit $RETVAL
 }
 
 testconfig()

--- a/src/init/ossec-hids-debian.init
+++ b/src/init/ossec-hids-debian.init
@@ -53,5 +53,3 @@ case "$1" in
 	echo "*** Usage: $0 {start|stop|restart|status}"
 	exit 1
 esac
-
-exit 0


### PR DESCRIPTION
Mody ossec-client.sh and ossec-hids-debian.init such that both ossec-control and service ossec commands will exit with the proper status code, based on the ossec client process status.
