### PR TITLE
Fix compile warnings printing size_t

### DIFF
--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -550,9 +550,9 @@ size_t CreateSecMSG(const keystore *keys, const char *msg, char *msg_encrypted, 
     {
         verbose("%s: INFO: Event count after '%u': %lu->%lu (%lu%%)", __local_name,
                     evt_count,
-                    c_orig_size,
-                    c_comp_size,
-                    (c_comp_size * 100)/c_orig_size);
+                    (unsigned long)c_orig_size,
+                    (unsigned long)c_comp_size,
+                    (unsigned long)(c_comp_size * 100)/c_orig_size);
         evt_count = 0;
         c_orig_size = 0;
         c_comp_size = 0;


### PR DESCRIPTION
Every time I was building on Windows I was getting the following warnings:

```
os_crypto/shared/msgs.c:555:21: warning: format '%lu' expects type 'long unsigned int', but argument 4 has type 'size_t'
os_crypto/shared/msgs.c:555:21: warning: format '%lu' expects type 'long unsigned int', but argument 5 has type 'size_t'
os_crypto/shared/msgs.c:555:21: warning: format '%lu' expects type 'long unsigned int', but argument 6 has type 'size_t'
```

I think these were coming from the changes made in https://github.com/ossec/ossec-hids/commit/45b75900deb3eec252611697dab18c7ae1790b19. 

This seems like the best fix but perhaps there is something better.
