### PR TITLE
Add rules/decoder for Apple MacOS X/Darwin environment

### DIFF
--- a/contrib/ossec-testing/tests/macos.ini
+++ b/contrib/ossec-testing/tests/macos.ini
@@ -56,6 +56,7 @@ rule = 120000
 alert = 0
 decoder = chrome
 
+## FIXME! decoder authorizationhost but not failure
 [authorizationhost-failure]
 log 1 pass = Mar 25 22:15:29 somemac authorizationhost[37573]: Failed to authenticate user <boo_admin> (error: 9).
 
@@ -63,6 +64,7 @@ rule = 101131
 alert = 7
 decoder = authorizationhost-failure
 
+## FIXME! not matching
 [mdworker error]
 log 1 pass = Mar 25 22:37:50 somemac mdworker[38218]: ENSpotlightImporter:importFileAtPath:attributes:error: caught exception: Cannot create an NSPersistentStoreCoordinator with a nil model
 
@@ -98,6 +100,7 @@ rule = 101101
 alert = 0
 decoder = PTPCamera
 
+## FIXME! not matching
 [com.apple.imfoundation.IMRemoteURLConnectionAgent error]
 log 1 pass = Mar  7 16:20:37 somemac com.apple.imfoundation.IMRemoteURLConnectionAgent[12644]: ERROR: __CFURLCache:CreateTablesAndIndexes version create - disk I/O error. ErrCode: 10.
 
@@ -105,6 +108,7 @@ rule = 101071
 alert = 1
 decoder = com.apple.imfoundation.IMRemoteURLConnectionAgent
 
+## FIXME! not matching
 [com.apple.imfoundation.IMRemoteURLConnectionAgent error2]
 log 1 pass = Mar  7 16:20:37 somemac com.apple.imfoundation.IMRemoteURLConnectionAgent[12644]: __CFURLCache:RecreateEmptyPersistentStoreOnDiskAndOpen: create tables and index failed.
 
@@ -126,6 +130,7 @@ rule = 130002
 alert = 0
 decoder = preview
 
+## FIXME! not matching
 [textedit network]
 log 1 pass = Mar 11 12:16:17 somemac TextEdit[47944]: tcp_connection_handle_destination_prepare_complete 1 failed to connect
 
@@ -140,6 +145,7 @@ rule = 102011
 alert = 6
 decoder = syslog
 
+## FIXME!
 [textedit network]
 log 1 pass = Mar 11 12:16:17 somemac TextEdit[47944]: tcp_connection_destination_prepare_complete 1 connectx to 23.34.194.70#443 failed: 1 - Operation not permitted
 
@@ -147,6 +153,7 @@ rule = 102013
 alert = 6
 decoder = syslog
 
+## FIXME! error because decoder not matching???
 [usbmuxd error]
 log 1 pass = Mar 25 23:00:24 somemac usbmuxd[25]: AMDeviceStartSession (thread 0x101881000): Could not start session: kAMDInvalidHostIDError
 
@@ -161,6 +168,7 @@ rule = 101151
 alert = 0
 decoder = mtmd
 
+## FIXME!
 [mtmd error]
 log 1 pass = Mar 31 07:22:29 somemac com.apple.mtmd[7447]: handler unblock failed. (status=-1/errno=2/token=131658/fd=9)
 
@@ -168,6 +176,7 @@ rule = 101152
 alert = 0
 decoder = mtmd
 
+## FIXME!
 [fsevents error]
 log 1 pass = Mar 28 03:32:20 somemac fseventsd[45]: client_buffer_flush: failed to send 32 events to client pid: 84563 (status: 268435460)
 
@@ -175,6 +184,7 @@ rule = 101042
 alert = 0
 decoder = fsevents
 
+## FIXME! not matching
 [CalendarAgent error]
 log 1 pass = Mar 31 07:21:43 somemac CalendarAgent[249]: [com.apple.calendar.store.log.caldav.queue] [Adding [<CalDAVAccountRefreshQueueableOperation: 0x7f8c0adc6a30; Sequence: 0>] to failed operations.]
 
