### PR TITLE
fix most gcc -Wall -Wextra warnings in windows build

### DIFF
--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -17,7 +17,7 @@ static void manage_shutdown(int sig) __attribute__((noreturn));
 
 
 #if defined(__MINGW32__)
-static int setenv(const char *name, const char *val, int overwrite)
+static int setenv(const char *name, const char *val, __attribute__((unused)) int overwrite)
 {
     int len = strlen(name) + strlen(val) + 2;
     char *str = (char *)malloc(len);

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -17,7 +17,7 @@
 
 
 /* Receive events from the server */
-void *receiver_thread(void *none)
+void *receiver_thread(__attribute__((unused)) void *none)
 {
     int recv_b;
 

--- a/src/config/localfile-config.h
+++ b/src/config/localfile-config.h
@@ -25,7 +25,7 @@ typedef struct _logreader {
 
 #ifdef WIN32
     HANDLE h;
-    int fd;
+    DWORD fd;
 #else
     ino_t fd;
 #endif

--- a/src/rootcheck/check_rc_dev.c
+++ b/src/rootcheck/check_rc_dev.c
@@ -163,7 +163,7 @@ void check_rc_dev(const char *basedir)
 #else
 
 /* Not relevant on Windows */
-void check_rc_dev(char *basedir)
+void check_rc_dev(__attribute__((unused)) char *basedir)
 {
     return;
 }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -277,8 +277,8 @@ static int read_sys_dir(const char *dir_name, int do_read)
     /* Entry count for directory different than the actual
      * link count from stats
      */
-    if ((entry_count != statbuf.st_nlink) &&
-            ((did_changed == 0) || ((entry_count + 1) != statbuf.st_nlink))) {
+    if ((entry_count != (unsigned) statbuf.st_nlink) &&
+            ((did_changed == 0) || ((entry_count + 1) != (unsigned) statbuf.st_nlink))) {
 #ifndef WIN32
         struct stat statbuf2;
         char op_msg[OS_SIZE_1024 + 1];

--- a/src/rootcheck/os_string.c
+++ b/src/rootcheck/os_string.c
@@ -263,7 +263,7 @@ int os_getch(os_strings *oss)
 }
 
 #else
-int os_string(char *file, char *regex)
+int os_string(__attribute__((unused)) char *file, __attribute__((unused)) char *regex)
 {
     return (0);
 }

--- a/src/rootcheck/rootcheck-config.c
+++ b/src/rootcheck/rootcheck-config.c
@@ -58,8 +58,9 @@ int Read_Rootcheck_Config(const char *cfgfile)
     const char *(xml_rootkit_winmalware[]) = {xml_rootcheck, "windows_malware", NULL};
     const char *(xml_scanall[]) = {xml_rootcheck, "scanall", NULL};
     const char *(xml_readall[]) = {xml_rootcheck, "readall", NULL};
+#ifdef OSSECHIDS
     const char *(xml_time[]) = {xml_rootcheck, "frequency", NULL};
-
+#endif
     const char *(xml_check_dev[]) = {xml_rootcheck, "check_dev", NULL};
     const char *(xml_check_files[]) = {xml_rootcheck, "check_files", NULL};
     const char *(xml_check_if[]) = {xml_rootcheck, "check_if", NULL};
@@ -75,8 +76,10 @@ int Read_Rootcheck_Config(const char *cfgfile)
     const char *(xml_check_unixaudit[]) = {xml_rootcheck, "check_unixaudit", NULL};
 #endif
 
+#ifdef OSSECHIDS
     /* :) */
     xml_time[2] = NULL;
+#endif
 
     if (OS_ReadXML(cfgfile, &xml) < 0) {
         merror("config_op: XML error: %s", xml.err);

--- a/src/rootcheck/win-common.c
+++ b/src/rootcheck/win-common.c
@@ -65,7 +65,8 @@ int os_check_ads(const char *full_path)
                        sid.dwStreamNameSize,
                        &dwRead, FALSE, FALSE, &context)) {
             if (dwRead != 0) {
-                int i = 0, max_path_size = 0;
+                DWORD i = 0;
+                int max_path_size = 0;
                 char *tmp_pt;
                 char op_msg[OS_SIZE_1024 + 1];
 
@@ -157,11 +158,13 @@ char *__os_winreg_getkey(char *reg_entry)
 }
 
 /* Query the key and get the value of a specific entry */
-int __os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name,
+int __os_winreg_querykey(HKEY hKey,
+        __attribute__((unused))char *p_key,
+        __attribute__((unused)) char *full_key_name,
                          char *reg_option, char *reg_value)
 {
-    int i, rc;
-    DWORD j;
+    int rc;
+    DWORD i, j;
 
     /* QueryInfo and EnumKey variables */
     TCHAR class_name_b[MAX_PATH + 1];

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -287,8 +287,7 @@ void start_daemon()
         }
 #elif defined(WIN32)
         if (syscheck.realtime && (syscheck.realtime->fd >= 0)) {
-            run_now = WaitForSingleObjectEx(syscheck.realtime->evt, SYSCHECK_WAIT * 1000, TRUE);
-            if (run_now == WAIT_FAILED) {
+            if (WaitForSingleObjectEx(syscheck.realtime->evt, SYSCHECK_WAIT * 1000, TRUE) == WAIT_FAILED) {
                 merror("%s: ERROR: WaitForSingleObjectEx failed (for realtime fim).", ARGV0);
                 sleep(SYSCHECK_WAIT);
             } else {

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -17,8 +17,6 @@
 
 #ifdef WIN32
 #define sleep(x) Sleep(x * 1000)
-#define os_calloc(x,y,z) (z = calloc(x,y))?(void)1:ErrorExit(MEM_ERROR, ARGV0, errno, strerror(errno))
-#define os_strdup(x,y) (y = strdup(x))?(void)1:ErrorExit(MEM_ERROR, ARGV0, errno, strerror(errno))
 #endif
 
 #ifdef INOTIFY_ENABLED

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -82,7 +82,7 @@ int os_winreg_changed(char *key, char *md5, char *sha1)
 }
 
 /* Notify of registry changes */
-int notify_registry(char *msg, int send_now)
+int notify_registry(char *msg, __attribute__((unused)) int send_now)
 {
     if (SendMSG(syscheck.queue, msg,
                 SYSCHECK_REG, SYSCHECK_MQ) < 0) {
@@ -145,8 +145,8 @@ char *os_winreg_sethkey(char *reg_entry)
 /* Query the key and get all its values */
 void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name)
 {
-    int i, rc;
-    DWORD j;
+    int rc;
+    DWORD i, j;
 
     /* QueryInfo and EnumKey variables */
     TCHAR sub_key_name_b[MAX_KEY_LENGTH + 2];

--- a/src/win32/ui/common.c
+++ b/src/win32/ui/common.c
@@ -170,7 +170,7 @@ void init_config()
 }
 
 /* Read ossec config */
-int config_read(HWND hwnd)
+int config_read(__attribute__((unused)) HWND hwnd)
 {
     char *tmp_str;
     char *delim = " - ";

--- a/src/win32/ui/os_win32ui.c
+++ b/src/win32/ui/os_win32ui.c
@@ -16,7 +16,8 @@
 
 /* Dialog -- About OSSEC */
 BOOL CALLBACK AboutDlgProc(HWND hwnd, UINT Message,
-                           WPARAM wParam, LPARAM lParam)
+       WPARAM wParam,
+       __attribute__((unused))LPARAM lParam)
 {
     switch (Message) {
         case WM_CREATE:
@@ -41,7 +42,8 @@ BOOL CALLBACK AboutDlgProc(HWND hwnd, UINT Message,
 }
 
 /* Main Dialog */
-BOOL CALLBACK DlgProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
+BOOL CALLBACK DlgProc(HWND hwnd, UINT Message, WPARAM wParam,
+        __attribute__((unused))LPARAM lParam)
 {
     int ret_code = 0;
 
@@ -384,8 +386,8 @@ BOOL CALLBACK DlgProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
     return TRUE;
 }
 
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
-                   LPSTR lpCmdLine, int nCmdShow)
+int WINAPI WinMain(HINSTANCE hInstance, __attribute__((unused))HINSTANCE hPrevInstance,
+        __attribute__((unused))LPSTR lpCmdLine, __attribute__((unused))int nCmdShow)
 {
     WSADATA wsaData;
 

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -261,7 +261,7 @@ int local_start()
 }
 
 /* SendMSG for Windows */
-int SendMSG(int queue, const char *message, const char *locmsg, char loc)
+int SendMSG(__attribute__((unused)) int queue, const char *message, const char *locmsg, char loc)
 {
     int _ssize;
     time_t cu_time;

--- a/src/win32/win_service.c
+++ b/src/win32/win_service.c
@@ -262,7 +262,7 @@ void WinSetError()
 }
 
 /* Initialize OSSEC-HIDS dispatcher */
-int os_WinMain(int argc, char **argv)
+int os_WinMain(__attribute__((unused)) int argc, __attribute__((unused)) char **argv)
 {
     SERVICE_TABLE_ENTRY   steDispatchTable[] = {
         { g_lpszServiceName, OssecServiceStart },
@@ -278,7 +278,7 @@ int os_WinMain(int argc, char **argv)
 }
 
 /* Start OSSEC service */
-void WINAPI OssecServiceStart (DWORD argc, LPTSTR *argv)
+void WINAPI OssecServiceStart (__attribute__((unused)) DWORD argc, __attribute__((unused)) LPTSTR *argv)
 {
     ossecServiceStatus.dwServiceType            = SERVICE_WIN32;
     ossecServiceStatus.dwCurrentState           = SERVICE_START_PENDING;


### PR DESCRIPTION
There are 2 issues left:
- the mingw-gcc version used at travis does not like the initialization at https://github.com/ossec/ossec-hids/blob/master/src/logcollector/read_win_event_channel.c#L667, but newer versions do not complain
- on windows sockets are unsigned, so calls like https://github.com/ossec/ossec-hids/blob/master/src/client-agent/receiver-win.c#L53 causes a warning about sign/unsigned comparison. The hole os_net code does not take this into account, so that might be fixed later