### PR TITLE
Fix win32 OS detection

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -816,11 +816,18 @@ int checkVista()
     /* We check if the system is vista (must be called during the startup.) */
     if(strstr(m_uname, "Windows Server 2008") ||
        strstr(m_uname, "Vista") ||
-       strstr(m_uname, "Windows 7"))
+       strstr(m_uname, "Windows 7") ||
+       strstr(m_uname, "Windows 8") ||
+       strstr(m_uname, "Windows Server 2012"))
     {
         isVista = 1;
-        verbose("%s: INFO: System is Vista, Windows 7 or Windows Server 2008.",
-                __local_name);
+        verbose("%s: INFO: System is Vista or newer (%s).",
+                __local_name, m_uname);
+    }
+    else
+    {
+        verbose("%s: INFO: System is older than Vista (%s).",
+                __local_name, m_uname);
     }
 
     free(m_uname);
@@ -887,6 +894,24 @@ char *getuname()
                     else
                     {
                         strncat(ret, "Microsoft Windows Server 2008 R2 ", ret_size -1);
+                    }
+                }
+                else if(osvi.dwMinorVersion == 2)
+                {
+                    if(osvi.wProductType == VER_NT_WORKSTATION )
+                        strncat(ret, "Microsoft Windows 8 ", ret_size -1);
+                    else
+                    {
+                        strncat(ret, "Microsoft Windows Server 2012 ", ret_size -1);
+                    }
+                }
+                else if(osvi.dwMinorVersion == 3)
+                {
+                    if(osvi.wProductType == VER_NT_WORKSTATION )
+                        strncat(ret, "Microsoft Windows 8.1 ", ret_size -1);
+                    else
+                    {
+                        strncat(ret, "Microsoft Windows Server 2012 R2 ", ret_size -1);
                     }
                 }
 


### PR DESCRIPTION
This starts to add support for 2012. Change the log message to be
more flexible with what it spits back out to the user after the
checkVista() function is run.

Although this helps with 2012 detection it is not perfect. With the
addition of Windows 8.1/2012 R2 the documentation provided by
Microsoft indicates that the GetVersionEx APIs have been deprecated.
This means that if you are on an 8.1 machine and run GetVersionEx it
will return the Windows 8 version (6.2.0.0). In order to get the
correct version you must target your application for Windows 8.1.

I am just trying to fix installations on 2012 and 2012 R2 so this
code works well enough for now but should be revisited at some point
so that it will work with future Windows versions.

For more details on how to target your application for Windows 8.1 read
the following http://msdn.microsoft.com/en-us/library/windows/desktop/dn481241(v=vs.85).aspx.
