### PR TITLE
Bugfix: wrong slash for windows filenames.

### DIFF
--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -322,7 +322,7 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
         }
 
         final_path[MAX_LINE] = '\0';
-        snprintf(final_path, MAX_LINE, "%s/%s", rtlocald->dir, finalfile);
+        snprintf(final_path, MAX_LINE, "%s\\%s", rtlocald->dir, finalfile);
 
 
         /* Checking the change. */


### PR DESCRIPTION
Subtle bug, most people probably don't realize this is happening.
