### PR TITLE
Fixes to ossec-installer.nsi

### DIFF
--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -85,6 +85,9 @@ SetOutPath $INSTDIR
 
 ClearErrors
 
+; overwrite existing files
+SetOverwrite on
+
 File \
 ossec-agent.exe \
 ossec-agent-eventchannel.exe \


### PR DESCRIPTION
Explicitly set SetOverwrite to on. This is the default but for clarity it is good to show exactly what action we are hoping to take with these files.
