### PR TITLE
gnu make fallout

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,7 @@ Install()
 
     echo "CEXTRA=${CEXTRA}" >> ./src/Config.OS
 
+    MAKEBIN=make
     ## Find make/gmake
     if [ "X$NUNAME" = "XOpenBSD" ]; then
         MAKEBIN=gmake


### PR DESCRIPTION
We cannot specify "make" if we're using gnu make.
I'm not sure which other systems need this fix, but I'm pretty sure this should help the BSDs.
