### PR TITLE
Fix the wrong ARGV0 defined for authd causing the init script to fail

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -932,7 +932,7 @@ os_auth_c := ${wildcard os_auth/*.c}
 os_auth_o := $(os_auth_c:.c=.o)
 
 os_auth/%.o: os_auth/%.c
-	${OSSEC_CC} ${CFLAGS}  -I./os_auth -DARGV0=\"auth\" -c $^ -o $@
+	${OSSEC_CC} ${CFLAGS}  -I./os_auth -DARGV0=\"ossec-authd\" -c $^ -o $@
 
 agent-auth: addagent/validate.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${CFLAGS} -I./os_auth $^ ${LDFLAGS} -o $@


### PR DESCRIPTION
Fix the wrong ARGV0 defined for authd (which caused, among other things, the pidfile to be written to '.../auth-${pid}.pid' instead of '.../ossec-authd-${pid}.pid'