@@ -182,6 +192,7 @@ rule = 101042
 alert = 0
 decoder = fsevents
 
+## FIXME! decoder not matching. space?
 [BezelServices error]
 log 1 pass = Mar 31 09:42:56 somemac BezelServices 240.49[6054]: HIDMonitor : IOHIDManagerOpen returned an error, but continuing anyway.
 
@@ -224,10 +235,95 @@ rule = 101193
 alert = 0
 decoder = mds_stores
 
+## FIXME!
 [mds_store error]
 log 1 pass = Apr  1 14:37:11 somemac mds_stores[132]: (/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T)(Error) IndexGeneral in void setAttributes(si_set_attr_ctx *, Boolean):Couldn't update index oid:360 options:5 updateErr:22 resolveErr:0
 
 rule = 101194
 alert = 0
 decoder = mds_stores
+
+[mds error]
+log 1 pass = Apr  1 20:43:23 somemac mds[38]: (Error) FMW: WE ARE DROPPING FMW EVENTS!
+
+rule = 101033
+alert = 4
+decoder = mds
+
+[ubd error]
+log 1 pass = Apr  2 15:21:10 somemac ubd[84836]: ApplePushService: Failed to flush connection during shutdown
+
+rule = 101221
+alert = 0
+decoder = ubd
+
+[Preview error]
+log 1 pass = Apr  3 00:57:14 somemac Preview[13572]: *** Assertion failure in void runningApplicationNotificationCallback(LSNotificationCode, CFAbsoluteTime, CFTypeRef, LSASNRef, const void *, LSSessionID, LSNotificationID)(), /SourceCache/AppKit/AppKit-1265.19/AppKit.subproj/NSRunningApplication.m:298
+
+rule = 130007
+alert = 0
+decoder = Preview
+
+## FIXME! how to handle that: calendar description finishing in log file = too large = alert
+[Calendar body too large]
+log 1 pass =             body = "3 avril 2014 05:00 : webinar: splunk: Masters of Machines: Gaining business insight from IT operational intelligence\n\n\nHello Mr Z,\n\nThanks for registering to join us at our upcoming webinar. Please plan to join at least 5 minutes before the scheduled starting time so you don't miss any valuable information.\n\nTopic: Masters of Machines: Gaining business insight from IT operational intelligence\nHost: Name\nDate and Time:\nThursday, April 3, 2014 10:00 am, GMT Summer Time (London, GMT+01:00)\nThursday, April 3, 2014 11:00 am, Europe Summer Time (Paris, GMT+02:00)\nThursday, April 3, 2014 5:00 am, Eastern Daylight Time (New York, GMT-04:00)\nEvent number: 666 035 991\nRegistration ID: This event does not require a registration ID\nEvent password: Splunk\n\n-------------------------------------------------------\nTo join the online event \n-------------------------------------------------------\n Click here  to join the online event.\nOr copy and paste
+  the following link to a browser: \n https://splunkevents.webex.com/splunkevents/onstage/g.php?MTID=zzzzzzzzzzzzzzzzzz\n\nTo view in other time zones or languages, please click the link:\nhttps://splunkevents.webex.com/splunkevents/onstage/g.p
+
+rule = 
+alert = 1
+decoder = 
+
+## FIXME!
+[ImageCaptureExtension error]
+log 1 pass = Apr  3 11:37:05 somemac Image Capture Extension[37863]: [2] Failed to register for death of process with pid: 41780
+
+rule = 101211
+alert = 1
+decoder = ImageCaptureExtension
+
+## FIXME!
+[iCloudHelper error]
+log 1 pass = Apr  3 21:26:42 somemac com.apple.iCloudHelper[89771]: AOSKit ERROR: ((null)) Cannot refresh account bag, missing acct info (user=.datc78d.012, hasPassword=0)
+
+rule = 101033
+alert = 1
+decoder = iCloudHelper
+
+## FIXME!
+[mds_stores error]
+log 1 pass = Apr  3 21:43:34 somemac mds_stores[132]: (/private/var/folders/zz/zyxvpxvq6csfxvn_n0000000000000/T)(Error) IndexStore in int computePath(SIRef, db_obj *, oid_t *, ssize_t *):SIPersistentIDStoreGetParentForOid error:0 at:740 oid:16658672 parent:0
+
+rule = 101033
+alert = 1
+decoder = mds_stores
+
+## FIXME! not matching
+[mdworker error]
+log 1 pass = Apr  4 13:49:46 somemac mdworker[59024]: (Warning) Import: Bad path:
+
+rule = 101142
+alert = 1
+decoder = mdworker
+
+## FIXME!
+[usernoted error]
+log 1 pass = Apr 14 22:24:43 somemac usernoted[207]: Connection does not have the proper entitlement (com.apple.private.notificationcenter-system) to connect to the system notification center. All communication will be denied. center com.apple.storeagent
+
+rule = 102040
+alert = 3
+decoder = usernoted
+
+[iCloudHelper error]
+log 1 pass = Apr 15 09:09:36 somemac com.apple.iCloudHelper[54489]: AOSKit ERROR: ((null)) Cannot refresh account bag, missing acct info (user=.datc87d.000, hasPassword=0)
+
+rule = 101201
+alert = 1
+decoder = iCloudHelper
+
+[preferences.network error]
+log 1 pass = Apr 16 08:07:27 somemac com.apple.preference.network.remoteservice[11626]: *** Assertion failure in void assertCGError(CGError, const char *)(), /SourceCache/ViewBridge/ViewBridge-46.2/ViewBridgeUtilities.m:346
+
+rule = 101231
+alert = 0
+decoder = com.apple.preference.network.remoteservice
 

