### PR TITLE
Fix csyslogd-config XML syslog location definition

### DIFF
--- a/src/config/csyslogd-config.c
+++ b/src/config/csyslogd-config.c
@@ -29,7 +29,7 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
     const char *xml_syslog_level = "level";
     const char *xml_syslog_id = "rule_id";
     const char *xml_syslog_group = "group";
-    const char *xml_syslog_location = "event_location";
+    const char *xml_syslog_location = "location";
 
 
     struct SyslogConfig_holder *config_holder = (struct SyslogConfig_holder *)config;


### PR DESCRIPTION
The documentation regarding the syslog_output configuration options states that a _location_ parameter is supported (see http://ossec-docs.readthedocs.org/en/latest/manual/output/syslog-output.html#element-location).

The csyslogd config parser was actually expecting an _event_location_ parameter. I thought it best to match the documentation. This simple fix does the job for me.
