### PR TITLE
Fix compile warnings printing size_t

### DIFF
--- a/src/os_crypto/shared/msgs.c
+++ b/src/os_crypto/shared/msgs.c
@@ -552,7 +552,7 @@ size_t CreateSecMSG(const keystore *keys, const char *msg, char *msg_encrypted, 
                     evt_count,
                     (unsigned long)c_orig_size,
                     (unsigned long)c_comp_size,
-                    (unsigned long)(c_comp_size * 100)/c_orig_size);
+                    (unsigned long)((c_comp_size * 100)/c_orig_size));
         evt_count = 0;
         c_orig_size = 0;
         c_comp_size = 0;


### PR DESCRIPTION
Original fix in 8b9566bd was enough to suppress the warning when
building the 32bit version of the Windows agent but the 64bit builds
still complain. An extra layer of encapsulation was required.
