### PR TITLE
derp, forgot that the domains end in a .

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -2580,7 +2580,7 @@ Author and (c): Michael Starks, 2014 -->
 
 <decoder name="unbound-a">
   <parent>unbound</parent>
-  <regex> info: (\S+) (\S+) A IN$| info: (\S+) (\S+) AAAA IN$</regex>
+  <regex> info: (\S+) (\S+). A IN$| info: (\S+) (\S+) AAAA IN$</regex>
   <order>srcip,url</order>
 </decoder>
 


### PR DESCRIPTION
The domains in the logs end in a ".", so the decoder was picking up "ossec.net." and this caused some issues.
