### PR TITLE
remove CPATH as it's not used by ossec build, but use used gcc

### DIFF
--- a/src/Config.Make
+++ b/src/Config.Make
@@ -8,7 +8,7 @@ include ${PT}LOCATION
 include ${PT}Config.OS
 
 CC?=cc
-CFLAGS = -g -Wall -I${PT} -I${PT}headers ${CPATH} ${CEXTRA} ${DEXTRA} ${EEXTRA} ${FEXTRA} ${GEXTRA} ${HEXTRA} ${MEXTRA} ${CGEOIP} -DARGV0=\"${NAME}\" -DOSSECHIDS
+CFLAGS = -g -Wall -I${PT} -I${PT}headers ${CEXTRA} ${DEXTRA} ${EEXTRA} ${FEXTRA} ${GEXTRA} ${HEXTRA} ${MEXTRA} ${CGEOIP} -DARGV0=\"${NAME}\" -DOSSECHIDS
 
 SOURCES = *.c
 OBJECTS = *.o


### PR DESCRIPTION
This for ossec/ossec-hids#230
