### PR TITLE
Set matching child decoder in lf->decoder_info, if a child decoder matches.

### DIFF
--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -234,6 +234,9 @@ void DecodeEvent(Eventinfo *lf)
                         continue;
                     }
                     return;
+                } else {
+                    //child decoder matches, set this has the matched decoder
+                    lf->decoder_info = nnode;
                 }
 
 


### PR DESCRIPTION
If a child decoder regex matches, set the decoder in lf->decoder_info, matching child decoder. As of now the decoder inlf->decoder_info remains set to parent decoder. 

This can potentially fix https://github.com/ossec/ossec-hids/issues/164
