### PR TITLE
Fix make.sh files for win32

### DIFF
--- a/src/win32/make.sh
+++ b/src/win32/make.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 echo Making windows agent
 BASES="${MING_BASE} i686-w64-mingw32 x86_w64-w64-mingw32-gcc"
 
@@ -10,6 +12,8 @@ done
 
 #echo ${MING_BASE}
 
+# exit on error
+set -e
 
 ${MING_BASE}-windres -i icofile.rc -o icon.o
 ${MING_BASE}-gcc -o ossec-agent.exe -Wall  -DARGV0=\"ossec-agent\" -DCLIENT -DWIN32 -DOSSECHIDS icon.o os_regex/*.c os_net/*.c os_xml/*.c zlib-1.2.8/*.c config/*.c shared/*.c os_execd/*.c os_crypto/blowfish/*.c os_crypto/md5/*.c os_crypto/sha1/*.c os_crypto/md5_sha1/*.c os_crypto/shared/*.c rootcheck/*.c *.c -Iheaders/ -I./ -lwsock32

--- a/src/win32/ui/make.sh
+++ b/src/win32/ui/make.sh
@@ -1,3 +1,8 @@
+#!/bin/sh
+
+# exit on error
+set -e
+
 echo Making windows agent UI
 
 ${MING_BASE}-windres -o resource.o win32ui.rc


### PR DESCRIPTION
Added the shebang. Also used 'set -e' to exit the scripts upon
getting an error from any of the command being run. That is it say
if there is an issue compiling anything for any reason stop there
and continue not further.

Previously, it would just continue on until something would look
for the executables that weren't there and exit. Usually after makensis.

This makes it a lot clearer on where things went wrong and you don't have
to trudge through a lot of output to find compile issues.
