### PR TITLE
Remove event ID 672

### DIFF
--- a/etc/rules/msauth_rules.xml
+++ b/etc/rules/msauth_rules.xml
@@ -62,7 +62,7 @@
 
   <rule id="18107" level="3">
     <if_sid>18104</if_sid>
-    <id>^528$|^540$|^672$|^673$|^4624$|^4769$</id>
+    <id>^528$|^540$|^673$|^4624$|^4769$</id>
     <description>Windows Logon Success.</description>
     <group>authentication_success,</group>
   </rule>
@@ -274,7 +274,7 @@
   
   <rule id="18139" level="5">
     <if_sid>18105</if_sid>
-    <id>^672$|^673$|^675$|^676$|^681$|^4769$</id>
+    <id>^673$|^675$|^676$|^681$|^4769$</id>
     <description>Windows DC Logon Failure.</description>
     <group>win_authentication_failed,</group>
   </rule>


### PR DESCRIPTION
Event 672 is related to the granting of Kerberos tickets. It is extraneous due to other authentication events for the same action being logged, and causes the number of logon failures to appear higher than they really are. From Microsoft:

Does not contain any additional information if audit details from logon events 528 and 540 are already being collected. This event records that a Kerberos TGT was granted, actual access will not occur until a service ticket is granted, which is audited by Event 673.
