### PR TITLE
fix chmod error message

### DIFF
--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -117,7 +117,7 @@ int add_agent()
     #ifndef WIN32
     if(chmod(AUTH_FILE, 0440) == -1)
     {
-        ErrorExit(CHMOD_ERROR, ARGV0, AUTH_FILE);
+        ErrorExit(CHMOD_ERROR, ARGV0, AUTH_FILE, errno ,strerror(errno));
     }
     #endif
 

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -139,7 +139,7 @@ int k_import(const char *cmdimport)
                             verbose(DELETE_ERROR, ARGV0, tmp_path, errno, strerror(errno));
                         }
 
-                        ErrorExit(CHMOD_ERROR, ARGV0, tmp_path, errno, strerror(errno));
+                        ErrorExit(CHMOD_ERROR, ARGV0, tmp_path, errno ,strerror(errno));
                     }
                     #endif
 
@@ -437,7 +437,7 @@ int k_bulkload(const char *cmdbulk)
         #ifndef WIN32
         if(chmod(AUTH_FILE, 0440) == -1)
         {
-            ErrorExit(CHMOD_ERROR, ARGV0, AUTH_FILE);
+            ErrorExit(CHMOD_ERROR, ARGV0, AUTH_FILE, errno ,strerror(errno));
         }
         #endif
 

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -99,7 +99,6 @@
 #define CHDIR_ERROR     "%s(1244): ERROR: Unable to chdir to directory: '%s'."
 #define LINK_ERROR      "%s(1245): ERROR: Unable to link from '%s' to '%s'."
 #define CHOWN_ERROR     "%s(1246): ERROR: Unable to run chown on: '%s'."
-#define CHMOD_ERROR     "%s(1247): ERROR: Unable to run chmod on: '%s'."
 
 #define MAILQ_ERROR	    "%s(1221): ERROR: No Mail queue at %s"
 #define IMSG_ERROR	    "%s(1222): ERROR: Invalid msg: %s"


### PR DESCRIPTION
Macro was defined twice

btw.: should every systemcall failure be reported with the suffix: `which returned [(%d)-(%s)]."` `errno, strerror(errno)`?
