### PR TITLE
Test web appsec rules

### DIFF
--- a/contrib/ossec-testing/tests/web_appsec.ini
+++ b/contrib/ossec-testing/tests/web_appsec.ini
@@ -89,7 +89,7 @@ decoder = web-accesslog
 log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /index.html? HTTP/1.1" 200 4617 "-" "Wget/1.15 (linux-gnu)"
 
 rule = 31511
-alert = 6
+alert = 0
 decoder = web-accesslog
 
 [Uploadify vulnerability exploit attempt.]

--- a/contrib/ossec-testing/tests/web_appsec.ini
+++ b/contrib/ossec-testing/tests/web_appsec.ini
@@ -1,0 +1,162 @@
+[WordPress Comment Spam (coming from a fake search engine UA).]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST /wp-comments-post.php HTTP/1.1" 403 181 "-" "Googlebot/1
+log 2 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST /wp-comments-post.php HTTP/1.1" 403 181 "-" "msnbot/1
+log 3 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST /wp-comments-post.php HTTP/1.1" 403 181 "-" "BingBot/1
+
+rule = 31501
+alert = 6
+decoder = web-accesslog
+
+
+[TimThumb vulnerability exploit attempt.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /examplethumb.php?src=example.php HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31502
+alert = 6
+decoder = web-accesslog
+
+
+[osCommerce login.php bypass attempt.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST /example.php/login.php?cPath= HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31503
+alert = 6
+decoder = web-accesslog
+
+
+[osCommerce file manager login.php bypass attempt.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST /admin/example.php/login.php HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31504
+alert = 6
+decoder = web-accesslog
+
+
+[TimThumb backdoor access attempt.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /example/cache/externalexample.php HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31505
+alert = 6
+decoder = web-accesslog
+
+
+[Cart.php directory transversal attempt.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /examplecart.php?exampletemplatefile=../ HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31506
+alert = 6
+decoder = web-accesslog
+
+
+[MSSQL Injection attempt (ur.php, urchin.js).]
+
+rule = 31507
+alert = 6
+decoder = web-accesslog
+
+[Blacklisted user agent (known malicious user agent).]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "ZmEu"
+log 2 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "libwww-perl/1.1 (X11)"
+log 3 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "the beast"
+log 4 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "Morfeus"
+log 5 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "ZmEu (X11)"
+log 6 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "Nikto (X11)"
+log 7 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "w3af.sourceforge.net (X11)"
+log 8 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET / HTTP/1.1" 403 181 "-" "MJ12bot/v (X11)"
+
+rule = 31508
+alert = 6
+decoder = web-accesslog
+
+
+[CMS (WordPress or Joomla) login attempt.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST /examplewp-login.php HTTP/1.1" 200 181 "-" "Mozilla/5.0 (X11)"
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST /administrator HTTP/1.1" 200 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31509
+alert = 3
+decoder = web-accesslog
+
+
+# Can't yet test repeat logs  <rule id="31510" level="8" frequency="6" timeframe="30">
+;[CMS (WordPress or Joomla) brute force attempt.]
+;
+;rule = 31510
+;alert = 8
+;decoder = web-accesslog
+
+[Blacklisted user agent (wget).]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /index.html? HTTP/1.1" 200 4617 "-" "Wget/1.15 (linux-gnu)"
+
+rule = 31511
+alert = 6
+decoder = web-accesslog
+
+[Uploadify vulnerability exploit attempt.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /example/uploadify.php?src=http://example.php HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31512
+alert = 6
+decoder = web-accesslog
+
+[BBS delete.php exploit attempt.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET example/delete.php?board_skin_path=http://example.php HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31513
+alert = 6
+decoder = web-accesslog
+
+[Simple shell.php command execution.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET example/shell.php?cmd= HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31514
+alert = 6
+decoder = web-accesslog
+
+[PHPMyAdmin scans (looking for setup.php).]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /phpMyAdmin/scripts/setup.php HTTP/1.1" 404 4617 "-" "Mozilla/15 (linux-gnu)"
+
+rule = 31515
+alert = 6
+decoder = web-accesslog
+
+[Suspicious URL access.]
+log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /db/config.php.swp HTTP/1.1" 404 4617 "-" "Mozilla/15 (linux-gnu)"
+log 2 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /db/config.php.bak HTTP/1.1" 404 4617 "-" "Mozilla/15 (linux-gnu)"
+log 3 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /db/.htaccess HTTP/1.1" 404 4617 "-" "Mozilla/15 (linux-gnu)"
+log 4 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /server-status HTTP/1.1" 404 4617 "-" "Mozilla/15 (linux-gnu)"
+log 5 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /.ssh HTTP/1.1" 404 4617 "-" "Mozilla/15 (linux-gnu)"
+log 6 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /.history HTTP/1.1" 404 4617 "-" "Mozilla/15 (linux-gnu)"
+
+rule = 31516
+alert = 6
+decoder = web-accesslog
+
+[POST request received.]
+log 1 fail = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] POST / HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+
+rule = 31530
+alert = 3
+decoder = web-accesslog
+
+[Ignoring often post requests inside /wp-admin and /admin.]
+log 1 fail = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] POST /wp-admin HTTP/1.1" 200 181 "-" "Mozilla/5.0 (X11)"
+log 2 fail = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] POST /admin HTTP/1.1" 200 181 "-" "Mozilla/5.0 (X11)"
+rule = 31531
+alert = 0
+decoder = web-accesslog
+
+# Can't currently test repeat requests <rule id="31533" level="10" timeframe="20" frequency="6">
+;[High amount of POST requests in a small period of time (likely bot).]
+;log 1 fail = 10.1.1.5 - - [29/Dec/2014:11:37:47 -0500] POST / HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+;rule = 31533
+;alert = 10
+;decoder = web-accesslog
+
+# This never matches due to Rule web_rules.xml id: '31104' Description: 'Common web attack.'
+;[Anomaly URL query (attempting to pass null termination).]
+;log 1 pass = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "GET /example.php?example%00 HTTP/1.1" 403 181 "-" "Mozilla/5.0 (X11)"
+;
+;rule = 31550
+;alert = 6
+;decoder = web-accesslog

--- a/etc/rules/web_appsec_rules.xml
+++ b/etc/rules/web_appsec_rules.xml
@@ -107,15 +107,6 @@
     <description>CMS (WordPress or Joomla) brute force attempt.</description>
   </rule>
 
-  <!-- Nothing wrong with wget per se, but it misses a lot of links
-     - that generates many 404s. Blocking it to avoid the noise.
-    -->
-  <rule id="31511" level="6">
-    <if_sid>31100</if_sid>
-    <match>" "Wget/</match>
-    <description>Blacklisted user agent (wget).</description>
-  </rule>
-
   <!-- Uploadify scans.
     -->
   <rule id="31512" level="6">

--- a/etc/rules/web_appsec_rules.xml
+++ b/etc/rules/web_appsec_rules.xml
@@ -107,6 +107,15 @@
     <description>CMS (WordPress or Joomla) brute force attempt.</description>
   </rule>
 
+  <!-- Nothing wrong with wget per se, but it misses a lot of links
+     - that generates many 404s. Blocking it to avoid the noise.
+    -->
+  <rule id="31511" level="0">
+    <if_sid>31100</if_sid>
+    <match>" "Wget/</match>
+    <description>Blacklisted user agent (wget).</description>
+  </rule>
+
   <!-- Uploadify scans.
     -->
   <rule id="31512" level="6">


### PR DESCRIPTION
An initial, passing set of rules for web_appsec_rules.xml.

There are a  few rules that are commented out because I know of now way of testing multiple similar log entries without rewriting runtests.py.

Some caveats and observations:
As tests these are pretty useless without corresponding False Positive testing log entries.  

Many of the requests were written as POSTs because of a precompiled URL check for 'basic requests' that prevent things like User Agent string matching later.

I also reduced the Alert level on both the test and the rule for a Wget user-agent from 6 to 0.