### PR TITLE
Output settings after doing a build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -64,10 +64,10 @@ ifeq (${uname_S},FreeBSD)
 		LDFLAGS+=-pthread
 		LUA_PLAT=freebsd
 else
-ifeq (${uname_S},OpenBSD) 
+ifeq (${uname_S},OpenBSD)
 #		DEFINES+=-DOpenBSD
-		DEFINES+=-pthread 
-		LUA_PLAT=posix 
+		DEFINES+=-pthread
+		LUA_PLAT=posix
 else
 ifeq (${uname_S},HP-UX)
 		DEFINES+=-DHPUX
@@ -262,7 +262,7 @@ endif
 
 
 .PHONY: build
-build:: ${TARGET}
+build:  ${TARGET} settings
 	@echo
 	${QUIET_NOTICE}
 	@echo "Done building ${TARGET}"
@@ -307,7 +307,7 @@ install-common: build
 	install -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/syscheck
 	install -d -m 0750 -o ${OSSEC_USER_REM} -g ${OSSEC_GROUP} ${PREFIX}/queue/rids
 	install -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/diff
-	
+
 	install -d -m 0550 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc
 	install -m 0440 -o root -g ${OSSEC_GROUP} /etc/localtime ${PREFIX}/etc
 ifneq (,$(wildcard /etc/TIMEZONE))


### PR DESCRIPTION
Show the settings to the user after a build is completed so they are
able to see exactly what went down. Arguably this might be better done
in the beginning but usually it gets lost in the sea of output.

This is merely a suggestion and a preference thing. Try it out and see
if you like it more/less than how things work now. I won't be offended if
people don't like it this way.
