### PR TITLE
Remove annoying win32ui dialog box

### DIFF
--- a/src/win32/ui/os_win32ui.c
+++ b/src/win32/ui/os_win32ui.c
@@ -468,13 +468,10 @@ BOOL CALLBACK DlgProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     LPSTR lpCmdLine, int nCmdShow)
 {
-    int ret;
     WSADATA wsaData;
-
 
     /* Starting Winsock -- for name resolution. */
     WSAStartup(MAKEWORD(2, 0), &wsaData);
-
 
     /* Initializing config */
     init_config();
@@ -484,23 +481,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
     /* Creating main dialogbox */
     DialogBox(hInstance, MAKEINTRESOURCE(IDD_MAIN), NULL, DlgProc);
-
-
-    /* Check if service is running and try to start it */
-    if((strcmp(config_inst.key, FL_NOKEY) != 0)&&
-            (strcmp(config_inst.server, FL_NOSERVER) != 0) &&
-            !CheckServiceRunning() &&
-            (config_inst.admin_access != 0))
-    {
-        ret = MessageBox(NULL, "OSSEC Agent not running. "
-                "Do you wish to start it?",
-                "Wish to start the agent?", MB_OKCANCEL);
-        if(ret == IDOK)
-        {
-            /* Starting the service */
-            os_start_service();
-        }
-    }
 
     return(0);
 }


### PR DESCRIPTION
If you close the win32ui, the win32ui is running with Administrative
privileges, everything to run the win32 agent is configured and the
Agent service is not running a dialog box will pop informing the user
the service is not running and ask them if they would like to start it.

This to me is an annoyance more than anything. It is likely the user
went into the win32ui to stop the service to begin with and knows it is
stopped.

If anyone has any strong opinions on keep this I'm all ears.
