### PR TITLE
Fix for issue #463 (rule overwrites causing a segfault)

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1662,8 +1662,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
     if(currently_rule->context == 1)
     {
 
-	if(currently_rule->context_opts & SAME_DODIFF) {
-	} else {
+	if(!(currently_rule->context_opts & SAME_DODIFF)) {
         	if(!currently_rule->event_search(lf, currently_rule))
             	return(NULL);
 	}

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1661,8 +1661,12 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
     /* If it is a context rule, search for it */
     if(currently_rule->context == 1)
     {
-        if(!currently_rule->event_search(lf, currently_rule))
-            return(NULL);
+
+	if(currently_rule->context_opts & SAME_DODIFF) {
+	} else {
+        	if(!currently_rule->event_search(lf, currently_rule))
+            	return(NULL);
+	}
     }
 
     #ifdef TESTRULE


### PR DESCRIPTION
This causes the <check_diff /> option to not crash overwrites of sid 533 (issue #463). It would require EXTENSIVE testing, or someone who knows
what they are doing to look it over.