### PR TITLE
Remove os_auth from win-files.txt

### DIFF
--- a/src/win32/win-files.txt
+++ b/src/win32/win-files.txt
@@ -4,7 +4,6 @@ os_xml os_xml
 os_crypto os_crypto
 headers headers
 shared shared
-os_auth os_auth
 error_messages error_messages
 addagent addagent
 config config


### PR DESCRIPTION
After commit 75a91043 the os_auth daemon no longer gets made during builds on NIX based systems so copying over the files is no longer necessary.
