### PR TITLE
Use file command in ossec-installer.nsi

### DIFF
--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -85,32 +85,39 @@ SetOutPath $INSTDIR
 
 ClearErrors
 
-File \
-ossec-agent.exe \
-ossec-agent-eventchannel.exe \
-default-ossec.conf \
-manage_agents.exe \
-os_win32ui.exe \
-ossec-rootcheck.exe \
-internal_options.conf \
-setup-windows.exe \
-setup-syscheck.exe \
-setup-iis.exe \
-service-start.exe \
-service-stop.exe \
-doc.html \
-rootkit_trojans.txt \
-rootkit_files.txt \
-add-localfile.exe \
-LICENSE.txt \
-rootcheck\rootcheck.conf \
-rootcheck\db\win_applications_rcl.txt \
-rootcheck\db\win_malware_rcl.txt \
-rootcheck\db\win_audit_rcl.txt \
-help.txt \
-vista_sec.csv \
-route-null.cmd \
-restart-ossec.cmd
+; create necessary directories
+CreateDirectory "$INSTDIR\bookmarks"
+CreateDirectory "$INSTDIR\rids"
+CreateDirectory "$INSTDIR\syscheck"
+CreateDirectory "$INSTDIR\shared"
+CreateDirectory "$INSTDIR\active-response"
+CreateDirectory "$INSTDIR\active-response\bin"
+
+; install files
+File ossec-agent.exe
+File ossec-agent-eventchannel.exe
+File default-ossec.conf
+File manage_agents.exe
+File /oname=win32ui.exe os_win32ui.exe
+File ossec-rootcheck.exe
+File internal_options.conf
+File setup-windows.exe
+File setup-syscheck.exe
+File setup-iis.exe
+File service-start.exe
+File service-stop.exe
+File doc.html
+File /oname=shared\rootkit_trojans.txt rootkit_trojans.txt
+File /oname=shared\rootkit_files.txt rootkit_files.txt
+File add-localfile.exe
+File LICENSE.txt
+File /oname=shared\win_applications_rcl.txt rootcheck\db\win_applications_rcl.txt
+File /oname=shared\win_malware_rcl.txt rootcheck\db\win_malware_rcl.txt
+File /oname=shared\win_audit_rcl.txt rootcheck\db\win_audit_rcl.txt
+File help.txt
+File vista_sec.csv
+File /oname=active-response\bin\route-null.cmd route-null.cmd
+File /oname=active-response\bin\restart-ossec.cmd restart-ossec.cmd
 
 ; Use appropriate version of "ossec-agent.exe"
 ${If} ${AtLeastWinVista}
@@ -119,7 +126,6 @@ ${If} ${AtLeastWinVista}
 ${Else}
   Delete "$INSTDIR\ossec-agent-eventchannel.exe"
 ${Endif}
-
 
 WriteRegStr HKLM SOFTWARE\ossec "Install_Dir" "$INSTDIR"
 WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC" "DisplayName" "${NAME} ${VERSION}"
@@ -140,22 +146,6 @@ FileWrite $0 "Installed on ${CDATE}"
 FileClose $0
 done:
 
-CreateDirectory "$INSTDIR\bookmarks"
-CreateDirectory "$INSTDIR\rids"
-CreateDirectory "$INSTDIR\syscheck"
-CreateDirectory "$INSTDIR\shared"
-CreateDirectory "$INSTDIR\active-response"
-CreateDirectory "$INSTDIR\active-response\bin"
-Delete "$INSTDIR\active-response\bin\route-null.cmd"
-Delete "$INSTDIR\active-response\bin\restart-ossec.cmd"
-Rename "$INSTDIR\rootkit_trojans.txt" "$INSTDIR\shared\rootkit_trojans.txt"
-Rename "$INSTDIR\rootkit_files.txt" "$INSTDIR\shared\rootkit_files.txt"
-Rename "$INSTDIR\win_malware_rcl.txt" "$INSTDIR\shared\win_malware_rcl.txt"
-Rename "$INSTDIR\win_audit_rcl.txt" "$INSTDIR\shared\win_audit_rcl.txt"
-Rename "$INSTDIR\win_applications_rcl.txt" "$INSTDIR\shared\win_applications_rcl.txt"
-Rename "$INSTDIR\route-null.cmd" "$INSTDIR\active-response\bin\route-null.cmd"
-Rename "$INSTDIR\restart-ossec.cmd" "$INSTDIR\active-response\bin\restart-ossec.cmd"
-Rename "$INSTDIR\os_win32ui.exe" "$INSTDIR\win32ui.exe"
 Delete "$SMPROGRAMS\OSSEC\Edit.lnk"
 Delete "$SMPROGRAMS\OSSEC\Uninstall.lnk"
 Delete "$SMPROGRAMS\OSSEC\Documentation.lnk"


### PR DESCRIPTION
Use the full ability of the the File command. Before when upgrading and doing a Rename after without the /Reboot command most of those commands would "fail silently" which is the best way I can describe it. It would just leave these files in the main ossec-agent directory never really upgrading parts of the system. Using the File command has the added benefit of complaining if a file is in use during the installation. For example have the win32ui.exe open and try to run a new installation. It hould complain that the file is inaccessible until the application is closed. Previously, this would just leave os_win32.exe in the ossec-agent directory and never successfully upgrade the executable.