--- a/etc/decoder_local_mac.xml
+++ b/etc/decoder_local_mac.xml
@@ -8,13 +8,13 @@
   - chrome log
   -  Examples:
   - kernel[0]: USBMSC Identifier (non-unique): 00001680D775EA97 0x781 0x5408 0x10, 2
-Feb 15 20:21:34 HOST kernel[0]: USBMSC Identifier (non-unique): 574343344530333937333935 0x1058 0x1230 0x1050, 2
+Feb 15 20:21:34 somemac kernel[0]: USBMSC Identifier (non-unique): 574343344530333937333935 0x1058 0x1230 0x1050, 2
   - Google Chrome Helper[50583]: Process unable to create connection because the sandbox denied the right to lookup com.apple.coreservices.launchservicesd and so this process cannot talk to launchservicesd. : LSXPCClient.cp #426 ___ZN26LSClientToServerConnection21setupServerConnectionEiPK14__CFDictionary_block_invoke() q=com.apple.main-thread
   - Google Chrome Helper[50583]: Process unable to create connection because the sandbox denied the right to lookup com.apple.coreservices.launchservicesd and so this process cannot talk to launchservicesd.
   - Google Chrome Helper[50583]: CGSLookupServerRootPort: Failed to look up the port for "com.apple.windowserver.active" 
-Feb 20 11:20:36 HOST Google Chrome Helper[59050]: Process unable to create connection because the sandbox denied the right to lookup com.apple.coreservices.launchservicesd and so this process cannot talk to launchservicesd.
+Feb 20 11:20:36 somemac Google Chrome Helper[59050]: Process unable to create connection because the sandbox denied the right to lookup com.apple.coreservices.launchservicesd and so this process cannot talk to launchservicesd.
   - Preview
-Feb 20 10:51:20 HOST Preview[33917]: It does not make sense to draw an image when [NSGraphicsContext currentContext] is nil.  This is a programming error. Break on void _NSWarnForDrawingImageWithNoCurrentContext() to debug.  This will be logged only once.  This may break in the future.
+Feb 20 10:51:20 somemac Preview[33917]: It does not make sense to draw an image when [NSGraphicsContext currentContext] is nil.  This is a programming error. Break on void _NSWarnForDrawingImageWithNoCurrentContext() to debug.  This will be logged only once.  This may break in the future.
 
   -->
 
@@ -62,6 +62,10 @@ http://ossec-docs.readthedocs.org/en/latest/syntax/head_decoders.html#element-de
   <program_name>^com.apple.launchd.peruser</program_name>
 </decoder>
 
