### PR TITLE
fix displaying settings after build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -262,7 +262,8 @@ endif
 
 
 .PHONY: build
-build:  ${TARGET} settings
+build: ${TARGET}
+	${MAKE} settings
 	@echo
 	${QUIET_NOTICE}
 	@echo "Done building ${TARGET}"


### PR DESCRIPTION
this ensures the settings are really displayed after the build (and not getting mixed up), e.g. when using -j4
