### PR TITLE
Add better version handling to win32ui

### DIFF
--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -249,6 +249,7 @@ void init_config()
 int config_read(HWND hwnd)
 {
     char *tmp_str;
+    char *delim = " - ";
 
 
     /* Clearing config */
@@ -270,11 +271,11 @@ int config_read(HWND hwnd)
     config_inst.version = cat_file(VERSION_FILE, NULL);
     if(config_inst.version)
     {
-        config_inst.install_date = strchr(config_inst.version, '-');
+        config_inst.install_date = strstr(config_inst.version, delim);
         if(config_inst.install_date)
         {
             *config_inst.install_date = '\0';
-            config_inst.install_date++;
+            config_inst.install_date += strlen(delim);
         }
     }
 


### PR DESCRIPTION
The delimiter of just '-' (no spaces) was not as strict as it could
be making adding things like releases to the version file, 2.7.1-1
for example not possible. This makes the delimiter " - " (with spaces)
which allows for that type of flexibility.
