### PR TITLE
fix a const to much:

### DIFF
--- a/src/headers/report_op.h
+++ b/src/headers/report_op.h
@@ -41,7 +41,7 @@ typedef struct _report_filter
     const char *user;
     const char *srcip;
     const char *files;
-    const char *filename;
+    char *filename;
 
     OSStore *top_user;
     OSStore *top_srcip;


### PR DESCRIPTION
```
monitord/generate_reports.c:93:22: warning: passing 'const char *' to parameter of type 'void *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
                free(mond.reports[s]->r_filter.filename);
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/stdlib.h:483:25: note: passing argument to parameter '__ptr' here
extern void free (void *__ptr) __THROW;
```
