### PR TITLE
fix to sshd rules

### DIFF
--- a/contrib/ossec-testing/tests/sshd.ini
+++ b/contrib/ossec-testing/tests/sshd.ini
@@ -56,6 +56,7 @@ decoder = sshd
 
 [ssh bad client public DH value]
 log 1 pass = Feb  4 23:05:57 someserver sshd[1234]: Disconnecting: bad client public DH value [preauth]
+log 1 pass = Feb  4 23:05:57 someserver sshd[1234]: Disconnecting: bad client public DH value
 
 rule = 5747
 alert = 6
@@ -63,6 +64,7 @@ decoder = sshd
 
 [ssh corrupted MAC on input]
 log 1 pass = Feb 14 14:34:15 someserver sshd[1234]: Corrupted MAC on input. [preauth]
+log 2 pass = Nov 22 19:24:55 server sshd[4046]: Corrupted MAC on input.
 
 rule = 5748
 alert = 6
@@ -70,6 +72,7 @@ decoder = sshd
 
 [ssh bad packet length]
 log 1 pass = Mar  4 13:34:59 someserver sshd[5396]: Bad packet length 4081586742. [preauth]
+log 2 pass = Mar  4 13:34:59 someserver sshd[5396]: Bad packet length 4081586742.
 
 rule = 5749
 alert = 4

--- a/etc/rules/sshd_rules.xml
+++ b/etc/rules/sshd_rules.xml
@@ -321,7 +321,7 @@
   <!-- http://www.gossamer-threads.com/lists/openssh/users/47438 -->
   <rule id="5747" level="6">
     <if_sid>5700</if_sid>
-    <match>bad client public DH value$</match>
+    <match>bad client public DH value</match>
     <description>ssh bad client public DH value</description>
   </rule>
 
@@ -332,7 +332,7 @@
   -->
   <rule id="5748" level="6">
     <if_sid>5700</if_sid>
-    <match>Corrupted MAC on input.$</match>
+    <match>Corrupted MAC on input.</match>
     <description>ssh corrupted MAC on input</description>
   </rule>
 


### PR DESCRIPTION
I don't know where the [preauth] comes from but I don't see it in my log messages and at least for the corrupted MAC messages I had to remove it so rule 1002 does not kick in.
