### PR TITLE
Decoder and Rules for apache-2.4 error logs

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1511,6 +1511,10 @@
   - [notice] Apache configured
   - httpd[18660]: [error] [client 12.34.56.78] File does not exist: /usr/local/htdocs/cache
   - httpd[23745]: [error] [client 12.34.56.78] PHP Notice:
+  - [Tue Sep 30 11:30:13.262255 2014] [core:error] [pid 20101] [client 99.47.227.95:34567] AH00037: Symbolic link not allowed or link target not accessible: /usr/share/awstats/icon/mime/document.png
+  - [Tue Sep 30 12:11:21.258612 2014] [ssl:error] [pid 30473] AH02032: Hostname www.example.com provided via SNI and hostname ssl://www.example.com provided via HTTP are different
+  - [Tue Sep 30 12:24:22.891366 2014] [proxy:warn] [pid 2331] [client 77.127.180.111:54082] AH01136: Unescaped URL path matched ProxyPass; ignoring unsafe nocanon, referer: http://www.easylinker.co.il/he/links.aspx?user=bguyb
+  - [Tue Sep 30 14:25:44.895897 2014] [authz_core:error] [pid 31858] [client 99.47.227.95:38870] AH01630: client denied by server configuration: /var/www/example.com/docroot/
   -->
 <decoder name="apache-errorlog">
   <program_name>^httpd</program_name>
@@ -1520,14 +1524,25 @@
   <prematch>^[warn] |^[notice] |^[error] </prematch>
 </decoder>
 
+<decoder name="apache-errorlog">
+    <prematch>^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:warn] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:notice] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:error] </prematch>
+</decoder>
+
+<decoder name="apache24-errorlog-ip">
+    <parent>apache-errorlog</parent>
+
+    <prematch offset="after_parent">[client</prematch>
+    <regex offset="after_prematch">^ (\S+):\d+] (\S+): </regex>
+    <order>srcip,id</order>
+</decoder>
+
 <decoder name="apache-errorlog-ip">
   <parent>apache-errorlog</parent>
 
   <prematch offset="after_parent">^[client</prematch>
-  <regex offset="after_prematch">^ (\d+.\d+.\d+.\d+)] </regex>
+  <regex offset="after_prematch">^ (\S+)] </regex>
   <order>srcip</order>
 </decoder>
-
 
 
 

--- a/etc/rules/apache_rules.xml
+++ b/etc/rules/apache_rules.xml
@@ -13,6 +13,7 @@
   -  License details: http://www.ossec.net/en/licensing.html
   -
   -  Contributed by: Ahmet Ozturk
+  -                  Ben Chavet <ben.chavet@lullabot.com>
   -->
                         
 
@@ -165,8 +166,109 @@
     <description>Multiple attempts blocked by Mod Security.</description>
     <group>access_denied,</group>
   </rule>
-</group> <!-- ERROR_LOG,APACHE -->
 
+  <!-- Apache 2.4 Rules -->
+  <rule id="30301" level="0">
+    <if_sid>30100</if_sid>
+    <regex> [\S+:error] </regex>
+    <description>Apache error messages grouped.</description>
+  </rule>
+
+  <rule id="30302" level="0">
+    <if_sid>30100</if_sid>
+    <regex> [\S+:warn] </regex>
+    <description>Apache warn messages grouped.</description>
+  </rule>
+
+  <rule id="30303" level="0">
+    <if_sid>30100</if_sid>
+    <regex> [\S+:notice] </regex>
+    <description>Apache notice messages grouped.</description>
+  </rule>
+
+  <rule id="30304" level="12">
+    <if_sid>30303</if_sid>
+    <match>exit signal Segmentation Fault</match>
+    <description>Apache segmentation fault.</description>
+    <info type="link">http://www.securityfocus.com/infocus/1633</info>
+    <group>service_availability,</group>
+  </rule>
+
+  <rule id="30305" level="5">
+    <if_sid>30301</if_sid>
+    <id>AH01630</id>
+    <description>Attempt to access forbidden file or directory.</description>
+    <group>access_denied,</group>
+  </rule>
+
+  <rule id="30306" level="5">
+    <if_sid>30301</if_sid>
+    <id>AH01276</id>
+    <description>Attempt to access forbidden directory index.</description>
+    <group>access_denied,</group>
+  </rule>
+
+  <rule id="30307" level="6">
+    <if_sid>30301</if_sid>
+    <id>AH00550</id>
+    <description>Client sent malformed Host header. Possible Code Red attack.</description>
+    <info type="link">http://www.cert.org/advisories/CA-2001-19.html</info>
+    <info type="text">CERT: Advisory CA-2001-19 "Code Red" Worm Exploiting Buffer Overflow In IIS Indexing Service DLL</info>
+    <group>automatic_attack,</group>
+  </rule>
+
+  <rule id="30308" level="5">
+    <if_sid>30302</if_sid>
+    <id>AH01617|AH01807|AH01694|AH01695|AH02009|AH02010</id>
+    <description>User authentication failed.</description>
+    <group>authentication_failed,</group>
+  </rule>
+
+  <rule id="30309" level="5">
+    <if_sid>30301</if_sid>
+    <id>AH01618|AH01808|AH01790</id>
+    <description>Attempt to login using a non-existent user.</description>
+    <group>invalid_login,</group>
+  </rule>
+
+  <rule id="30310" level="10" frequency="10" timeframe="160">
+    <if_matched_sid>30309</if_matched_sid>
+    <same_source_ip/>
+    <description>Multiple authentication failures with invalid user.</description>
+    <group>authentication_failures,</group>
+  </rule>
+
+  <rule id="30312" level="0">
+    <if_sid>30301</if_sid>
+    <match>File does not exist: |</match>
+    <match>failed to open stream: No such file or directory|</match>
+    <match>Failed opening </match>
+    <description>Attempt to access an non-existent file (those are reported on the access.log).</description>
+    <group>unknown_resource,</group>
+  </rule>
+
+  <rule id="30315" level="5">
+    <if_sid>30301</if_sid>
+    <id>AH00126</id>
+    <description>Invalid URI (bad client request).</description>
+    <group>invalid_request,</group>
+  </rule>
+
+  <rule id="30316" level="10" frequency="8" timeframe="120">
+    <if_matched_sid>30315</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple Invalid URI requests from </description>
+    <description>same source.</description>
+    <group>invalid_request,</group>
+  </rule>
+
+  <rule id="30317" level="10">
+    <if_sid>30301</if_sid>
+    <id>AH00565</id>
+    <description>Invalid URI, file name too long.</description>
+    <group>invalid_request,</group>
+  </rule>
+</group> <!-- ERROR_LOG,APACHE -->
 
 <!-- EOF -->
 


### PR DESCRIPTION
Apache-2.4 has a different error log format than previous versions. This pull request adds the ability to analyze the new log format, while maintaining the ability to continue to analyze error logs from older versions of apache.
