### PR TITLE
Show details during win32 installation

### DIFF
--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -25,6 +25,13 @@ OutFile "${OutFile}"
 InstallDir "$PROGRAMFILES\ossec-agent"
 InstallDirRegKey HKLM Software\OSSEC ""
 
+; show installation details
+ShowInstDetails show
+
+; do not close details pages immediately
+!define MUI_FINISHPAGE_NOAUTOCLOSE
+!define MUI_UNFINISHPAGE_NOAUTOCLOSE
+
 ;--------------------------------
 ;Interface Settings
 
@@ -72,7 +79,7 @@ Function .onInit
     NoAbort:
 
    ;; Stopping ossec service.
-   nsExec::ExecToStack '"net" "stop" "OssecSvc"'
+   nsExec::ExecToLog '"net" "stop" "OssecSvc"'
 FunctionEnd
 
 ;--------------------------------
@@ -177,22 +184,20 @@ CreateShortCut "$SMPROGRAMS\OSSEC\Edit Config.lnk" "$INSTDIR\ossec.conf" "" "$IN
 CreateShortCut "$SMPROGRAMS\OSSEC\Uninstall.lnk" "$INSTDIR\uninstall.exe" "" "$INSTDIR\uninstall.exe" 0
 
 ; Install in the services  (perhaps it would be better to use a plug-in here?)
-;nsExec::ExecToStack '"$INSTDIR\ossec-agent.exe" install-service'
-ExecWait '"$INSTDIR\ossec-agent.exe" install-service'
-;nsExec::ExecToStack '"$INSTDIR\setup-windows.exe" "$INSTDIR"'
-ExecWait '"$INSTDIR\setup-windows.exe" "$INSTDIR"'
+nsExec::ExecToLog '"$INSTDIR\ossec-agent.exe" install-service'
+nsExec::ExecToLog '"$INSTDIR\setup-windows.exe" "$INSTDIR"'
 
 SectionEnd
 
 Section "Scan and monitor IIS logs (recommended)" IISLogs
 
-nsExec::ExecToStack '"$INSTDIR\setup-iis.exe" "$INSTDIR"'
+nsExec::ExecToLog '"$INSTDIR\setup-iis.exe" "$INSTDIR"'
 
 SectionEnd
 
 Section "Enable integrity checking (recommended)" IntChecking
 
-nsExec::ExecToStack '"$INSTDIR\setup-syscheck.exe" "$INSTDIR" "enable"'
+nsExec::ExecToLog '"$INSTDIR\setup-syscheck.exe" "$INSTDIR" "enable"'
 
 SectionEnd
 
@@ -203,10 +208,10 @@ Section "Uninstall"
   ;Need a step to check for a running agent manager, otherwise it and the INSTDIR directory will not be removed.
 
   ; Stop ossec. Perhaps we should look for an exit status here. Also, may be a good place to use a plug-in.
-  nsExec::ExecToStack '"net" "stop" "OssecSvc"'
+  nsExec::ExecToLog '"net" "stop" "OssecSvc"'
 
   ; Uninstall from the services. Again, maybe use a plugin here.
-  nsExec::ExecToStack '"$INSTDIR\ossec-agent.exe" uninstall-service'
+  nsExec::ExecToLog '"$INSTDIR\ossec-agent.exe" uninstall-service'
 
   ; Remove registry keys
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OSSEC"


### PR DESCRIPTION
When doing a win32 installation the details are hidden and only shown
very briefly. In some cases when doing an Exec on some of the OSSEC
command line tools it will spawn a cmd.exe that only appears for a
second. Some of the details those processes do are logged in the
ossec.log but it would be nice if they were also displayed in the details
window and those details can be reviewed.

Changed all Exec's to use ExecToLog so their details show up in the
installer details section.

Configured the details to be displayed by default and to not skip
past the details page automatically when the installation is completed.

This also has the added benefit of now popping up cmd.exe windows when
an installation takes place.
