### PR TITLE
mac osx requries time.h for time_t to be present

### DIFF
--- a/src/shared/sig_op.c
+++ b/src/shared/sig_op.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <signal.h>
+#include <time.h>
 
 #include "sig_op.h"
 #include "file_op.h"


### PR DESCRIPTION
SMALL fix for building on MacOSX time.h is required in the sing_op.c file for the time_t typedef to be present. 