+<decoder name="launchd">
+  <program_name>^com.apple.launchd</program_name>
+</decoder>
+
 <decoder name="secd">
   <program_name>^secd</program_name>
 </decoder>
@@ -71,7 +75,7 @@ http://ossec-docs.readthedocs.org/en/latest/syntax/head_decoders.html#element-de
 </decoder>
 
 <!-- BUG: match 
-Feb 26 20:24:56 HOST com.apple.authd[71]: Succeeded authorizing right 'com.apple.ServiceManagement.daemons.modify' by client '/usr/libexec/UserEventAgent' [11] for authorization created by '/usr/libexec/UserEventAgent' [11] (12,0)
+Feb 26 20:24:56 somemac com.apple.authd[71]: Succeeded authorizing right 'com.apple.ServiceManagement.daemons.modify' by client '/usr/libexec/UserEventAgent' [11] for authorization created by '/usr/libexec/UserEventAgent' [11] (12,0)
 -->
 <decoder name="SecurityServer">
   <program_name>^SecurityServer</program_name>
@@ -115,6 +119,9 @@ Feb 26 20:24:56 HOST com.apple.authd[71]: Succeeded authorizing right 'com.apple
 
 <decoder name="usbmuxd">
   <program_name>com.apple.usbmuxd</program_name>
+</decoder>
+
+<decoder name="usbmuxd">
   <program_name>usbmuxd</program_name>
 </decoder>
 
@@ -128,6 +135,10 @@ Feb 26 20:24:56 HOST com.apple.authd[71]: Succeeded authorizing right 'com.apple
 
 <decoder name="mds">
   <program_name>mds</program_name>
+</decoder>
+
+<decoder name="mds_stores">
+  <program_name>mds_stores</program_name>
 </decoder>
 
 <decoder name="appleeventsd">
@@ -189,6 +200,41 @@ Feb 26 20:24:56 HOST com.apple.authd[71]: Succeeded authorizing right 'com.apple
 
 <decoder name="mtmd">
   <program_name>com.apple.mtmd</program_name>
+</decoder>
+
+<decoder name="CalendarAgent">
+  <program_name>CalendarAgent</program_name>
+</decoder>
+
+<!-- "BezelServices 240.49" http://cocoadev.com/BezelServices -->
+<decoder name="BezelServices">
+<!-- NOK
+  <program_name>BezelServices</program_name>
+-->
+  <program_name>^BezelServices</program_name>
+</decoder>
+
+<decoder name="mDNSResponder">
+  <program_name>mDNSResponder</program_name>
+</decoder>
+
+<decoder name="iCloudHelper">
+  <program_name>com.apple.iCloudHelper</program_name>
+</decoder>
+
+<decoder name="ImageCaptureExtension">
+<!--
+  <program_name>Image Capture Extension</program_name>
+-->
+  <program_name>^Image</program_name>
+</decoder>
+
+<decoder name="ubd">
+  <program_name>ubd</program_name>
+</decoder>
+
+<decoder name="com.apple.preference.network.remoteservice">
+  <program_name>com.apple.preference.network.remoteservice</program_name>
 </decoder>
 
 <!-- Non-Apple programs -->

--- a/etc/rules/local_rules_mac.xml
+++ b/etc/rules/local_rules_mac.xml
@@ -59,7 +59,7 @@
     <description>apple.appkot.xpc log noise</description>
   </rule>
 <!-- multi-line...
-Mar  4 23:32:07 HOST com.apple.appkit.xpc.openAndSavePanelService[20708]: Bogus event received by listener connection:
+Mar  4 23:32:07 somemac com.apple.appkit.xpc.openAndSavePanelService[20708]: Bogus event received by listener connection:
         <error: 0x7fff75dbfb50> { count = 1, contents =
                 "XPCErrorDescription" => <string: 0x7fff75dbfe60> { length = 18, contents = "Connection invalid" }
         }
@@ -102,10 +102,12 @@ Mar  4 23:32:07 HOST com.apple.appkit.xpc.openAndSavePanelService[20708]: Bogus 
     <description>tcp connection failed??? (1)</description>
   </rule>
   <rule id="102013" level="6">
