### PR TITLE
Fix include order warnings when compiling win32

### DIFF
--- a/src/shared/randombytes.c
+++ b/src/shared/randombytes.c
@@ -1,6 +1,4 @@
-#ifdef WIN32
-#include "windows.h"
-#else
+#ifndef WIN32
 #include <sys/stat.h>
 #include <fcntl.h>
 #endif


### PR DESCRIPTION
Let shared.h include handle the inclusion of all the necessary Windows
libraries. This is similar to 1e2406f4. Fixes the following warning:

from shared/randombytes.c:10:
    warning: #warning Please include winsock2.h before windows.h
