### PR TITLE
Fix incorrect declaration

### DIFF
--- a/src/logcollector/read_win_event_channel.c
+++ b/src/logcollector/read_win_event_channel.c
@@ -39,7 +39,7 @@
 
 /* Audit types */
 #define WINEVENT_AUDIT_FAILURE 0x10000000000000LL
-#define WINEVENT_AUDIT_SUCCESS 0x20000000000000L
+#define WINEVENT_AUDIT_SUCCESS 0x20000000000000LL
 
 #include "shared.h"
 #include "logcollector.h"


### PR DESCRIPTION
Copy and paste error when declaring WINEVENT_AUDIT_SUCCESS. It should be
a long long.