+<!-- NOK? -->
     <regex>tcp_connection_destination_prepare_complete \d+ connectx to \S+ failed: 1 - Operation not permitted</regex>
     <description>tcp connection failed??? (2)</description>
   </rule>
   <rule id="102014" level="6">
+<!-- NOK? -->
     <regex>tcp_connection_handle_destination_prepare_complete \d+ failed to connect</regex>
     <description>tcp connection failed??? (3)</description>
   </rule>
@@ -181,6 +183,10 @@ OK
     <match>Job appears to have crashed: </match>
     <description>launchd: some apps crashed</description>
   </rule>
+  <rule id="103003" level="3">
+    <match>Failed to add kevent for PI</match>
+    <description>launchd: failed to add kevent</description>
+  </rule>
 </group>
 
 <group name="syslog,secd,">
@@ -226,6 +232,7 @@ OK
 
 <group name="syslog,usernoted,">
   <rule id="102040" level="3">
+<!-- NOK? -->
     <match>Connection does not have the proper entitlement (com.apple.developer.notificationcenter-identifiers) to connect on behalf of com.apple.appstore. All communication will be denied.</match>
     <description>usernoted?</description>
   </rule>
@@ -298,7 +305,7 @@ OK
     <description>Preview log noise</description>
   </rule>
 <!--
-Mar  7 15:05:38 HOST Preview[8520]: view service marshal for <NSRemoteView: 0x7f9d61e84ba0> failed to forget accessibility connection due to Error Domain=NSCocoaErrorDomain Code=4099 "Impossible de communiquer avec un utilitaire." (The connection was invalidated from this process.) UserInfo=0x7f9d61dc7170 {NSDebugDescription=The connection was invalidated from this process.}
+Mar  7 15:05:38 somemac Preview[8520]: view service marshal for <NSRemoteView: 0x7f9d61e84ba0> failed to forget accessibility connection due to Error Domain=NSCocoaErrorDomain Code=4099 "Impossible de communiquer avec un utilitaire." (The connection was invalidated from this process.) UserInfo=0x7f9d61dc7170 {NSDebugDescription=The connection was invalidated from this process.}
         timestamp: 15:05:38.126 Friday 07 March 2014
         process/thread/queue: Preview (8520) / 0x110293000 / com.apple.NSXPCConnection.user.endpoint
         code: line 2972 of /SourceCache/ViewBridge/ViewBridge-46.2/NSRemoteView.m in __57-[NSRemoteView viewServiceMarshalProxy:withErrorHandler:]_block_invoke
@@ -324,6 +331,10 @@ Mar  7 15:05:38 HOST Preview[8520]: view service marshal for <NSRemoteView: 0x7f
   </rule>
   <rule id="130006" level="0">
     <match>Layout still needs update after calling -[NSToolbarView layout].  NSToolbarView or one of its superclasses may have overridden -layout without calling super. Or, something may have dirtied layout in the middle of updating it.  Both are programming errors in Cocoa Autolayout.  The former is pretty likely to arise if some pre-Cocoa Autolayout class had a method called layout, but it should be fixed.</match>
+    <description>Preview log noise</description>
+  </rule>
+  <rule id="130007" level="0">
+    <match>Assertion failure in void runningApplicationNotificationCallback(LSNotificationCode, CFAbsoluteTime, CFTypeRef, LSASNRef, const void *, LSSessionID, LSNotificationID)()</match>
     <description>Preview log noise</description>
   </rule>
 </group>
@@ -413,6 +424,7 @@ Mar  7 15:05:38 HOST Preview[8520]: view service marshal for <NSRemoteView: 0x7f
     <description>usbmuxd log noise ? (2)</description>
   </rule>
   <rule id="101003" level="0">
+<!-- NOK? -->
     <match>Could not start session: kAMDInvalidHostIDError</match>
     <description>usbmuxd log noise</description>
   </rule>
