### PR TITLE
fix for time.h time_t on macosx.

### DIFF
--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -21,6 +21,10 @@
 
 #define __FILE_H
 
+#include <time.h>
+
+
+
 #define OS_PIDFILE	"/var/run"
 
 /* Set the program name. Must be done before **anything** else */


### PR DESCRIPTION
fix for my fix on macosx not compiling due to time_t not being defined. 
