### PR TITLE
Add support for FQDN in csyslogd

### DIFF
--- a/src/config/csyslogd-config.c
+++ b/src/config/csyslogd-config.c
@@ -30,6 +30,7 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
     const char *xml_syslog_id = "rule_id";
     const char *xml_syslog_group = "group";
     const char *xml_syslog_location = "location";
+    const char *xml_syslog_use_fqdn = "use_fqdn";
 
 
     struct SyslogConfig_holder *config_holder = (struct SyslogConfig_holder *)config;
@@ -57,6 +58,7 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
     syslog_config[s]->level = 0;
     syslog_config[s]->port = 514;
     syslog_config[s]->format = DEFAULT_CSYSLOG;
+    syslog_config[s]->use_fqdn = 0;
     /* local 0 facility (16) + severity 4 - warning. --default */
     syslog_config[s]->priority = (16 * 8) + 4;
 
@@ -196,6 +198,18 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
                 merror(REGEX_COMPILE, __local_name, node[i]->content,
                        syslog_config[s]->location->error);
                 goto fail;
+            }
+        }
+        else if(strcmp(node[i]->element, xml_syslog_use_fqdn) == 0)
+        {  
+            if(strcmp(node[i]->content, "yes") == 0)
+                {syslog_config[s]->use_fqdn = 1;}
+            else if(strcmp(node[i]->content, "no") == 0)
+                {syslog_config[s]->use_fqdn = 0;}
+            else
+            {
+                merror(XML_VALUEERR,__local_name,node[i]->element,node[i]->content);
+                return(OS_INVALID);
             }
         }
         else if(strcmp(node[i]->element, xml_syslog_group) == 0)

--- a/src/config/csyslogd-config.h
+++ b/src/config/csyslogd-config.h
@@ -26,6 +26,7 @@ typedef struct _SyslogConfig
     unsigned int level;
     unsigned int *rule_id;
     unsigned int priority;
+    unsigned int use_fqdn;
     int socket;
 
     char *server;

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -26,6 +26,7 @@
 int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
 {
     char *tstamp;
+    char *hostname;
     char syslog_msg[OS_SIZE_2048];
 
     /* Invalid socket. */
@@ -109,13 +110,22 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
             tstamp[4] = ' ';
     }
 
+    if(syslog_config->use_fqdn)
+    {
+        hostname = __shost_long;
+    }
+    else
+    {
+        hostname = __shost;
+    }
+
     /* Inserting data */
     if(syslog_config->format == DEFAULT_CSYSLOG)
     {
        	/* Building syslog message. */
        	snprintf(syslog_msg, OS_SIZE_2048,
                 "<%u>%s %s ossec: Alert Level: %u; Rule: %u - %s; Location: %s;",
-               	syslog_config->priority, tstamp, __shost,
+               	syslog_config->priority, tstamp, hostname,
                 al_data->level,
                 al_data->rule, al_data->comment,
                 al_data->location
@@ -146,7 +156,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
 		al_data->rule,
 		al_data->comment,
 		(al_data->level > 10) ? 10 : al_data->level,
-                __shost, al_data->location);
+                hostname, al_data->location);
         field_add_string(syslog_msg, OS_SIZE_2048, " src=%s", al_data->srcip );
         field_add_int(syslog_msg, OS_SIZE_2048, " dpt=%d", al_data->dstport );
         field_add_int(syslog_msg, OS_SIZE_2048, " spt=%d", al_data->srcport );
@@ -214,7 +224,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                 "<%u>%s %s ossec: %s",
 
                 /* syslog header */
-                syslog_config->priority, tstamp, __shost,
+                syslog_config->priority, tstamp, hostname,
 
                 /* JSON Encoded Data */
                 json_string
@@ -230,7 +240,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                 "<%u>%s %s ossec: crit=%u id=%u description=\"%s\" component=\"%s\",",
 
                 /* syslog header */
-                syslog_config->priority, tstamp, __shost,
+                syslog_config->priority, tstamp, hostname,
 
                 /* OSSEC metadata */
                 al_data->level, al_data->rule, al_data->comment,

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -19,6 +19,7 @@
 
 #include "csyslogd.h"
 char __shost[512];
+char __shost_long[512];
 
 #include "os_net/os_net.h"
 

--- a/src/os_csyslogd/csyslogd.h
+++ b/src/os_csyslogd/csyslogd.h
@@ -45,6 +45,8 @@ int field_add_truncated(char *dest, size_t size, const char *format, const char 
 
 /* System hostname */
 extern char __shost[512];
+/* System hostname (full length) */
+extern char __shost_long[512];
 
 
 #endif

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -129,6 +129,8 @@ int main(int argc, char **argv)
     }
     else
     {
+        /* Save the full hostname */
+        memcpy(__shost_long, __shost, 512);
         char *ltmp;
 
         /* Remove domain part if available */


### PR DESCRIPTION
Hi,

The existing csyslogd always truncates hostnames in the syslog output at the first '.', which creates a lot of ambiguity if you differentiate hosts by a hierarchical DNS scheme. These patches add a "use_fqdn" option into the syslog config that toggles between using the short or full hostname. 

Some notes:
* The default behaviour is to use the short hostname, so current behaviour is preserved
* I would have preferred to make this a global option (since hostnames are truncated in a few places) but it looks like csyslogd only has infrastructure to read its own configuration at the moment. Adding the global option would be a much more invasive change
* The code works on a per syslog config block basis, which looks to be the expected method.

Thanks,