### PR TITLE
os_auth/main-server.c won't compile without any headers

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -24,6 +24,8 @@
  *
  */
 
+#include "shared.h"
+
 #ifndef USE_OPENSSL
 int main()
 {
@@ -33,8 +35,6 @@ int main()
 #else
 
 #include <sys/wait.h>
-
-#include "shared.h"
 #include "auth.h"
 
 /* TODO: Pulled this value out of the sky, may or may not be sane */


### PR DESCRIPTION
Included the shared.h to pull in the basics so printf and exit are defined.
