### PR TITLE
add decoder for ossec-logcollector messages

### DIFF
--- a/contrib/ossec-testing/tests/ossec.ini
+++ b/contrib/ossec-testing/tests/ossec.ini
@@ -24,3 +24,10 @@ log 4 pass = Sat May  7 03:27:57 CDT 2011 /var/ossec/active-response/bin/firewal
 rule = 602
 alert = 3
 decoder = ar_log
+
+[ossec-logcollector: ignore informational messages at startup]
+log 1 pass = 2015/01/29 21:09:49 ossec-logcollector(1950): INFO: Analyzing file: '/var/log/httpd/error_log'.
+
+rule = 701
+alert = 0
+decoder = ossec-logcollector

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1870,7 +1870,7 @@
 <decoder name="ossec-logcollector">
   <type>ossec</type>
   <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d ossec-logcollector</prematch>
-  <regex offset="after_prematch">^ '(\S+)'</regex>
+  <regex offset="after_prematch">^\(\d+\): (\.)</regex>
   <order>extra_data</order>
 </decoder>
 
@@ -1878,7 +1878,7 @@
   <parent>ossec</parent>
   <type>ossec</type>
   <prematch offset="after_parent">^Agent started:</prematch>
-  <regex offset="after_prematch">^\(\d+\): (\.)</regex>
+  <regex offset="after_prematch">^ '(\S+)'</regex>
   <order>extra_data</order>
   <fts>name, location, extra_data</fts>
 </decoder>

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1867,11 +1867,18 @@
   <type>ossec</type>
 </decoder>
 
+<decoder name="ossec-logcollector">
+  <type>ossec</type>
+  <prematch>^\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d ossec-logcollector</prematch>
+  <regex offset="after_prematch">^ '(\S+)'</regex>
+  <order>extra_data</order>
+</decoder>
+
 <decoder name="ossec-agent">
   <parent>ossec</parent>
   <type>ossec</type>
   <prematch offset="after_parent">^Agent started:</prematch>
-  <regex offset="after_prematch">^ '(\S+)'</regex>
+  <regex offset="after_prematch">^\(\d+\): (\.)</regex>
   <order>extra_data</order>
   <fts>name, location, extra_data</fts>
 </decoder>

--- a/etc/rules/ossec_rules.xml
+++ b/etc/rules/ossec_rules.xml
@@ -293,7 +293,7 @@ Example:
 Sat May  7 03:27:57 CDT 2011 /var/ossec/active-response/bin/firewall-drop.sh delete - 172.16.0.1 1304756247.60385 31151
 -->
 
-<rule id="600" level="0">
+  <rule id="600" level="0">
     <decoded_as>ar_log</decoded_as>
     <description>Active Response Messages Grouped</description>
     <group>active_response,</group>
@@ -345,6 +345,18 @@ Sat May  7 03:27:57 CDT 2011 /var/ossec/active-response/bin/firewall-drop.sh del
     <status>delete</status>
     <description>Host Unblocked by route-null.sh Active Response</description>
     <group>active_response,</group>
+  </rule>
+
+  <rule id="700" level="0">
+    <category>ossec</category>
+    <decoded_as>ossec-logcollector</decoded_as>
+    <description>Logcollector Messages Grouped</description>
+  </rule>
+
+  <rule id="701" level="0">
+    <if_sid>700</if_sid>
+    <match>INFO: </match>
+    <description>Ignore informational messages (usually at startup)</description>
   </rule>
 
 </group> <!-- OSSEC -->


### PR DESCRIPTION
The problem is that if ossec.log is monitored and ossec-logcollector starts up it prints info messages about what files are monitored. If the logfile contains a bad word it gets picked up by rule 1002. This decoder and rules will detect those info messages so rule 1002 is not triggered.