### PR TITLE
Use the evironment for the CC binary

### DIFF
--- a/src/external/lua-5.2.3/src/Makefile
+++ b/src/external/lua-5.2.3/src/Makefile
@@ -6,7 +6,7 @@
 # Your platform. See PLATS for possible values.
 PLAT= none
 
-CC= gcc
+#CC= gcc
 CFLAGS= -O2 -Wall -DLUA_COMPAT_ALL $(SYSCFLAGS) $(MYCFLAGS)
 LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
 LIBS= -lm $(SYSLIBS) $(MYLIBS)


### PR DESCRIPTION
See discussion at https://groups.google.com/forum/#!topic/ossec-list/FOTncDNnNk0 

The ossec-lua addition included a regression on @cgzones changes for using clang correctly.  This corrects that regression (as suggest by cgzones on the mailing list). 

I think this should also be merged into stable for the 2.8 release as the ossec-lua introduced a regression into clang builds.  

Please note travis will not pick up this try of errors due to gcc still being installed. 
