### PR TITLE
fixes ossec/ossec-hids#211

### DIFF
--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -357,7 +357,7 @@ int read_sys_dir(char *dir_name, int do_read)
                 notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
                 _sys_errors++;
             }
-            #elif Darwin || FreeBSD
+            #elif Darwin || FreeBSD || SOLARIS
             if(strncmp(dir_name, "/dev", strlen("/dev")) != 0)
             {
                 notify_rk(ALERT_ROOTKIT_FOUND, op_msg);


### PR DESCRIPTION
This is a fix for Solaris and Rootcheck: 

> From: ossec/ossec-hids#211
> 
> We have 2 brand new Oracle Solaris 11.1 SPARC servers and compiled OSSEC 2.7.1 
> on them. On OSSEC startup, they both complain many directories (all of them 
> under /dev) have possible hidden files because "Link count does not match 
> number of files"
> 
> Example:
> 
> ```
> ...
> outstanding,2014 May 22 15:50:52,2014 May 22 15:50:52,System Audit: Files hidden inside directory '/dev/rdsk'. Link count does not match number of files (2,42).
> outstanding,2014 May 22 15:50:52,2014 May 22 15:50:52,System Audit: Files hidden inside directory '/dev/removable-media/dsk'. Link count does not match number of files (2,18).
> outstanding,2014 May 22 15:50:52,2014 May 22 15:50:52,System Audit: Files hidden inside directory '/dev/removable-media/rdsk'. Link count does not match number of files (2,18).
> outstanding,2014 May 22 15:50:52,2014 May 22 15:50:52,System Audit: Files hidden inside directory '/dev/sad'. Link count does not match number of files (2,4).
> outstanding,2014 May 22 15:50:52,2014 May 22 15:50:52,System Audit: Files hidden inside directory '/dev/term'. Link count does not match number of files (2,13).
> outstanding,2014 May 22 15:50:52,2014 May 22 15:50:52,System Audit: Files hidden inside directory '/dev/usb/46b.ff10/0'. Link count does not match number of files (2,9).
> outstanding,2014 May 22 15:50:52,2014 May 22 15:50:52,System Audit: Files hidden inside directory '/dev/usb/46b.ff20/0'. Link count does not match number of files (2,9).
> ...
> ```
