### PR TITLE
fix warnings

### DIFF
--- a/src/addagent/b64.c
+++ b/src/addagent/b64.c
@@ -119,7 +119,7 @@ char *decode_base64(const char *src)
 
         p = (unsigned char *)dest;
 
-        buf = malloc(l);
+        buf = (unsigned char *) malloc(l);
         if (!buf) {
             free(dest);
             return (NULL);

--- a/src/analysisd/accumulator.h
+++ b/src/analysisd/accumulator.h
@@ -41,13 +41,13 @@ typedef struct _OS_ACM_Store {
 #define OS_ACM_PURGE_COUNT     200
 
 /* Accumulator Functions */
-int Accumulate_Init();
+int Accumulate_Init(void);
 Eventinfo *Accumulate(Eventinfo *lf);
-void Accumulate_CleanUp();
+void Accumulate_CleanUp(void);
 
 /* Internal Functions */
 int acm_str_replace(char **dst, const char *src);
-OS_ACM_Store *InitACMStore();
+OS_ACM_Store *InitACMStore(void);
 void FreeACMStore(OS_ACM_Store *obj);
 
 #endif /* __ACCUMULATOR_H */

--- a/src/analysisd/active-response.h
+++ b/src/analysisd/active-response.h
@@ -15,7 +15,7 @@
 #include "list_op.h"
 
 /* Initialize active response */
-void AR_Init();
+void AR_Init(void);
 
 /* Read active response configuration and write it
  * to the appropriate lists.

--- a/src/analysisd/alerts/getloglocation.h
+++ b/src/analysisd/alerts/getloglocation.h
@@ -13,8 +13,8 @@
 #include "eventinfo.h"
 
 /* Start the log location (need to be called before getlog) */
-void OS_InitLog();
-void OS_InitFwLog();
+void OS_InitLog(void);
+void OS_InitFwLog(void);
 
 /* Get the log file based on the date/logtype
  * Returns 0 on success or -1 on error

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -12,6 +12,8 @@
 
 #include <sys/types.h>
 
+#include "decoders/decoder.h"
+
 /* Time structures */
 int today;
 int thishour;
@@ -27,7 +29,7 @@ time_t c_time; /* Current time of event. Used everywhere */
 /* Local host name */
 char __shost[512];
 
-void *NULL_Decoder;
+OSDecoderInfo *NULL_Decoder;
 
 #define OSSEC_SERVER    "ossec-server"
 

--- a/src/analysisd/cdb/cdb.c
+++ b/src/analysisd/cdb/cdb.c
@@ -38,7 +38,7 @@ void cdb_init(struct cdb *c, int fd)
 
     if (fstat(fd, &st) == 0)
         if ((size_t) st.st_size <= 0xffffffff) {
-            x = mmap(0, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
+            x = (char *) mmap(0, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
             if (x + 1) {
                 c->size = st.st_size;
                 c->map = x;

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -67,7 +67,7 @@ int os_setdecoderids(char *p_name)
 
     do {
         int p_id = 0;
-        char *p_name;
+        char *tmp_name;
 
         nnode = node->osdecoder;
         nnode->id = getDecoderfromlist(nnode->name);
@@ -85,7 +85,7 @@ int os_setdecoderids(char *p_name)
 
         /* Set parent id */
         p_id = nnode->id;
-        p_name = nnode->name;
+        tmp_name = nnode->name;
 
         /* Also set on the child nodes */
         while (child_node) {
@@ -97,7 +97,7 @@ int os_setdecoderids(char *p_name)
                 nnode->id = p_id;
 
                 /* Set parent name */
-                nnode->name = p_name;
+                nnode->name = tmp_name;
             }
 
             /* Id cannot be 0 */
@@ -205,7 +205,7 @@ int ReadDecodeXML(char *file)
     NULL_Decoder_tmp->type = SYSLOG;
     NULL_Decoder_tmp->name = NULL;
     NULL_Decoder_tmp->fts = 0;
-    NULL_Decoder = (void *)NULL_Decoder_tmp;
+    NULL_Decoder = NULL_Decoder_tmp;
 
     i = 0;
     while (node[i]) {
@@ -383,10 +383,9 @@ int ReadDecodeXML(char *file)
                     if (strcmp(plugin_decoders[ed_c],
                                elements[j]->content) == 0) {
                         /* Initialize plugin */
-                        void (*dec_init)() = plugin_decoders_init[ed_c];
-
+                        void (*dec_init)(void) = (void (*)(void)) plugin_decoders_init[ed_c];
                         dec_init();
-                        pi->plugindecoder = plugin_decoders_exec[ed_c];
+                        pi->plugindecoder = (void (*)(void *)) plugin_decoders_exec[ed_c];
                         break;
                     }
                 }
@@ -444,37 +443,37 @@ int ReadDecodeXML(char *file)
                 /* Check the values from the order */
                 while (*norder) {
                     if (strstr(*norder, "dstuser") != NULL) {
-                        pi->order[order_int] = (void *)DstUser_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) DstUser_FP;
                     } else if (strstr(*norder, "srcuser") != NULL) {
-                        pi->order[order_int] = (void *)SrcUser_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) SrcUser_FP;
                     }
                     /* User is an alias to dstuser */
                     else if (strstr(*norder, "user") != NULL) {
-                        pi->order[order_int] = (void *)DstUser_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) DstUser_FP;
                     } else if (strstr(*norder, "srcip") != NULL) {
-                        pi->order[order_int] = (void *)SrcIP_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) SrcIP_FP;
                     } else if (strstr(*norder, "dstip") != NULL) {
-                        pi->order[order_int] = (void *)DstIP_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) DstIP_FP;
                     } else if (strstr(*norder, "srcport") != NULL) {
-                        pi->order[order_int] = (void *)SrcPort_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) SrcPort_FP;
                     } else if (strstr(*norder, "dstport") != NULL) {
-                        pi->order[order_int] = (void *)DstPort_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) DstPort_FP;
                     } else if (strstr(*norder, "protocol") != NULL) {
-                        pi->order[order_int] = (void *)Protocol_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) Protocol_FP;
                     } else if (strstr(*norder, "action") != NULL) {
-                        pi->order[order_int] = (void *)Action_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) Action_FP;
                     } else if (strstr(*norder, "id") != NULL) {
-                        pi->order[order_int] = (void *)ID_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) ID_FP;
                     } else if (strstr(*norder, "url") != NULL) {
-                        pi->order[order_int] = (void *)Url_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) Url_FP;
                     } else if (strstr(*norder, "data") != NULL) {
-                        pi->order[order_int] = (void *)Data_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) Data_FP;
                     } else if (strstr(*norder, "extra_data") != NULL) {
-                        pi->order[order_int] = (void *)Data_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) Data_FP;
                     } else if (strstr(*norder, "status") != NULL) {
-                        pi->order[order_int] = (void *)Status_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) Status_FP;
                     } else if (strstr(*norder, "system_name") != NULL) {
-                        pi->order[order_int] = (void *)SystemName_FP;
+                        pi->order[order_int] = (void (*)(void *, char *)) SystemName_FP;
                     } else {
                         ErrorExit("decode-xml: Wrong field '%s' in the order"
                                   " of decoder '%s'", *norder, pi->name);
@@ -716,7 +715,7 @@ char *_loadmemory(char *at, char *str)
     if (at == NULL) {
         int strsize = 0;
         if ((strsize = strlen(str)) < OS_SIZE_1024) {
-            at = calloc(strsize + 1, sizeof(char));
+            at = (char *) calloc(strsize + 1, sizeof(char));
             if (at == NULL) {
                 merror(MEM_ERROR, ARGV0, errno, strerror(errno));
                 return (NULL);
@@ -737,7 +736,7 @@ char *_loadmemory(char *at, char *str)
             merror(SIZE_ERROR, ARGV0, str);
             return (NULL);
         }
-        at = realloc(at, (finalsize + 1) * sizeof(char));
+        at = (char *) realloc(at, (finalsize + 1) * sizeof(char));
         if (at == NULL) {
             merror(MEM_ERROR, ARGV0, errno, strerror(errno));
             return (NULL);

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -88,16 +88,16 @@ void DecodeEvent(Eventinfo *lf)
                  * and go for the regexes.
                  */
                 if (nnode->prematch) {
-                    const char *llog;
+                    const char *llog2;
 
                     /* If we have an offset set, use it */
                     if (nnode->prematch_offset & AFTER_PARENT) {
-                        llog = pmatch;
+                        llog2 = pmatch;
                     } else {
-                        llog = lf->log;
+                        llog2 = lf->log;
                     }
 
-                    if ((cmatch = OSRegex_Execute(llog, nnode->prematch))) {
+                    if ((cmatch = OSRegex_Execute(llog2, nnode->prematch))) {
                         if (*cmatch != '\0') {
                             cmatch++;
                         }

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -52,10 +52,14 @@ typedef struct _OSDecoderNode {
 /* Functions to Create the list, add a osdecoder to the
  * list and to get the first osdecoder
  */
-void OS_CreateOSDecoderList();
+void OS_CreateOSDecoderList(void);
 int OS_AddOSDecoder(OSDecoderInfo *pi);
 OSDecoderNode *OS_GetFirstOSDecoder(char *pname);
 int getDecoderfromlist(char *name);
+int SetDecodeXML(void);
+void HostinfoInit(void);
+void SyscheckInit(void);
+void RootcheckInit(void);
 
 #endif
 

--- a/src/analysisd/decoders/hostinfo.c
+++ b/src/analysisd/decoders/hostinfo.c
@@ -99,7 +99,7 @@ void HostinfoInit()
 }
 
 /* Return the file pointer to be used */
-FILE *HI_File()
+static FILE *HI_File(void)
 {
     if (_hi_fp) {
         fseek(_hi_fp, 0, SEEK_SET);

--- a/src/analysisd/decoders/plugin_decoders.c
+++ b/src/analysisd/decoders/plugin_decoders.c
@@ -1,0 +1,30 @@
+/* Copyright (C) 2015 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include "plugin_decoders.h"
+
+/* List of plugins. All three lists must be in the same order */
+char *(plugin_decoders[]) = {"PF_Decoder",
+                             "SymantecWS_Decoder",
+                             "SonicWall_Decoder",
+                             "OSSECAlert_Decoder",
+                             NULL
+                            };
+void *(plugin_decoders_init[]) = {PF_Decoder_Init,
+                                  SymantecWS_Decoder_Init,
+                                  SonicWall_Decoder_Init,
+                                  OSSECAlert_Decoder_Init,
+                                  NULL
+                                 };
+void *(plugin_decoders_exec[]) = {PF_Decoder_Exec,
+                                  SymantecWS_Decoder_Exec,
+                                  SonicWall_Decoder_Exec,
+                                  OSSECAlert_Decoder_Exec,
+                                  NULL
+                                 };

--- a/src/analysisd/decoders/plugin_decoders.h
+++ b/src/analysisd/decoders/plugin_decoders.h
@@ -10,41 +10,28 @@
 #ifndef __PLUGINDECODER_H
 #define __PLUGINDECODER_H
 
+#include "eventinfo.h"
+
 /* Plugin decoder for OpenBSD PF */
-void *PF_Decoder_Init(char *p_name);
-void *PF_Decoder_Exec(void *lf);
+void *PF_Decoder_Init(void);
+void *PF_Decoder_Exec(Eventinfo *lf);
 
 /* Plugin for Symantec Web Security */
-void *SymantecWS_Decoder_Init(char *p_name);
-void *SymantecWS_Decoder_Exec(void *lf);
+void *SymantecWS_Decoder_Init(void);
+void *SymantecWS_Decoder_Exec(Eventinfo *lf);
 
 /* Plugin for Sonicwall */
-void *SonicWall_Decoder_Init(char *p_name);
-void *SonicWall_Decoder_Exec(void *lf);
+void *SonicWall_Decoder_Init(void);
+void *SonicWall_Decoder_Exec(Eventinfo *lf);
 
 /* Plugin for OSSEC alert */
-void *OSSECAlert_Decoder_Init(char *p_name);
-void *OSSECAlert_Decoder_Exec(void *lf);
+void *OSSECAlert_Decoder_Init(void);
+void *OSSECAlert_Decoder_Exec(Eventinfo *lf);
 
 /* List of plugins. All three lists must be in the same order */
-char *(plugin_decoders[]) = {"PF_Decoder",
-                             "SymantecWS_Decoder",
-                             "SonicWall_Decoder",
-                             "OSSECAlert_Decoder",
-                             NULL
-                            };
-void *(plugin_decoders_init[]) = {PF_Decoder_Init,
-                                  SymantecWS_Decoder_Init,
-                                  SonicWall_Decoder_Init,
-                                  OSSECAlert_Decoder_Init,
-                                  NULL
-                                 };
-void *(plugin_decoders_exec[]) = {PF_Decoder_Exec,
-                                  SymantecWS_Decoder_Exec,
-                                  SonicWall_Decoder_Exec,
-                                  OSSECAlert_Decoder_Exec,
-                                  NULL
-                                 };
+extern char *(plugin_decoders[]);
+extern void *(plugin_decoders_init[]);
+extern void *(plugin_decoders_exec[]);
 
-#endif
+#endif /* __PLUGINDECODER_H */
 

--- a/src/analysisd/decoders/plugins/ossecalert_decoder.c
+++ b/src/analysisd/decoders/plugins/ossecalert_decoder.c
@@ -7,6 +7,8 @@
  * Foundation.
  */
 
+#include "../plugin_decoders.h"
+
 #include "shared.h"
 #include "eventinfo.h"
 #include "config.h"
@@ -32,7 +34,7 @@ void *OSSECAlert_Decoder_Exec(Eventinfo *lf)
     char *oa_val;
     char oa_newlocation[256];
     char *tmp_str = NULL;
-    void *rule_pointer;
+    RuleInfo *rule_pointer;
 
     lf->decoder_info->type = OSSEC_ALERT;
 
@@ -60,7 +62,7 @@ void *OSSECAlert_Decoder_Exec(Eventinfo *lf)
     *tmp_str = '\0';
 
     /* Get rule structure */
-    rule_pointer = OSHash_Get(Config.g_rules_hash, oa_id);
+    rule_pointer = (RuleInfo *) OSHash_Get(Config.g_rules_hash, oa_id);
     if (!rule_pointer) {
         merror("%s: WARN: Rule id '%s' not found internally.", ARGV0, oa_id);
         *tmp_str = ' ';

--- a/src/analysisd/decoders/plugins/pf_decoder.c
+++ b/src/analysisd/decoders/plugins/pf_decoder.c
@@ -7,6 +7,8 @@
  * Foundation.
  */
 
+#include "../plugin_decoders.h"
+
 #include "shared.h"
 #include "eventinfo.h"
 

--- a/src/analysisd/decoders/plugins/sonicwall_decoder.c
+++ b/src/analysisd/decoders/plugins/sonicwall_decoder.c
@@ -7,6 +7,8 @@
  * Foundation.
  */
 
+#include "../plugin_decoders.h"
+
 #include "shared.h"
 #include "eventinfo.h"
 

--- a/src/analysisd/decoders/plugins/symantecws_decoder.c
+++ b/src/analysisd/decoders/plugins/symantecws_decoder.c
@@ -7,6 +7,8 @@
  * Foundation.
  */
 
+#include "../plugin_decoders.h"
+
 #include "shared.h"
 #include "eventinfo.h"
 

--- a/src/analysisd/dodiff.c
+++ b/src/analysisd/dodiff.c
@@ -10,11 +10,6 @@
 #include "eventinfo.h"
 #include "shared.h"
 
-/* Global variables */
-char flastcontent[OS_SIZE_8192 + 1];
-char *fmsglast = "Previous output:";
-
-
 static int _add2last(char *str, int strsize, char *file)
 {
     FILE *fp;
@@ -70,7 +65,7 @@ static int _add2last(char *str, int strsize, char *file)
     return (1);
 }
 
-int doDiff(RuleInfo *currently_rule, Eventinfo *lf)
+int doDiff(RuleInfo *rule, Eventinfo *lf)
 {
     int date_of_change;
     char *htpt = NULL;
@@ -80,7 +75,7 @@ int doDiff(RuleInfo *currently_rule, Eventinfo *lf)
     /* Clean up global */
     flastcontent[0] = '\0';
     flastcontent[OS_SIZE_8192] = '\0';
-    currently_rule->last_events[0] = NULL;
+    rule->last_events[0] = NULL;
 
     if (lf->hostname[0] == '(') {
         htpt = strchr(lf->hostname, ')');
@@ -88,7 +83,7 @@ int doDiff(RuleInfo *currently_rule, Eventinfo *lf)
             *htpt = '\0';
         }
         snprintf(flastfile, OS_SIZE_2048, "%s/%s/%d/%s", DIFF_DIR, lf->hostname + 1,
-                 currently_rule->sigid, DIFF_LAST_FILE);
+                 rule->sigid, DIFF_LAST_FILE);
 
         if (htpt) {
             *htpt = ')';
@@ -96,7 +91,7 @@ int doDiff(RuleInfo *currently_rule, Eventinfo *lf)
         htpt = NULL;
     } else {
         snprintf(flastfile, OS_SIZE_2048, "%s/%s/%d/%s", DIFF_DIR, lf->hostname,
-                 currently_rule->sigid, DIFF_LAST_FILE);
+                 rule->sigid, DIFF_LAST_FILE);
     }
 
     /* lf->size can't be too long */
@@ -142,8 +137,8 @@ int doDiff(RuleInfo *currently_rule, Eventinfo *lf)
         merror("%s: ERROR: unable to create last file: %s", ARGV0, flastfile);
     }
 
-    currently_rule->last_events[0] = fmsglast;
-    currently_rule->last_events[1] = flastcontent;
+    rule->last_events[0] = "Previous output:";
+    rule->last_events[1] = flastcontent;
     return (1);
 }
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -16,22 +16,22 @@
 /* Search last times a signature fired
  * Will look for only that specific signature.
  */
-Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule)
+Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
 {
     Eventinfo *lf;
     Eventinfo *first_lf;
     OSListNode *lf_node;
 
     /* Set frequency to 0 */
-    currently_rule->__frequency = 0;
+    rule->__frequency = 0;
 
     /* Checking if sid search is valid */
-    if (!currently_rule->sid_search) {
+    if (!rule->sid_search) {
         merror("%s: No sid search!! XXX", ARGV0);
     }
 
     /* Get last node */
-    lf_node = OSList_GetLastNode(currently_rule->sid_search);
+    lf_node = OSList_GetLastNode(rule->sid_search);
     if (!lf_node) {
         return (NULL);
     }
@@ -41,19 +41,19 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule)
         lf = (Eventinfo *)lf_node->data;
 
         /* If time is outside the timeframe, return */
-        if ((c_time - lf->time) > currently_rule->timeframe) {
+        if ((c_time - lf->time) > rule->timeframe) {
             return (NULL);
         }
 
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
-        else if (lf->matched >= currently_rule->level) {
+        else if (lf->matched >= rule->level) {
             return (NULL);
         }
 
         /* Check for same ID */
-        if (currently_rule->context_opts & SAME_ID) {
+        if (rule->context_opts & SAME_ID) {
             if ((!lf->id) || (!my_lf->id)) {
                 continue;
             }
@@ -64,7 +64,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* Check for repetitions from same src_ip */
-        if (currently_rule->context_opts & SAME_SRCIP) {
+        if (rule->context_opts & SAME_SRCIP) {
             if ((!lf->srcip) || (!my_lf->srcip)) {
                 continue;
             }
@@ -75,9 +75,9 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* Grouping of additional data */
-        if (currently_rule->alert_opts & SAME_EXTRAINFO) {
+        if (rule->alert_opts & SAME_EXTRAINFO) {
             /* Check for same source port */
-            if (currently_rule->context_opts & SAME_SRCPORT) {
+            if (rule->context_opts & SAME_SRCPORT) {
                 if ((!lf->srcport) || (!my_lf->srcport)) {
                     continue;
                 }
@@ -88,7 +88,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule)
             }
 
             /* Check for same dst port */
-            if (currently_rule->context_opts & SAME_DSTPORT) {
+            if (rule->context_opts & SAME_DSTPORT) {
                 if ((!lf->dstport) || (!my_lf->dstport)) {
                     continue;
                 }
@@ -99,7 +99,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule)
             }
 
             /* Check for repetitions on user error */
-            if (currently_rule->context_opts & SAME_USER) {
+            if (rule->context_opts & SAME_USER) {
                 if ((!lf->dstuser) || (!my_lf->dstuser)) {
                     continue;
                 }
@@ -110,14 +110,14 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule)
             }
 
             /* Check for same location */
-            if (currently_rule->context_opts & SAME_LOCATION) {
+            if (rule->context_opts & SAME_LOCATION) {
                 if (strcmp(lf->hostname, my_lf->hostname) != 0) {
                     continue;
                 }
             }
 
             /* Check for different URLs */
-            if (currently_rule->context_opts & DIFFERENT_URL) {
+            if (rule->context_opts & DIFFERENT_URL) {
                 if ((!lf->url) || (!my_lf->url)) {
                     continue;
                 }
@@ -129,24 +129,24 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* Check if the number of matches worked */
-        if (currently_rule->__frequency <= 10) {
-            currently_rule->last_events[currently_rule->__frequency]
+        if (rule->__frequency <= 10) {
+            rule->last_events[rule->__frequency]
                 = lf->full_log;
-            currently_rule->last_events[currently_rule->__frequency + 1]
+            rule->last_events[rule->__frequency + 1]
                 = NULL;
         }
 
-        if (currently_rule->__frequency < currently_rule->frequency) {
-            currently_rule->__frequency++;
+        if (rule->__frequency < rule->frequency) {
+            rule->__frequency++;
             continue;
         }
-        currently_rule->__frequency++;
+        rule->__frequency++;
 
 
         /* If reached here, we matched */
-        my_lf->matched = currently_rule->level;
-        lf->matched = currently_rule->level;
-        first_lf->matched = currently_rule->level;
+        my_lf->matched = rule->level;
+        lf->matched = rule->level;
+        first_lf->matched = rule->level;
 
         return (lf);
 
@@ -158,22 +158,22 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule)
 /* Search last times a group fired
  * Will look for only that specific group on that rule.
  */
-Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
+Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
 {
     Eventinfo *lf;
     Eventinfo *first_lf;
     OSListNode *lf_node;
 
     /* Set frequency to 0 */
-    currently_rule->__frequency = 0;
+    rule->__frequency = 0;
 
     /* Check if sid search is valid */
-    if (!currently_rule->group_search) {
+    if (!rule->group_search) {
         merror("%s: No group search!! XXX", ARGV0);
     }
 
     /* Get last node */
-    lf_node = OSList_GetLastNode(currently_rule->group_search);
+    lf_node = OSList_GetLastNode(rule->group_search);
     if (!lf_node) {
         return (NULL);
     }
@@ -183,19 +183,19 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
         lf = (Eventinfo *)lf_node->data;
 
         /* If time is outside the timeframe, return */
-        if ((c_time - lf->time) > currently_rule->timeframe) {
+        if ((c_time - lf->time) > rule->timeframe) {
             return (NULL);
         }
 
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
-        else if (lf->matched >= currently_rule->level) {
+        else if (lf->matched >= rule->level) {
             return (NULL);
         }
 
         /* Check for same ID */
-        if (currently_rule->context_opts & SAME_ID) {
+        if (rule->context_opts & SAME_ID) {
             if ((!lf->id) || (!my_lf->id)) {
                 continue;
             }
@@ -206,7 +206,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* Check for repetitions from same src_ip */
-        if (currently_rule->context_opts & SAME_SRCIP) {
+        if (rule->context_opts & SAME_SRCIP) {
             if ((!lf->srcip) || (!my_lf->srcip)) {
                 continue;
             }
@@ -217,9 +217,9 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* Grouping of additional data */
-        if (currently_rule->alert_opts & SAME_EXTRAINFO) {
+        if (rule->alert_opts & SAME_EXTRAINFO) {
             /* Check for same source port */
-            if (currently_rule->context_opts & SAME_SRCPORT) {
+            if (rule->context_opts & SAME_SRCPORT) {
                 if ((!lf->srcport) || (!my_lf->srcport)) {
                     continue;
                 }
@@ -230,7 +230,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
             }
 
             /* Check for same dst port */
-            if (currently_rule->context_opts & SAME_DSTPORT) {
+            if (rule->context_opts & SAME_DSTPORT) {
                 if ((!lf->dstport) || (!my_lf->dstport)) {
                     continue;
                 }
@@ -241,7 +241,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
             }
 
             /* Check for repetitions on user error */
-            if (currently_rule->context_opts & SAME_USER) {
+            if (rule->context_opts & SAME_USER) {
                 if ((!lf->dstuser) || (!my_lf->dstuser)) {
                     continue;
                 }
@@ -252,7 +252,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
             }
 
             /* Check for same location */
-            if (currently_rule->context_opts & SAME_LOCATION) {
+            if (rule->context_opts & SAME_LOCATION) {
                 if (strcmp(lf->hostname, my_lf->hostname) != 0) {
                     continue;
                 }
@@ -260,7 +260,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
 
 
             /* Check for different URLs */
-            if (currently_rule->context_opts & DIFFERENT_URL) {
+            if (rule->context_opts & DIFFERENT_URL) {
                 if ((!lf->url) || (!my_lf->url)) {
                     continue;
                 }
@@ -273,23 +273,23 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* Check if the number of matches worked */
-        if (currently_rule->__frequency < currently_rule->frequency) {
-            if (currently_rule->__frequency <= 10) {
-                currently_rule->last_events[currently_rule->__frequency]
+        if (rule->__frequency < rule->frequency) {
+            if (rule->__frequency <= 10) {
+                rule->last_events[rule->__frequency]
                     = lf->full_log;
-                currently_rule->last_events[currently_rule->__frequency + 1]
+                rule->last_events[rule->__frequency + 1]
                     = NULL;
             }
 
-            currently_rule->__frequency++;
+            rule->__frequency++;
             continue;
         }
 
 
         /* If reached here, we matched */
-        my_lf->matched = currently_rule->level;
-        lf->matched = currently_rule->level;
-        first_lf->matched = currently_rule->level;
+        my_lf->matched = rule->level;
+        lf->matched = rule->level;
+        first_lf->matched = rule->level;
 
         return (lf);
 
@@ -303,7 +303,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule)
 /* Look if any of the last events (inside the timeframe)
  * match the specified rule
  */
-Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *currently_rule)
+Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
 {
     EventNode *eventnode_pt;
     Eventinfo *lf;
@@ -319,7 +319,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *currently_rule)
     }
 
     /* Set frequency to 0 */
-    currently_rule->__frequency = 0;
+    rule->__frequency = 0;
     first_lf = (Eventinfo *)eventnode_pt->event;
 
     /* Search all previous events */
@@ -327,14 +327,14 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *currently_rule)
         lf = eventnode_pt->event;
 
         /* If time is outside the timeframe, return */
-        if ((c_time - lf->time) > currently_rule->timeframe) {
+        if ((c_time - lf->time) > rule->timeframe) {
             return (NULL);
         }
 
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
-        else if (lf->matched >= currently_rule->level) {
+        else if (lf->matched >= rule->level) {
             return (NULL);
         }
 
@@ -344,15 +344,15 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* If regex does not match, go to next */
-        if (currently_rule->if_matched_regex) {
-            if (!OSRegex_Execute(lf->log, currently_rule->if_matched_regex)) {
+        if (rule->if_matched_regex) {
+            if (!OSRegex_Execute(lf->log, rule->if_matched_regex)) {
                 /* Didn't match */
                 continue;
             }
         }
 
         /* Check for repetitions on user error */
-        if (currently_rule->context_opts & SAME_USER) {
+        if (rule->context_opts & SAME_USER) {
             if ((!lf->dstuser) || (!my_lf->dstuser)) {
                 continue;
             }
@@ -363,7 +363,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* Check for same ID */
-        if (currently_rule->context_opts & SAME_ID) {
+        if (rule->context_opts & SAME_ID) {
             if ((!lf->id) || (!my_lf->id)) {
                 continue;
             }
@@ -374,7 +374,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* Check for repetitions from same src_ip */
-        if (currently_rule->context_opts & SAME_SRCIP) {
+        if (rule->context_opts & SAME_SRCIP) {
             if ((!lf->srcip) || (!my_lf->srcip)) {
                 continue;
             }
@@ -385,7 +385,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *currently_rule)
         }
 
         /* Check for different urls */
-        if (currently_rule->context_opts & DIFFERENT_URL) {
+        if (rule->context_opts & DIFFERENT_URL) {
             if ((!lf->url) || (!my_lf->url)) {
                 continue;
             }
@@ -397,22 +397,22 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *currently_rule)
 
 
         /* Check if the number of matches worked */
-        if (currently_rule->__frequency < currently_rule->frequency) {
-            if (currently_rule->__frequency <= 10) {
-                currently_rule->last_events[currently_rule->__frequency]
+        if (rule->__frequency < rule->frequency) {
+            if (rule->__frequency <= 10) {
+                rule->last_events[rule->__frequency]
                     = lf->full_log;
-                currently_rule->last_events[currently_rule->__frequency + 1]
+                rule->last_events[rule->__frequency + 1]
                     = NULL;
             }
 
-            currently_rule->__frequency++;
+            rule->__frequency++;
             continue;
         }
 
         /* If reached here, we matched */
-        my_lf->matched = currently_rule->level;
-        lf->matched = currently_rule->level;
-        first_lf->matched = currently_rule->level;
+        my_lf->matched = rule->level;
+        lf->matched = rule->level;
+        first_lf->matched = rule->level;
 
         return (lf);
 

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -129,7 +129,7 @@ void Free_Eventinfo(Eventinfo *lf);
 void OS_AddEvent(Eventinfo *lf);
 
 /* Return the last event from the Event list */
-EventNode *OS_GetLastEvent();
+EventNode *OS_GetLastEvent(void);
 
 /* Create the event list. Maxsize must be specified */
 void OS_CreateEventList(int maxsize);

--- a/src/analysisd/fts.h
+++ b/src/analysisd/fts.h
@@ -19,5 +19,7 @@
 #define IG_QUEUE  "/queue/fts/ig-queue"
 #endif
 
+int FTS_Init(void);
+
 #endif /* __FTS_H */
 

--- a/src/analysisd/lists.h
+++ b/src/analysisd/lists.h
@@ -42,7 +42,7 @@ typedef struct ListRule {
 } ListRule;
 
 /* Create the rule list */
-void OS_CreateListsList();
+void OS_CreateListsList(void);
 
 /* Add rule information to the list */
 int OS_AddList( ListNode *new_listnode );
@@ -53,13 +53,15 @@ int OS_DBSearchKey(ListRule *lrule, char *key);
 
 int OS_DBSearch(ListRule *lrule, char *key);
 
-void OS_ListLoadRules();
+void OS_ListLoadRules(void);
 
 ListRule *OS_AddListRule(ListRule *first_rule_list, int lookup_type, int field, char *listname, OSMatch *matcher);
 
-ListNode *OS_GetFirstList();
+ListNode *OS_GetFirstList(void);
 
 ListNode *OS_FindList(char *listname);
+
+void Lists_OP_CreateLists(void);
 
 #endif /* __LISTS_H */
 

--- a/src/analysisd/lists_list.c
+++ b/src/analysisd/lists_list.c
@@ -15,9 +15,6 @@
 #include <string.h>
 #include <errno.h>
 
-/* Prototypes */
-ListNode *_OS_AddList(ListNode *new_listnode);
-
 /* Global variables */
 ListNode *global_listnode;
 ListRule *global_listrule;
@@ -38,12 +35,6 @@ ListNode *OS_GetFirstList()
     ListNode *listnode_pt = global_listnode;
 
     return (listnode_pt);
-}
-
-ListRule *OS_GetFirstListRule()
-{
-    ListRule *listrule_pt = global_listrule;
-    return listrule_pt;
 }
 
 void OS_ListLoadRules()
@@ -171,7 +162,7 @@ int OS_DBSearchKeyValue(ListRule *lrule, char *key)
         if (cdb_find(&lrule->db->cdb, key, strlen(key)) > 0 ) {
             vpos = cdb_datapos(&lrule->db->cdb);
             vlen = cdb_datalen(&lrule->db->cdb);
-            val = malloc(vlen);
+            val = (char *) malloc(vlen);
             cdb_read(&lrule->db->cdb, val, vlen, vpos);
             result = OSMatch_Execute(val, vlen, lrule->matcher);
             free(val);
@@ -237,7 +228,7 @@ int OS_DBSearchKeyAddressValue(ListRule *lrule, char *key)
         if (cdb_find(&lrule->db->cdb, key, strlen(key)) > 0 ) {
             vpos = cdb_datapos(&lrule->db->cdb);
             vlen = cdb_datalen(&lrule->db->cdb);
-            val = malloc(vlen);
+            val = (char *) malloc(vlen);
             cdb_read(&lrule->db->cdb, val, vlen, vpos);
             result = OSMatch_Execute(val, vlen, lrule->matcher);
             free(val);
@@ -251,7 +242,7 @@ int OS_DBSearchKeyAddressValue(ListRule *lrule, char *key)
                     if ( cdb_find(&lrule->db->cdb, tmpkey, strlen(tmpkey)) > 0 ) {
                         vpos = cdb_datapos(&lrule->db->cdb);
                         vlen = cdb_datalen(&lrule->db->cdb);
-                        val = malloc(vlen);
+                        val = (char *) malloc(vlen);
                         cdb_read(&lrule->db->cdb, val, vlen, vpos);
                         result = OSMatch_Execute(val, vlen, lrule->matcher);
                         free(val);

--- a/src/analysisd/makelists.c
+++ b/src/analysisd/makelists.c
@@ -25,12 +25,10 @@
 /* For config  */
 int GlobalConf(char *cfgfile);
 
-/* For Lists */
-void Lists_OP_CreateLists();
-
 
 /* print help statement */
-void help_makelists()
+__attribute__((noreturn))
+static void help_makelists(void)
 {
     print_header();
     print_out("  %s: -[VhdtF] [-u user] [-g group] [-c config] [-D dir]", ARGV0);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -28,7 +28,6 @@ int getattributes(char **attributes,
 int doesRuleExist(int sid, RuleNode *r_node);
 void Rule_AddAR(RuleInfo *config_rule);
 char *loadmemory(char *at, char *str);
-int getDecoderfromlist(char *name);
 
 /* Global variables */
 extern int _max_freq;
@@ -449,7 +448,7 @@ int Rules_OP_ReadRules(char *rulefile)
                         }
 
                         config_ruleinfo->srcip =
-                            realloc(config_ruleinfo->srcip,
+                            (os_ip **) realloc(config_ruleinfo->srcip,
                                     (ip_s + 2) * sizeof(os_ip *));
 
 
@@ -479,7 +478,7 @@ int Rules_OP_ReadRules(char *rulefile)
                         }
 
                         config_ruleinfo->dstip =
-                            realloc(config_ruleinfo->dstip,
+                            (os_ip **) realloc(config_ruleinfo->dstip,
                                     (ip_s + 2) * sizeof(os_ip *));
 
 
@@ -692,7 +691,7 @@ int Rules_OP_ReadRules(char *rulefile)
 
                         }
 
-                        config_ruleinfo->compiled_rule = compiled_rules_list[it_id];
+                        config_ruleinfo->compiled_rule = (void *(*)(void *)) compiled_rules_list[it_id];
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
@@ -1162,8 +1161,8 @@ int Rules_OP_ReadRules(char *rulefile)
 
             /* Set the event_search pointer */
             if (config_ruleinfo->if_matched_sid) {
-                config_ruleinfo->event_search =
-                    (void *)Search_LastSids;
+                config_ruleinfo->event_search = (void *(*)(void *, void *))
+                    Search_LastSids;
 
                 /* Mark rules that match this id */
                 OS_MarkID(NULL, config_ruleinfo);
@@ -1181,15 +1180,15 @@ int Rules_OP_ReadRules(char *rulefile)
                 OS_MarkGroup(NULL, config_ruleinfo);
 
                 /* Set function pointer */
-                config_ruleinfo->event_search =
-                    (void *)Search_LastGroups;
+                config_ruleinfo->event_search = (void *(*)(void *, void *))
+                    Search_LastGroups;
             } else if (config_ruleinfo->context) {
                 if ((config_ruleinfo->context == 1) &&
                         (config_ruleinfo->context_opts & SAME_DODIFF)) {
                     config_ruleinfo->context = 0;
                 } else {
-                    config_ruleinfo->event_search =
-                        (void *)Search_LastEvents;
+                    config_ruleinfo->event_search = (void *(*)(void *, void *))
+                        Search_LastEvents;
                 }
             }
 
@@ -1233,7 +1232,7 @@ char *loadmemory(char *at, char *str)
     if (at == NULL) {
         int strsize = 0;
         if ((strsize = strlen(str)) < OS_SIZE_2048) {
-            at = calloc(strsize + 1, sizeof(char));
+            at = (char *) calloc(strsize + 1, sizeof(char));
             if (at == NULL) {
                 merror(MEM_ERROR, ARGV0, errno, strerror(errno));
                 return (NULL);
@@ -1255,7 +1254,7 @@ char *loadmemory(char *at, char *str)
             return (NULL);
         }
 
-        at = realloc(at, (finalsize) * sizeof(char));
+        at = (char *) realloc(at, (finalsize) * sizeof(char));
 
         if (at == NULL) {
             merror(MEM_ERROR, ARGV0, errno, strerror(errno));
@@ -1656,7 +1655,7 @@ void Rule_AddAR(RuleInfo *rule_config)
         if (mark_to_ar == 1) {
             rule_ar_size++;
 
-            rule_config->ar = realloc(rule_config->ar,
+            rule_config->ar = (active_response **) realloc(rule_config->ar,
                                       (rule_ar_size + 1)
                                       * sizeof(active_response *));
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -185,7 +185,7 @@ RuleInfo *zerorulemember(int id,
 /** Rule_list Functions **/
 
 /* create the rule list */
-void OS_CreateRuleList();
+void OS_CreateRuleList(void);
 
 /* Add rule information to the list */
 int OS_AddRule(RuleInfo *read_rule);
@@ -203,7 +203,9 @@ int OS_MarkGroup(RuleNode *r_node, RuleInfo *orig_rule);
 int OS_MarkID(RuleNode *r_node, RuleInfo *orig_rule);
 
 /* Get first rule */
-RuleNode *OS_GetFirstRule();
+RuleNode *OS_GetFirstRule(void);
+
+void Rules_OP_CreateRules(void);
 
 /** Definition of the internal rule IDS **
  ** These SIGIDs cannot be used         **

--- a/src/analysisd/stats.c
+++ b/src/analysisd/stats.c
@@ -40,15 +40,13 @@ int maxdiff = 0;
 int mindiff = 0;
 int percent_diff = 20;
 
-char __stats_comment[192];
-
 /* Last msgs, to avoid floods */
 char *_lastmsg;
 char *_prevlast;
 char *_pprevlast;
 
 
-void print_totals()
+static void print_totals(void)
 {
     int i, totals = 0;
     char logfile[OS_FLSIZE + 1];

--- a/src/analysisd/stats.h
+++ b/src/analysisd/stats.h
@@ -15,5 +15,9 @@ int LastMsg_Stats(char *log);
 
 char __stats_comment[192];
 
+void Update_Hour(void);
+int Check_Hour(void);
+int Start_Hour(void);
+
 #endif /* _STAT__H */
 

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -25,6 +25,7 @@
 #include "eventinfo.h"
 #include "accumulator.h"
 #include "analysisd.h"
+#include "fts.h"
 
 /** Internal Functions **/
 void OS_ReadMSG(char *ut_str);
@@ -36,8 +37,6 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node);
 int GlobalConf(char *cfgfile);
 
 /* For rules */
-void Rules_OP_CreateRules();
-void Lists_OP_CreateLists();
 int Rules_OP_ReadRules(char *cfgfile);
 int _setlevels(RuleNode *node, int nnode);
 int AddHash_Rule(RuleNode *node);
@@ -46,7 +45,6 @@ int AddHash_Rule(RuleNode *node);
 int OS_CleanMSG(char *msg, Eventinfo *lf);
 
 /* for FTS */
-int FTS_Init();
 int AddtoIGnore(Eventinfo *lf);
 int IGnore(Eventinfo *lf);
 
@@ -55,11 +53,11 @@ void DecodeEvent(Eventinfo *lf);
 
 /* For Decoders */
 int ReadDecodeXML(char *file);
-int SetDecodeXML();
 
 
 /* Print help statement */
-void help_logtest()
+__attribute__((noreturn))
+static void help_logtest(void)
 {
     print_header();
     print_out("  %s: -[Vhdtva] [-c config] [-D dir] [-U rule:alert:decoder]", ARGV0);
@@ -300,6 +298,7 @@ int main(int argc, char **argv)
 }
 
 /* Receive the messages (events) and analyze them */
+__attribute__((noreturn))
 void OS_ReadMSG(char *ut_str)
 {
     int i;
@@ -579,6 +578,5 @@ void OS_ReadMSG(char *ut_str)
         }
     }
     exit(exit_code);
-    return;
 }
 

--- a/src/os_crypto/sha1/md32_common.h
+++ b/src/os_crypto/sha1/md32_common.h
@@ -402,7 +402,7 @@
 
 int HASH_UPDATE (HASH_CTX *c, const void *data_, size_t len)
 {
-    const unsigned char *data = data_;
+    const unsigned char *data = (const unsigned char *)data_;
     register HASH_LONG *p;
     register HASH_LONG l;
     size_t sw, sc, ew, ec;

--- a/src/os_crypto/sha1/sha_locl.h
+++ b/src/os_crypto/sha1/sha_locl.h
@@ -236,7 +236,7 @@ int HASH_INIT (SHA_CTX *c)
 #ifndef DONT_IMPLEMENT_BLOCK_HOST_ORDER
 void HASH_BLOCK_HOST_ORDER (SHA_CTX *c, const void *d, size_t num)
 {
-    const SHA_LONG *W = d;
+    const SHA_LONG *W = (const SHA_LONG *)d;
     register unsigned MD32_REG_T A, B, C, D, E, T;
 #ifndef MD32_XARRAY
     unsigned MD32_REG_T XX0, XX1, XX2, XX3, XX4, XX5, XX6, XX7,
@@ -362,7 +362,7 @@ void HASH_BLOCK_HOST_ORDER (SHA_CTX *c, const void *d, size_t num)
 #ifndef DONT_IMPLEMENT_BLOCK_DATA_ORDER
 void HASH_BLOCK_DATA_ORDER (SHA_CTX *c, const void *p, size_t num)
 {
-    const unsigned char *data = p;
+    const unsigned char *data = (const unsigned char *)p;
     register unsigned MD32_REG_T A, B, C, D, E, T, l;
 #ifndef MD32_XARRAY
     unsigned MD32_REG_T XX0, XX1, XX2, XX3, XX4, XX5, XX6, XX7,

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -136,7 +136,7 @@ int field_add_truncated(char *dest, size_t size, const char *format, const char 
             )
        ) {
 
-        if ( (truncated = malloc(field_sz + 1)) != NULL ) {
+        if ( (truncated = (char *) malloc(field_sz + 1)) != NULL ) {
             if ( total_sz > available_sz ) {
                 /* Truncate and add a trailer */
                 os_substr(truncated, value, 0, field_sz - strlen(trailer));

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -22,7 +22,7 @@ char _g_subject[SUBJECT_SIZE + 2];
 
 /* Prototypes */
 static void OS_Run(MailConfig *mail) __attribute__((nonnull)) __attribute__((noreturn));
-static void help_maild() __attribute__((noreturn));
+static void help_maild(void) __attribute__((noreturn));
 
 
 /* Print help statement */

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -244,7 +244,8 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg)
 
 int OS_Sendmail(MailConfig *mail, struct tm *p)
 {
-    int socket, i = 0;
+    int socket;
+    unsigned int i = 0;
     char *msg;
     char snd_msg[128];
 

--- a/src/remoted/ar-forward.c
+++ b/src/remoted/ar-forward.c
@@ -154,7 +154,5 @@ void *AR_Forward(__attribute__((unused)) void *arg)
             key_unlock();
         }
     }
-
-    return (NULL);
 }
 

--- a/src/remoted/remoted.h
+++ b/src/remoted/remoted.h
@@ -35,7 +35,7 @@ void HandleSyslogTCP(void) __attribute__((noreturn));
 void HandleSecure(void) __attribute__((noreturn));
 
 /* Forward active response events */
-void *AR_Forward(void *arg);
+void *AR_Forward(void *arg) __attribute__((noreturn));
 
 /* Initialize the manager */
 void manager_init(int isUpdate);

--- a/src/rootcheck/os_string.c
+++ b/src/rootcheck/os_string.c
@@ -157,7 +157,7 @@ int os_string(char *file, char *regex)
     }
 
     /* Allocate the buffer */
-    bfr = calloc(STR_MINLEN + 2, sizeof(unsigned char));
+    bfr = (unsigned char *) calloc(STR_MINLEN + 2, sizeof(unsigned char));
     if (!bfr) {
         merror(MEM_ERROR, ARGV0, errno, strerror(errno));
         return (0);

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -236,8 +236,3 @@ int os_write_agent_info(const char *agent_name, __attribute__((unused)) const ch
     return (1);
 }
 
-int os_agent_config_changed()
-{
-    return (0);
-}
-

--- a/src/shared/mem_op.c
+++ b/src/shared/mem_op.c
@@ -130,7 +130,7 @@ char *os_LoadString(char *at, const char *str)
  */
 void *memset_secure(void *v, int c, size_t n)
 {
-    volatile unsigned char *p = v;
+    volatile unsigned char *p = (volatile unsigned char *)v;
     while (n--) {
         *p++ = (unsigned char) c;
     }

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -13,7 +13,7 @@
 
 /* Prototypes */
 static char *gen_diff_alert(const char *filename, time_t alert_diff_time) __attribute__((nonnull));
-static int seechanges_dupfile(const char *old, const char *new) __attribute__((nonnull));
+static int seechanges_dupfile(const char *old, const char *current) __attribute__((nonnull));
 static int seechanges_createpath(const char *filename) __attribute__((nonnull));
 
 #ifdef USE_MAGIC
@@ -108,7 +108,7 @@ static char *gen_diff_alert(const char *filename, time_t alert_diff_time)
     return (strdup(diff_alert));
 }
 
-static int seechanges_dupfile(const char *old, const char *new)
+static int seechanges_dupfile(const char *old, const char *current)
 {
     size_t n;
     FILE *fpr;
@@ -122,7 +122,7 @@ static int seechanges_dupfile(const char *old, const char *new)
         return (0);
     }
 
-    fpw = fopen(new, "w");
+    fpw = fopen(current, "w");
     if (!fpw) {
         fclose(fpr);
         return (0);


### PR DESCRIPTION
fix several gcc warnings:
-Wabi -Wdouble-promotion -Winit-self -Wmissing-include-dirs -Wunused -Wsuggest-attribute=noreturn -Wsuggest-attribute=format -Wfloat-equal -Wundef -Wshadow -Wbad-function-cast -Wcast-qual -Wcast-align -Wlogical-op -Waggregate-return -Wstrict-prototypes -Wold-style-declaration -Wredundant-decls -Wnested-externs -Winline -Wc++-compat -Winvalid-pch -Wswitch-enum