### PR TITLE
Remove local file additions in setup-win.c

### DIFF
--- a/src/win32/setup-win.c
+++ b/src/win32/setup-win.c
@@ -45,11 +45,6 @@ int main(int argc, char **argv)
     }
 
 
-    /* Setting up local files */
-    system("add-localfile.exe \"C:\\Windows\\pfirewall.log\" --quiet");
-    system("add-localfile.exe \"C:\\Documents and Settings\\All Users\\Application Data\\Symantec\\Symantec AntiVirus Corporate Edition\\7.5\\Logs\\\%m\%d20\%y.log\" --quiet");
-
-
     /* Configure ossec for automatic startup */
     system("sc config OssecSvc start= auto");
 


### PR DESCRIPTION
In my opinion adding these should be a user decision and shouldn't get done by default.
