### PR TITLE
Do not truncate OS information in agent_control

### DIFF
--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -65,7 +65,7 @@ int get_agent_status(char *agent_name, char *agent_ip);
 /** agent_info *get_agent_info(char *agent_name, char *agent_ip)
  * Get information from an agent.
  */
-agent_info *get_agent_info(char *agent_name, char *agent_ip);
+agent_info *get_agent_info(char *agent_name, char *agent_ip, int truncate);
 
 
 /** int connect_to_remoted()

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -1176,7 +1176,7 @@ char *_get_agent_keepalive(char *agent_name, char *agent_ip)
 
 
 /* Internal funtion. Extracts operating system. */
-int _get_agent_os(char *agent_name, char *agent_ip, agent_info *agt_info)
+int _get_agent_os(char *agent_name, char *agent_ip, agent_info *agt_info, int truncate)
 {
     FILE *fp;
     char buf[1024 +1];
@@ -1203,7 +1203,7 @@ int _get_agent_os(char *agent_name, char *agent_ip, agent_info *agt_info)
         }
 
 
-        if(strlen(agt_info->os) > 55)
+        if(truncate && strlen(agt_info->os) > 55)
         {
             agt_info->os[52] = '.';
             agt_info->os[53] = '.';
@@ -1246,7 +1246,7 @@ int _get_agent_os(char *agent_name, char *agent_ip, agent_info *agt_info)
         }
 
 
-        if(strlen(buf) > 55)
+        if(truncate && strlen(buf) > 55)
         {
             buf[52] = '.';
             buf[53] = '.';
@@ -1272,7 +1272,7 @@ int _get_agent_os(char *agent_name, char *agent_ip, agent_info *agt_info)
 /** agent_info *get_agent_info(char *agent_name, char *agent_ip)
  * Get information from an agent.
  */
-agent_info *get_agent_info(char *agent_name, char *agent_ip)
+agent_info *get_agent_info(char *agent_name, char *agent_ip, int truncate)
 {
     char *agent_ip_pt = NULL;
     char *tmp_str = NULL;
@@ -1301,7 +1301,7 @@ agent_info *get_agent_info(char *agent_name, char *agent_ip)
 
 
     /* Getting information about the OS. */
-    _get_agent_os(agent_name, agent_ip, agt_info);
+    _get_agent_os(agent_name, agent_ip, agt_info, truncate);
     _get_time_rkscan(agent_name, agent_ip, agt_info);
     agt_info->last_keepalive = _get_agent_keepalive(agent_name, agent_ip);
 

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
     int gid = 0;
     int uid = 0;
     int c = 0, restart_syscheck = 0, restart_all_agents = 0, list_agents = 0;
-    int info_agent = 0, agt_id = 0, active_only = 0, csv_output = 0;
+    int info_agent = 0, agt_id = 0, active_only = 0, csv_output = 0, truncate = 1;
     int list_responses = 0, end_time = 0, restart_agent = 0;
 
     char shost[512];
@@ -99,6 +99,7 @@ int main(int argc, char **argv)
                 break;
             case 's':
                 csv_output = 1;
+                truncate = 0;
                 break;
             case 'c':
                 active_only++;
@@ -315,7 +316,8 @@ int main(int argc, char **argv)
                                           keys.keyentries[agt_id]->ip->ip);
 
             agt_info = get_agent_info(keys.keyentries[agt_id]->name,
-                                      keys.keyentries[agt_id]->ip->ip);
+                                      keys.keyentries[agt_id]->ip->ip,
+                                      truncate);
 
             /* Getting netmask from ip. */
             getNetmask(keys.keyentries[agt_id]->ip->netmask, final_mask, 128);
@@ -342,7 +344,7 @@ int main(int argc, char **argv)
         else
         {
             agt_status = get_agent_status(NULL, NULL);
-            agt_info = get_agent_info(NULL, "127.0.0.1");
+            agt_info = get_agent_info(NULL, "127.0.0.1", truncate);
 
             if(!csv_output)
             {


### PR DESCRIPTION
When getting agent information from agent_control it provides really useful OS information about the agent it is running on. Unfortunately, that information gets truncated both when displaying in it's normal mode and when CSV output is chosen.

At the very least the CSV output should show this data without getting truncated. My guess is the data was originally truncated to make the display nicer. That isn't a concern with CSV output.

I think we should consider removing this truncation entirely. The truncation doesn't really make the display of data that much nicer and it is cleaner. If enough people agree I can close this pull request and re-open with the appropriate changes.

Some examples of the output:

```
OSSEC HIDS agent_control. Agent information:
   Agent ID:   045
   Agent Name: example-agent
   IP address: 1.2.3.4
   Status:     Active

   Operating system:    Microsoft Windows Server 2012 Standard Edition  (Build 9200)
   Client version:      OSSEC HIDS v2.8
   Last keep alive:     Sun Sep 14 09:42:57 2014

   Syscheck last started  at: Sun Sep 14 08:38:16 2014
   Rootcheck last started at: Sun Sep 14 07:32:57 2014
```

```
OSSEC HIDS agent_control. Agent information:
   Agent ID:   000 (local instance)
   Agent Name: example-master
   IP address: 127.0.0.1
   Status:     Active/Local

   Operating system:    Linux example-master 2.6.32-431.23.3.el6.x86_64 #1 SMP Wed Jul 16 06:12:23 EDT 2014 x86_64
   Client version:      OSSEC HIDS v2.8
   Last keep alive:     Not available

   Syscheck last started  at: Sun Sep 14 04:19:20 2014
   Rootcheck last started at: Sun Sep 14 02:06:29 2014
```

As you can see, the second listing is a big longer but not really all that bad. I can't imagine where that OS information gets any longer than that but I'm sure it is possible. At the very least we can truncate at a higher level of chars.
