### PR TITLE
Fix help for ossec-rootcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ src/os_dbd/ossec-dbd
 src/os_execd/ossec-execd
 src/os_maild/ossec-maild
 src/remoted/ossec-remoted
+src/rootcheck/ossec-rootcheck
 src/syscheckd/ossec-syscheckd
 src/util/agent_control
 src/util/clear_stats

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -37,25 +37,25 @@ int Read_Rootcheck_Config(char * cfgfile, rkconfig *cfg);
 
 #ifndef OSSECHIDS
 
-void rootcheck_help()
+/* print help statement */
+void help_rootcheck()
 {
-    printf("\n");
-    printf("Rootcheck v0.8 (Mar/12/2008):\n");
-    printf("http://www.ossec.net/rootcheck/\n");
-    printf("Available options:\n");
-    printf("\t\t-h\t  This Help message\n");
-    printf("\t\t-c <file> Configuration file\n");
-    printf("\t\t-d\t  Enable debug\n");
-    printf("\t\t-D <dir>  Set the working directory\n");
-    printf("\t\t-s\t  Scans the whole system\n");
-    printf("\t\t-r\t  Read all the files for kernel-based detection\n");
-    printf("\n");
-    exit(0);
+    print_header();
+    print_out("  %s: -[Vhdtsr] [-c config] [-D dir]", ARGV0);
+    print_out("    -V          Version and license message");
+    print_out("    -h          This help message");
+    print_out("    -d          Execute in debug mode. This parameter");
+    print_out("                can be specified multiple times");
+    print_out("                to increase the debug level.");
+    print_out("    -t          Test configuration");
+    print_out("    -s          Scans the whole system");
+    print_out("    -r          Read all the files for kernel-based detection");
+    print_out("    -c <config> Configuration file to use");
+    print_out("    -D <dir>    Directory to chroot into (default: %s)", DEFAULTDIR);
+    print_out(" ");
+    exit(1);
 }
 
-/* main v0.1
- *
- */
 int main(int argc, char **argv)
 {
     int c;
@@ -135,7 +135,7 @@ int rootcheck_init(int test_config)
                 print_version();
                 break;
             case 'h':
-                rootcheck_help();
+                help_rootcheck();
                 break;
             case 'd':
                 nowDebug();
@@ -160,7 +160,7 @@ int rootcheck_init(int test_config)
                 rootcheck.readall = 1;
                 break;
             default:
-                rootcheck_help();
+                help_rootcheck();
                 break;
         }
 


### PR DESCRIPTION
Added help output to match what the other binaries have. Was going to
rmeove ossec-rootcheck but found that it has been decently well
maintained through the years and has the potential to provide value.
Also, added the binary to .gitignore.
