### PR TITLE
update ar command

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -107,9 +107,6 @@ CFLAGS+=-Wall -Wextra
 CFLAGS+=-I./ -I./headers/
 
 
-BUILDLIB=ar -crus
-
-
 CCCOLOR="\033[34m"
 LINKCOLOR="\033[34;1m"
 SRCCOLOR="\033[33m"
@@ -129,7 +126,7 @@ endif
 
 OSSEC_CC     =${QUIET_CC}${CC}
 OSSEC_CCBIN  =${QUIET_CCBIN}${CC}
-OSSEC_LINK   =${QUIET_LINK}${BUILDLIB}
+OSSEC_LINK   =${QUIET_LINK}ar -rc
 OSSEC_RANLIB =${QUIET_RANLIB}ranlib
 
 


### PR DESCRIPTION
-s is obolete due to ranlib and -u can be skipped, see http://linux.die.net/man/1/ar
