### PR TITLE
Fixes to ossec-installer.nsi

### DIFF
--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -162,6 +162,12 @@ Delete "$SMPROGRAMS\OSSEC\Documentation.lnk"
 Delete "$SMPROGRAMS\OSSEC\Edit Config.lnk"
 Delete "$SMPROGRAMS\OSSEC\*.*"
 
+; rename ossec.conf if it does not
+; already exist
+IfFileExists "$INSTDIR\ossec.conf" ConfPresent
+Rename "$INSTDIR\default-ossec.conf" "$INSTDIR\ossec.conf"
+ConfPresent:
+
 ; Handle shortcuts
 ; http://nsis.sourceforge.net/Shortcuts_removal_fails_on_Windows_Vista
 SetShellVarContext all

--- a/src/win32/setup-win.c
+++ b/src/win32/setup-win.c
@@ -34,16 +34,6 @@ int main(int argc, char **argv)
         return(0);
     }
 
-    /* Checking if ossec was installed already (upgrade) */
-    if(!fileexist(OSSECCONF))
-    {
-        char cmd[OS_MAXSTR +1];
-
-        /* Copy default config to ossec.conf */
-        snprintf(cmd, OS_MAXSTR, "copy %s %s", OSSECDEF, OSSECCONF);
-        system(cmd);
-    }
-
 
     /* Configure ossec for automatic startup */
     system("sc config OssecSvc start= auto");


### PR DESCRIPTION
Move the logic that determines whether the ossec.conf should be
replaced/renamed out of the C code and into NSIS. The NSIS stuff is
built for installing things. No need to write a bunch of C code to do
something that there is already a system for. Going to try and move
as much out of C and into NSIS to help cut down on the amount of code
that needs to be maintained for no real reason.
