### PR TITLE
Fix include order warnings when compiling win32

### DIFF
--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -21,20 +21,10 @@
 
 
 #ifdef WIN32
-#include <windows.h>
-#include <winsock.h>
-#include <io.h>
-
 #define sleep(x) Sleep(x * 1000)
 #define os_calloc(x,y,z) (z = calloc(x,y))?(void)1:ErrorExit(MEM_ERROR, ARGV0)
 #define os_strdup(x,y) (y = strdup(x))?(void)1:ErrorExit(MEM_ERROR, ARGV0)
 #endif
-
-
-#include "hash_op.h"
-#include "debug_op.h"
-#include "syscheck.h"
-#include "error_messages/error_messages.h"
 
 
 #ifdef USEINOTIFY
@@ -45,6 +35,11 @@
 #include "shared.h"
 #endif
 
+
+#include "hash_op.h"
+#include "debug_op.h"
+#include "syscheck.h"
+#include "error_messages/error_messages.h"
 
 
 /** Global functions for all realtime options. **/


### PR DESCRIPTION
When compiling win32 it warns about including windows.h before
winsock2.h. Since Windows cannot use inotify remove the local includes
for the Windows components and let the later inclusion of shared.h
handle the inclusion of all the necessary Windows libraries.

Fixes:

```
In file included from headers/shared.h:83:0,
                 from run_realtime.c:45:
/usr/lib/gcc/i686-w64-mingw32/4.6/../../../../i686-w64-mingw32/include/winsock2.h:15:2: warning: #warning Please include winsock2.h before windows.h [-Wcpp]
```
