### PR TITLE
Fix Windows Installed Date

### DIFF
--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -193,7 +193,7 @@ Section "OSSEC Agent (required)" MainSec
 
     ; get current local time
     ${GetTime} "" "L" $0 $1 $2 $3 $4 $5 $6
-    Var /global CURRENTTIME
+    var /global CURRENTTIME
     StrCpy $CURRENTTIME "$2-$1-$0 $4:$5:$6"
 
     ; write version and install information


### PR DESCRIPTION
Fixes #225. The installed date was only ever gathered at compile time
and not each and every time the ossec-installer was run on each system.
This would result in the installed date being the same on all systems
and equal to the time when the installer was compiled.

This makes me wonder if installed date was actually supposed to be
something like 'compiled date'. I'm going to go with it being a bug
though just because of the naming of everything.

This bug has likely existed for quite some time but was only recently
discovered becuase I moved the installed date into the win32ui making it
more visible to end users.

The current time should now be gathered on every run of the installer
and updating VERSION.txt with the information. Also, the issue of the
seconds being cut off should hopefully no longer be an issue as well
since the new method of getting the time shortens the string due to the
difference in the way the time is formatted.
