### PR TITLE
Update log.c

### DIFF
--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -427,7 +427,7 @@ void OS_CustomLog(Eventinfo *lf,char* format)
     tmp_log=NULL;
   }
 
-  snprintf(tmp_buffer, 1024, "%s",lf->srcuser?lf->srcuser:"None");
+  snprintf(tmp_buffer, 1024, "%s",lf->dstuser?lf->dstuser:"None");
 
   tmp_log = searchAndReplace(log, CustomAlertTokenName[CUSTOM_ALERT_TOKEN_DST_USER], tmp_buffer);
   if(log)


### PR DESCRIPTION
fixes ossec/ossec-hids#348

Correct the custom replace string to be based correctly on dstuser. 
