### PR TITLE
Fix make.sh files for win32

### DIFF
--- a/src/win32/make.sh
+++ b/src/win32/make.sh
@@ -1,3 +1,7 @@
+#!/bin/sh
+
+set -e
+
 echo Making windows agent
 BASES="${MING_BASE} amd64-mingw32msvc i586-mingw32msvc i686-pc-mingw32  i686-w64-mingw32"
 

--- a/src/win32/ui/make.sh
+++ b/src/win32/ui/make.sh
@@ -1,3 +1,7 @@
+#!/bin/sh
+
+set -e
+
 echo Making windows agent UI
 
 ${MING_BASE}-windres -o resource.o win32ui.rc


### PR DESCRIPTION
Added the shebang. Also used 'set -e' to exit the scripts upon
getting an error from any of the command being run. That is it say
if there is an issue compiling anything for any reason stop there
and continue not further.

Previously, it would just continue on until something would look
for the executables that weren't there and exit. Usually after makensis.

This makes it a lot clearer on where things went wrong and you don't have
to trudge through a lot of output to find compile issues.