@@ -434,6 +446,14 @@ Mar  7 15:05:38 HOST Preview[8520]: view service marshal for <NSRemoteView: 0x7f
     <match>(Error) Import: sandbox_extension_issue_file: 2</match>
     <description>mds/spotlight: sandbox_extension_issue_file</description>
   </rule>
+<!--
+	http://apple.stackexchange.com/questions/56071/what-does-this-mean-mds-warning-fmw-event1-had-an-arg-mismatch-ac2-am5
+	https://discussions.apple.com/thread/2014732?threadID=2014732
+-->
+  <rule id="101033" level="4">
+    <match>(Error) FMW: WE ARE DROPPING FMW EVENTS!</match>
+    <description>mds: FMW: WE ARE DROPPING FMW EVENTS</description>
+  </rule>
 </group>
 
 <group name="syslog,fsevents,">
@@ -442,7 +462,11 @@ Mar  7 15:05:38 HOST Preview[8520]: view service marshal for <NSRemoteView: 0x7f
     <description>fseventsd: sleeping</description>
   </rule>
   <rule id="101042" level="0">
+<!-- NOK
     <regex>client_buffer_flush: failed to send \d+ events to client pid: \d+ (status: \d+)</regex>
+    <match>client_buffer_flush: failed to send </match>
+-->
+    <match>client_buffer_flush: failed to send </match>
     <description>fseventsd: buffer failed</description>
   </rule>
 </group>
@@ -477,10 +501,12 @@ com.apple.internetaccounts[6930]: An instance 0x7ffe51729420 of class IMAPMailbo
 
 <group name="syslog,com.apple.imfoundation.IMRemoteURLConnectionAgent,">
   <rule id="101071" level="1">
+<!-- NOK? -->
     <match>ERROR: __CFURLCache:CreateTablesAndIndexes version create - disk I/O error. ErrCode: 10.</match>
     <description>com.apple.imfoundation.IMRemoteURLConnectionAgent: disk I/O error</description>
   </rule>
   <rule id="101072" level="1">
+<!-- NOK? -->
     <match>__CFURLCache:RecreateEmptyPersistentStoreOnDiskAndOpen: create tables and index failed.</match>
     <description>com.apple.imfoundation.IMRemoteURLConnectionAgent: create tables and index failed</description>
   </rule>
@@ -536,9 +562,18 @@ com.apple.internetaccounts[6930]: An instance 0x7ffe51729420 of class IMAPMailbo
   <rule id="101141" level="1">
 <!-- NOK?
     <match>ENSpotlightImporter:importFileAtPath:attributes:error: caught exception: Cannot create an NSPersistentStoreCoordinator with a nil model</match>
+    <match>ENSpotlightImporter:importFileAtPath:attributes:error: caught exception: Cannot create an NSPersistentStoreCoordinator</match>
 -->
     <match>ENSpotlightImporter:importFileAtPath:attributes:error: caught exception: Cannot create an NSPersistentStoreCoordinator</match>
     <description>mdworker: ENSpotlightImporter error</description>
+  </rule>
+  <rule id="101142" level="1">
+<!-- NOK?
+    <match>(Warning) Import: Bad path:</match>
+    <match> Import: Bad path:</match>
+-->
+    <match> Import: Bad path:</match>
+    <description>mdworker: Bad path</description>
   </rule>
 </group>
 
@@ -552,7 +587,105 @@ com.apple.internetaccounts[6930]: An instance 0x7ffe51729420 of class IMAPMailbo
     <regex>Failed to get the path for fd \d+ (Invalid argument)</regex>
     <description>mtmd error</description>
   </rule>
