### PR TITLE
Adding a new sshd rule for bad packet lengths

### DIFF
--- a/contrib/ossec-testing/tests/sshd.ini
+++ b/contrib/ossec-testing/tests/sshd.ini
@@ -54,7 +54,7 @@ rule = 5746
 alert = 4
 decoder = sshd
 
-[ssh bad client public DH value
+[ssh bad client public DH value]
 log 1 pass = Feb  4 23:05:57 someserver sshd[1234]: Disconnecting: bad client public DH value [preauth]
 
 rule = 5747
@@ -66,4 +66,11 @@ log 1 pass = Feb 14 14:34:15 someserver sshd[1234]: Corrupted MAC on input. [pre
 
 rule = 5748
 alert = 6
+decoder = sshd
+
+[ssh bad packet length]
+log 1 pass = Mar  4 13:34:59 someserver sshd[5396]: Bad packet length 4081586742. [preauth]
+
+rule = 5749
+alert = 4
 decoder = sshd

--- a/etc/rules/sshd_rules.xml
+++ b/etc/rules/sshd_rules.xml
@@ -331,6 +331,12 @@
     <description>ssh corrupted MAC on input</description>
   </rule>
 
+  <rule id="5749" level="4">
+    <if_sid>5700</if_sid>
+    <match>^Bad packet length</match>
+    <description>ssh bad packet length</description>
+  </rule>
+
 </group> <!-- SYSLOG, SSHD -->
 
 <!-- EOF -->


### PR DESCRIPTION
Nothing fancy, just a new rule for an sshd message I encountered recently.  Unit test created also.
