### PR TITLE
Added src/dst IP and username to the email if it exists in the alert_data.

### DIFF
--- a/src/os_maild/maild.h
+++ b/src/os_maild/maild.h
@@ -43,6 +43,7 @@
                             "Received From: %s\r\n" \
                             "Rule: %d fired (level %d) -> \"%s\"\r\n" \
 			    "%s" \
+			    "%s" \
                             "%s" \
                             "Portion of the log(s):\r\n\r\n%s\r\n" \
                             "\r\n\r\n --END OF NOTIFICATION\r\n\r\n\r\n"
@@ -51,6 +52,7 @@
                             "%s\r\n\r\n" \
                             "Received From: %s\r\n" \
                             "Rule: %d fired (level %d) -> \"%s\"\r\n" \
+                            "%s" \
                             "Portion of the log(s):\r\n\r\n%s\r\n" \
                             "\r\n\r\n --END OF NOTIFICATION\r\n\r\n\r\n"
 #endif

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -30,6 +30,8 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p,
     int i = 0, sms_set = 0,donotgroup = 0;
     size_t body_size = OS_MAXSTR -3, log_size;
     char logs[OS_MAXSTR + 1];
+    char extra_data[OS_MAXSTR + 1];
+    char log_string[OS_MAXSTR / 4 + 1];
     char *subject_host;
 #ifdef GEOIP
     char geoip_msg_src[OS_SIZE_1024 +1];
@@ -56,6 +58,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p,
 
     /* Generating the logs */
     logs[0] = '\0';
+    extra_data[0] = '\0';
     logs[OS_MAXSTR] = '\0';
 
     while(al_data->log[i])
@@ -118,6 +121,36 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p,
             body_size -= log_size;
         }
     }
+
+    /* EXTRA DATA */
+    if(al_data->srcip)
+    {
+        log_size = snprintf(log_string, sizeof(log_string)-1, "Src IP: %s\r\n", al_data->srcip );
+        if(body_size > log_size) {
+           if( strncat(extra_data, log_string, log_size) != NULL ) {
+                body_size -= log_size;
+           }
+        }
+    }
+    if(al_data->dstip)
+    {
+        log_size = snprintf(log_string, sizeof(log_string)-1, "Dst IP: %s\r\n", al_data->dstip );
+        if(body_size > log_size) {
+           if( strncat(extra_data, log_string, log_size) != NULL ) {
+                body_size -= log_size;
+           }
+        }
+    }
+    if(al_data->user)
+    {
+        log_size = snprintf(log_string, sizeof(log_string)-1, "User: %s\r\n", al_data->user );
+        if(body_size > log_size) {
+           if( strncat(extra_data, log_string, log_size) != NULL ) {
+                body_size -= log_size;
+           }
+        }
+    }
+
 
 
     /* Subject */
@@ -188,6 +221,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p,
             al_data->comment,
             geoip_msg_src,
             geoip_msg_dst,
+            extra_data,
             logs);
 #else
     snprintf(mail->body, BODY_SIZE -1, MAIL_BODY,
@@ -196,6 +230,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p,
             al_data->rule,
             al_data->level,
             al_data->comment,
+            extra_data,
             logs);
 #endif
     debug2("OS_RecvMailQ: mail->body[%s]", mail->body);


### PR DESCRIPTION
This is especially useful if the alert is generated with data from the accumulator as the log entry in the email may lack these helpful details.