+  <rule id="101152" level="1">
+<!-- NOK
+    <match>handler unblock failed. (status=</match>
+    <match>handler unblock failed.</match>
+-->
+    <match>handler unblock failed.</match>
+    <description>mtmd error (handler)</description>
+  </rule>
 </group>
+
+<group name="syslog,CalendarAgent,">
+  <rule id="101161" level="0">
+<!-- NOK? -->
+    <match>[com.apple.calendar.store.log.caldav.queue] [Adding [&lt;CalDAVAccountRefreshQueueableOperation: </match>
+    <description>CalendarAgent error</description>
+  </rule>
+</group>
+
+<group name="syslog,BezelServices,">
+  <rule id="101171" level="0">
+<!-- NOK? -->
+    <match>HIDMonitor : IOHIDManagerOpen returned an error, but continuing anyway.</match>
+    <description>BezelServices log</description>
+  </rule>
+</group>
+
+<group name="syslog,mDNSResponder,">
+  <rule id="101181" level="0">
+    <match>send_msg ERROR: failed to write</match>
+    <description>mDNSResponder log</description>
+  </rule>
+</group>
+
+<group name="syslog,mds_stores,">
+  <rule id="101191" level="0">
+    <match>(Error) IndexCI in _Bool indexMarkDirty(ContentIndexPtr):indexMarkDirty failed - state</match>
+    <description>mds_stores log error</description>
+  </rule>
+  <rule id="101192" level="0">
+    <match>(Error) IndexCI in int setDocumentAttributes(ContentIndexPtr, int, StoreOID *, int, StoreOID *, StoreOID, char, CFDictionaryRef, CFTypeRef, CFDictionaryRef, DocID, DocID *, int, _Bool (*)(void *), void *, _Bool):indexMarkDirty failed</match>
+    <description>mds_stores log error</description>
+  </rule>
+  <rule id="101193" level="0">
+    <match>(Error) IndexGeneral in int si_writeBackAndIndex(SIRef, ContentIndexRef, CFDictionaryRef, CFDictionaryRef, oid_t, db_obj **, CFStringRef, CFDataRef, int, _Bool, _Bool, _Bool, _Bool, SIUserCtxRef, CFStringRef, CFStringRef, int32_t, _Bool, _Bool, _Bool, _Bool, _Bool, _Bool, off_t, uint8_t, _Bool):ContentIndexUpdateContent failed</match>
+    <description>mds_stores log error</description>
+  </rule>
+  <rule id="101194" level="0">
+<!-- NOK? -->
+    <match>(Error) IndexGeneral in void setAttributes(si_set_attr_ctx *, Boolean):Couldn't update index oid:</match>
+    <description>mds_stores log error</description>
+  </rule>
+  <rule id="101195" level="0">
+<!-- NOK? -->
+    <match>(Error) IndexStore in int computePath(SIRef, db_obj *, oid_t *, ssize_t *):SIPersistentIDStoreGetParentForOid error:</match>
+    <description>mds_stores log error</description>
+  </rule>
+</group>
+
+<group name="syslog,iCloudHelper,">
+  <rule id="101201" level="1">
+<!-- NOK
+    <match>AOSKit ERROR: ((null)) Cannot refresh account bag, missing acct info</match>
+-->
+    <match> Cannot refresh account bag, missing acct info</match>
+    <description>iCloudHelper log</description>
+  </rule>
+</group>
+
+<group name="syslog,ImageCaptureExtension,">
+  <rule id="101211" level="1">
+<!-- NOK? -->
+    <match>Failed to register for death of process with pid:</match>
+    <description>ImageCaptureExtension log</description>
+  </rule>
+</group>
+
+<group name="syslog,ubd,">
+  <rule id="101221" level="0">
+    <match>ApplePushService: Failed to flush connection during shutdown</match>
+    <description>ubd log</description>
+  </rule>
+</group>
+
+<group name="syslog,com.apple.preference.network.remoteservice,">
+  <rule id="101231" level="0">
+    <match>*** Assertion failure in void assertCGError(CGError, const char *)(), /SourceCache/ViewBridge/ViewBridge-46.2/ViewBridgeUtilities.m:346</match>
+    <description>mds log</description>
+  </rule>
+</group>
+
+<!-- TEMPLATE
+<group name="syslog,mds,">
+  <rule id="101031" level="0">
+    <match></match>
+    <description>mds log</description>
+  </rule>
+</group>
+
+-->
 
 <!-- command rules -->
 


### PR DESCRIPTION
This is a base for a client/user environment.
For now rules number are in the user-range but could be probably changed once validated enough.

Still a work in progress. Please review and comment
It is tested with macports w the following Portfile
https://trac.macports.org/ticket/42533
