### PR TITLE
Prevent internal_options.conf from getting overwritten

### DIFF
--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -146,7 +146,7 @@ Section "OSSEC Agent (required)" MainSec
     File manage_agents.exe
     File /oname=win32ui.exe os_win32ui.exe
     File ossec-rootcheck.exe
-    File internal_options.conf
+    File default-internal_options.conf
     File setup-windows.exe
     File setup-syscheck.exe
     File setup-iis.exe
@@ -216,19 +216,35 @@ Section "OSSEC Agent (required)" MainSec
         ClearErrors
 
     ; rename ossec.conf if it does not already exist
-    ConfInstall:
+    ConfInstallOSSEC:
         ClearErrors
-        IfFileExists "$INSTDIR\ossec.conf" ConfPresent
+        IfFileExists "$INSTDIR\ossec.conf" ConfPresentOSSEC
         Rename "$INSTDIR\default-ossec.conf" "$INSTDIR\ossec.conf"
-        IfErrors ConfError ConfPresent
-    ConfError:
+        IfErrors ConfErrorOSSEC ConfPresentOSSEC
+    ConfErrorOSSEC:
         MessageBox MB_ABORTRETRYIGNORE|MB_ICONSTOP "$\r$\nFailure renaming configuration file.$\r$\n$\r$\nFrom:$\r$\n$\r$\n$INSTDIR\default-ossec.conf\
             $\r$\n$\r$\nTo:$\r$\n$\r$\n$INSTDIR\ossec.conf$\r$\n$\r$\nClick Abort to stop the installation,$\r$\nRetry to try again, or\
-            $\r$\nIgnore to skip this file." /SD IDABORT IDIGNORE ConfPresent IDRETRY ConfInstall
+            $\r$\nIgnore to skip this file." /SD IDABORT IDIGNORE ConfPresentOSSEC IDRETRY ConfInstallOSSEC
 
         SetErrorLevel 2
         Abort
-    ConfPresent:
+    ConfPresentOSSEC:
+        ClearErrors
+
+    ; rename internal_options.conf if it does not already exist
+    ConfInstallInternal:
+        ClearErrors
+        IfFileExists "$INSTDIR\internal_options.conf" ConfPresentInternal
+        Rename "$INSTDIR\default-internal_options.conf" "$INSTDIR\internal_options.conf"
+        IfErrors ConfErrorInternal ConfPresentInternal
+    ConfErrorInternal:
+        MessageBox MB_ABORTRETRYIGNORE|MB_ICONSTOP "$\r$\nFailure renaming configuration file.$\r$\n$\r$\nFrom:$\r$\n$\r$\n$INSTDIR\default-internal_options.conf\
+            $\r$\n$\r$\nTo:$\r$\n$\r$\n$INSTDIR\internal_options.conf$\r$\n$\r$\nClick Abort to stop the installation,$\r$\nRetry to try again, or\
+            $\r$\nIgnore to skip this file." /SD IDABORT IDIGNORE ConfPresentInternal IDRETRY ConfInstallInternal
+
+        SetErrorLevel 2
+        Abort
+    ConfPresentInternal:
         ClearErrors
 
     ; handle shortcuts

--- a/src/win32/win-files.txt
+++ b/src/win32/win-files.txt
@@ -46,7 +46,7 @@ syscheckd/seechanges.c seechanges.c
 rootcheck rootcheck
 external/zlib-1.2.8/zlib.h zlib.h
 external/zlib-1.2.8/zconf.h zconf.h
-external/lua-5.2.3/src lua 
+external/lua-5.2.3/src lua
 os_zlib/os_zlib.c os_zlib.c
 os_zlib/os_zlib.h os_zlib.h
 win32/os_win.h os_win.h
@@ -61,7 +61,7 @@ win32/setup-syscheck.c setup/setup-syscheck.c
 win32/add-localfile.c setup/add-localfile.c
 win32/ossec-win.conf default-ossec.conf
 win32/vista_sec.csv vista_sec.csv
-win32/internal_options-win.conf internal_options.conf
+win32/internal_options-win.conf default-internal_options.conf
 win32/doc.html doc.html
 win32/help_win.txt help.txt
 win32/ossec-installer.nsi ossec-installer.nsi


### PR DESCRIPTION
This stops the internal_options.conf from getting overwritten when
installing/upgrading a newer version of the OSSEC agent on win32 platforms.
This should fix #169.
