### PR TITLE
SetDateSave off in ossec-installer.nsi

### DIFF
--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -36,7 +36,7 @@ InstallDirRegKey HKLM Software\OSSEC ""
   !define MUI_WELCOMEPAGE_TEXT "This wizard will guide you through the install of ${Name}.\r\n\r\nClick next to continue."
   !define MUI_FINISHPAGE_TITLE_3LINES
   !define MUI_FINISHPAGE_RUN "$INSTDIR\win32ui.exe"
-  !define  MUI_FINISHPAGE_RUN_TEXT "Run OSSEC Agent Manager"
+  !define MUI_FINISHPAGE_RUN_TEXT "Run OSSEC Agent Manager"
 
   ; Page for choosing components.
   !define MUI_COMPONENTSPAGE_TEXT_TOP "Select the options you want to be executed. Click next to continue."
@@ -84,6 +84,9 @@ SectionIn RO
 SetOutPath $INSTDIR
 
 ClearErrors
+
+; use real data modified times
+SetDateSave off
 
 File \
 ossec-agent.exe \


### PR DESCRIPTION
Turned SetDateSave to off. Reference http://nsis.sourceforge.net/Reference/SetDateSave for more information on what this does. While keeping the original DateModified times has some advantages I think not having NSIS overwrite the new DateModified times with the originals is much better. It lets the user see when a file was actually modified.
