### PR TITLE
fix crash in is_simple_http_request

### DIFF
--- a/src/analysisd/compiled_rules/generic_samples.c
+++ b/src/analysisd/compiled_rules/generic_samples.c
@@ -137,6 +137,12 @@ void *comp_mswin_targetuser_calleruser_diff(Eventinfo *lf)
 void *is_simple_http_request(Eventinfo *lf)
 {
 
+    if(!lf->url)
+    {
+        return(NULL);
+    }
+
+
     /* Simple GET / request. */
     if(strcmp(lf->url,"/") == 0)
     {


### PR DESCRIPTION
Under some conditions is_simple_http_request access lf->url unchecked. If lf->url is null, it will segfault.
