### PR TITLE
Fix cleanup code in mkstemp_ex() for Windows

### DIFF
--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -955,7 +955,7 @@ int mkstemp_ex(char *tmp_path)
 {
     DWORD dwResult;
     int result;
-    int error = -1;
+    int status = -1;
 
     HANDLE h;
     PACL pACL;
@@ -1014,7 +1014,7 @@ int mkstemp_ex(char *tmp_path)
             GetLastError()
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
     /* create SID for the SYSTEM group */
@@ -1034,7 +1034,7 @@ int mkstemp_ex(char *tmp_path)
             GetLastError()
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
     /* initialize an EXPLICIT_ACCESS structure for an ACE */
@@ -1067,7 +1067,7 @@ int mkstemp_ex(char *tmp_path)
             dwResult
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
     /* initialize security descriptor */
@@ -1084,7 +1084,7 @@ int mkstemp_ex(char *tmp_path)
             GetLastError()
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
     if (!InitializeSecurityDescriptor(pSD, SECURITY_DESCRIPTOR_REVISION))
@@ -1095,7 +1095,7 @@ int mkstemp_ex(char *tmp_path)
             GetLastError()
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
     /* set owner */
@@ -1107,7 +1107,7 @@ int mkstemp_ex(char *tmp_path)
             GetLastError()
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
     /* set group owner */
@@ -1119,7 +1119,7 @@ int mkstemp_ex(char *tmp_path)
             GetLastError()
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
     /* add ACL to security descriptor */
@@ -1131,7 +1131,7 @@ int mkstemp_ex(char *tmp_path)
             GetLastError()
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
     /* initialize security attributes structure */
@@ -1158,7 +1158,7 @@ int mkstemp_ex(char *tmp_path)
             GetLastError()
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
     if (!CloseHandle(h))
@@ -1170,13 +1170,13 @@ int mkstemp_ex(char *tmp_path)
             GetLastError()
         );
 
-        goto Cleanup;
+        goto cleanup;
     }
 
-    /* everything was successful */
-    error = 0;
+    /* success */
+    status = 0;
 
-    Cleanup:
+    cleanup:
         if (pAdminGroupSID)
             FreeSid(pAdminGroupSID);
         if (pSystemGroupSID)
@@ -1186,7 +1186,7 @@ int mkstemp_ex(char *tmp_path)
         if (pSD)
             LocalFree(pSD);
 
-    return(error);
+    return(status);
 }
 
 


### PR DESCRIPTION
This commit is meant to help standardize how Windows cleanup code should
be handled.