### PR TITLE
Fix win32 setup log message

### DIFF
--- a/src/win32/setup-win.c
+++ b/src/win32/setup-win.c
@@ -17,6 +17,9 @@
 /* Setup windows after install */
 int main(int argc, char **argv)
 {
+    /* Setting the name */
+    OS_SetName(ARGV0);
+
     if(argc < 2)
     {
         printf("%s: Invalid syntax.\n", argv[0]);


### PR DESCRIPTION
When installing the win32 agent it does a call to checkVista() which
logs a message. The problem is no name is set so (null) is placed
where the executable name should be. This sets the name so that
the executable name is displayed instead of (null).

Before:
![before](https://f.cloud.github.com/assets/3237256/2314652/adfc22e6-a319-11e3-90d9-2fbe43a47dc7.PNG)

After:
![after](https://f.cloud.github.com/assets/3237256/2314653/b139b55e-a319-11e3-87ae-02aebc9fdc0d.PNG)
