### PR TITLE
Fix windows agent compile error/warnings #define ENOBUFS, ALERT_SYSTEM_ERR

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -37,8 +37,12 @@ socklen_t us_l = sizeof(n_us);
 		                      + strlen ((ptr)->sun_path))
 #endif /* Sun_LEN */
 
-/*#else*/
+#else /* WIN32 */
 /*int ENOBUFS = 0;*/
+# ifndef ENOBUFS
+# define ENOBUFS 0
+# endif
+
 #endif /* WIN32*/
 
 

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -478,7 +478,7 @@ void check_rc_sys(char *basedir)
             (ftell(_suid) == 0)?"":
             "       rootcheck-suid-files.txt (list of suid files)");
 
-        notify_rk(ALERT_SYSTEM_ERROR, op_msg);
+        notify_rk(ALERT_SYSTEM_ERR, op_msg);
     }
 
     if(_wx)

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -29,7 +29,7 @@ rkconfig rootcheck;
 
 /* rk_types */
 #define ALERT_OK                0
-#define ALERT_SYSTEM_ERROR      1
+#define ALERT_SYSTEM_ERR        1
 #define ALERT_SYSTEM_CRIT       2
 #define ALERT_ROOTKIT_FOUND     3
 #define ALERT_POLICY_VIOLATION  4

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -25,7 +25,7 @@ int notify_rk(int rk_type, char *msg)
     {
         if(rk_type == ALERT_OK)
             printf("[OK]: %s\n", msg);
-        else if(rk_type == ALERT_SYSTEM_ERROR)
+        else if(rk_type == ALERT_SYSTEM_ERR)
             printf("[ERR]: %s\n", msg);
         else if(rk_type == ALERT_POLICY_VIOLATION)
             printf("[INFO]: %s\n", msg);
@@ -39,7 +39,7 @@ int notify_rk(int rk_type, char *msg)
     }
 
     /* No need to alert on that to the server */
-    if(rk_type <= ALERT_SYSTEM_ERROR)
+    if(rk_type <= ALERT_SYSTEM_ERR)
         return(0);
 
     #ifdef OSSECHIDS


### PR DESCRIPTION
The errno.h in some versions of MinGW do not have ENOBUFS defined, causing Travis CI windows_agent build to fail. This PR fixs that. 
Also, this PR gets rid of compile warnings regarding ALERT_SYSTEM_ERROR being redefined in rootcheck/rootcheck.h, which was also defined in /i686-w64-mingw32/include/winuser.h:4997
