### PR TITLE
Feature/nfs exclusion v2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,6 +39,7 @@ DEFINES+=-DUSER=\"${OSSEC_USER}\"
 DEFINES+=-DREMUSER=\"${OSSEC_USER_REM}\"
 DEFINES+=-DGROUPGLOBAL=\"${OSSEC_GROUP}\"
 DEFINES+=-DMAILUSER=\"${OSSEC_USER_MAIL}\"
+DEFINES+=-D${uname_S}
 
 OSSEC_LDFLAGS=${LDFLAGS} -lm
 
@@ -154,7 +155,7 @@ $(error No windows cross-compiler found!) #MING_BASE:=unknown-
 endif
 endif
 endif
-endif #winagent 
+endif #winagent
 
 
 OSSEC_CC      =${QUIET_CC}${MING_BASE}${CC}

--- a/src/config/rootcheck-config.c
+++ b/src/config/rootcheck-config.c
@@ -42,6 +42,7 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
     const char *xml_readall = "readall";
     const char *xml_time = "frequency";
     const char *xml_disabled = "disabled";
+    const char *xml_skip_nfs = "skip_nfs";
     const char *xml_base_dir = "base_directory";
     const char *xml_ignore = "ignore";
 
@@ -90,7 +91,18 @@ int Read_Rootcheck(XML_NODE node, void *configp, __attribute__((unused)) void *m
                 merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
                 return (OS_INVALID);
             }
-        } else if (strcmp(node[i]->element, xml_readall) == 0) {
+        }
+        else if(strcmp(node[i]->element, xml_skip_nfs) == 0)
+        {
+            rootcheck->skip_nfs = eval_bool(node[i]->content);
+            if (rootcheck->skip_nfs == OS_INVALID)
+            {
+                merror(XML_VALUEERR,__local_name,node[i]->element,node[i]->content);
+                return(OS_INVALID);
+            }
+        }
+        else if(strcmp(node[i]->element,xml_readall) == 0)
+        {
             rootcheck->readall = eval_bool(node[i]->content);
             if (rootcheck->readall == OS_INVALID) {
                 merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);

--- a/src/config/rootcheck-config.h
+++ b/src/config/rootcheck-config.h
@@ -30,6 +30,7 @@ typedef struct _rkconfig {
     int scanall;
     int readall;
     int disabled;
+    short skip_nfs;
 
     int time;
     int queue;

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -442,6 +442,7 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
     const char *xml_disabled = "disabled";
     const char *xml_scan_on_start = "scan_on_start";
     const char *xml_prefilter_cmd = "prefilter_cmd";
+    const char *xml_skip_nfs = "skip_nfs";
 
     /* Configuration example
     <directories check_all="yes">/etc,/usr/bin</directories>
@@ -537,8 +538,23 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
             }
         }
 
-        /* Get file/dir ignore */
-        else if (strcmp(node[i]->element, xml_ignore) == 0) {
+        /* Getting if skip_nfs. */
+        else if (strcmp(node[i]->element,xml_skip_nfs) == 0)
+        {
+            if(strcmp(node[i]->content, "yes") == 0)
+                syscheck->skip_nfs = 1;
+            else if(strcmp(node[i]->content, "no") == 0)
+                syscheck->skip_nfs = 0;
+            else
+            {
+                merror(XML_VALUEERR,__local_name,node[i]->element,node[i]->content);
+                return(OS_INVALID);
+            }
+        }
+
+        /* Getting file/dir ignore */
+        else if (strcmp(node[i]->element,xml_ignore) == 0)
+        {
             unsigned int ign_size = 0;
 
 #ifdef WIN32

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -43,6 +43,7 @@ typedef struct _config {
     int disabled;                   /* is syscheck disabled? */
     int scan_on_start;
     int realtime_count;
+    short skip_nfs;
 
     int time;                       /* frequency (secs) for syscheck to run */
     int queue;                      /* file descriptor of socket to write to queue */

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -87,7 +87,6 @@
 #define NO_CONFIG       "%s(1239): ERROR: Configuration file not found: '%s'."
 #define INVALID_TIME    "%s(1240): ERROR: Invalid time format: '%s'."
 #define INVALID_DAY     "%s(1241): ERROR: Invalid day format: '%s'."
-#define STATFS_ERROR    "%s(1242): ERROR: statfs() failed for: '%s'."
 
 #define MAILQ_ERROR     "%s(1221): ERROR: No Mail queue at %s"
 #define IMSG_ERROR      "%s(1222): ERROR: Invalid msg: %s"

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -87,6 +87,7 @@
 #define NO_CONFIG       "%s(1239): ERROR: Configuration file not found: '%s'."
 #define INVALID_TIME    "%s(1240): ERROR: Invalid time format: '%s'."
 #define INVALID_DAY     "%s(1241): ERROR: Invalid day format: '%s'."
+#define STATFS_ERROR    "%s(1242): ERROR: statfs() failed for: '%s'."
 
 #define MAILQ_ERROR     "%s(1221): ERROR: No Mail queue at %s"
 #define IMSG_ERROR      "%s(1222): ERROR: Invalid msg: %s"

--- a/src/headers/fs_op.h
+++ b/src/headers/fs_op.h
@@ -19,9 +19,13 @@
 #ifndef _OS_FS
 #define _OS_FS
 
-#ifdef Linux
-#define _CAN_CHECK_FS_TYPE
+#ifdef __linux__
 #include <sys/vfs.h>
+#endif
+
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#include <sys/mount.h>
 #endif
 
 short IsNFS(const char *file)  __attribute__((nonnull));

--- a/src/headers/fs_op.h
+++ b/src/headers/fs_op.h
@@ -30,7 +30,11 @@
 
 struct file_system_type {
     const char *name;
+#ifdef WIN32
+    const unsigned __int32 f_type;
+#else
     const uint32_t f_type;
+#endif
     const int flag;
 };
 

--- a/src/headers/fs_op.h
+++ b/src/headers/fs_op.h
@@ -19,14 +19,22 @@
 #ifndef _OS_FS
 #define _OS_FS
 
-#ifdef __linux__
+#ifdef Linux
 #include <sys/vfs.h>
 #endif
 
-#ifdef __FreeBSD__
+#ifdef FreeBSD
 #include <sys/param.h>
 #include <sys/mount.h>
 #endif
+
+struct file_system_type {
+    const char *name;
+    const uint32_t f_type;
+    const int flag;
+};
+
+extern const struct file_system_type network_file_systems[];
 
 short IsNFS(const char *file)  __attribute__((nonnull));
 

--- a/src/headers/fs_op.h
+++ b/src/headers/fs_op.h
@@ -1,0 +1,31 @@
+/* @(#) $Id: ./src/headers/dirtree_op.h, 2011/09/08 dcid Exp $
+ */
+
+/* Copyright (C) 2014 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * License details at the LICENSE file included with OSSEC or
+ * online at: http://www.ossec.net/en/licensing.html
+ */
+
+/* Common API for dealing with file system information */
+
+
+#ifndef _OS_FS
+#define _OS_FS
+
+#ifdef Linux
+#define _CAN_CHECK_FS_TYPE
+#include <sys/vfs.h>
+#endif
+
+short IsNFS(const char *file)  __attribute__((nonnull));
+
+#endif
+
+/* EOF */

--- a/src/headers/fs_op.h
+++ b/src/headers/fs_op.h
@@ -19,6 +19,8 @@
 #ifndef _OS_FS
 #define _OS_FS
 
+#ifndef WIN32
+
 #ifdef Linux
 #include <sys/vfs.h>
 #endif
@@ -26,6 +28,8 @@
 #ifdef FreeBSD
 #include <sys/param.h>
 #include <sys/mount.h>
+#endif
+
 #endif
 
 struct file_system_type {

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -176,6 +176,7 @@ extern const char *__local_name;
 #include "wait_op.h"
 #include "agent_op.h"
 #include "file_op.h"
+#include "fs_op.h"
 #include "mem_op.h"
 #include "math_op.h"
 #include "mq_op.h"

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -9,7 +9,6 @@
 
 #include "shared.h"
 #include "rootcheck.h"
-#include <sys/statfs.h>
 
 /* Prototypes */
 static int read_sys_file(const char *file_name, int do_read);
@@ -148,6 +147,7 @@ static int read_sys_dir(const char *dir_name, int do_read)
     DIR *dp;
     struct dirent *entry;
     struct stat statbuf;
+    short is_nfs;
 
 #ifndef WIN32
     const char *(dirs_to_doread[]) = { "/bin", "/sbin", "/usr/bin",
@@ -172,9 +172,23 @@ static int read_sys_dir(const char *dir_name, int do_read)
         i = 0;
     }
 
-    /* Get the number of nodes. The total number on opendir must be the same. */
-    if (lstat(dir_name, &statbuf) < 0) {
-        return (-1);
+    /* Should we check for NFS? */
+    if(rootcheck.skip_nfs)
+    {
+        is_nfs = IsNFS(dir_name);
+        if(is_nfs != 0)
+        {
+            // Error will be -1, and 1 means skipped
+            return(is_nfs);
+        }
+    }
+
+    /* Getting the number of nodes. The total number on opendir
+     * must be the same
+     */
+    if(lstat(dir_name, &statbuf) < 0)
+    {
+        return(-1);
     }
 
     /* Current device id */

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -9,6 +9,7 @@
 
 #include "shared.h"
 #include "rootcheck.h"
+#include <sys/statfs.h>
 
 /* Prototypes */
 static int read_sys_file(const char *file_name, int do_read);

--- a/src/rootcheck/common_rcl.c
+++ b/src/rootcheck/common_rcl.c
@@ -446,10 +446,20 @@ int rkcl_get_entry(FILE *fp, const char *msg, OSList *p_list)
                 }
 
                 while (dir) {
+
                     debug2("%s: Checking dir: %s", ARGV0, dir);
-                    if (rk_check_dir(dir, file, pattern)) {
-                        debug2("%s: DEBUG: Found dir.", ARGV0);
-                        found = 1;
+
+                    short is_nfs = IsNFS(dir);
+                    if( is_nfs == 1 && rootcheck.skip_nfs ) {
+                        debug1("%s: DEBUG: rootcheck.skip_nfs enabled and %s is flagged as NFS.", ARGV0, dir);
+                    }
+                    else {
+                        debug2("%s: DEBUG: %s => is_nfs=%d, skip_nfs=%d", ARGV0, dir, is_nfs, rootcheck.skip_nfs);
+
+                        if (rk_check_dir(dir, file, pattern)) {
+                            debug2("%s: DEBUG: Found dir.", ARGV0);
+                            found = 1;
+                        }
                     }
 
                     if (f_value) {

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -79,6 +79,7 @@ int rootcheck_init(int test_config)
     rootcheck.scanall = 0;
     rootcheck.readall = 0;
     rootcheck.disabled = 0;
+    rootcheck.skip_nfs = 0;
     rootcheck.alert_msg = NULL;
     rootcheck.time = ROOTCHECK_WAIT;
 

--- a/src/rootcheck/rootcheck.conf
+++ b/src/rootcheck/rootcheck.conf
@@ -1,5 +1,6 @@
 <rootcheck>
   <daemon>no</daemon>
+  <skip_nfs>no</skip_nfs>
   <notify>syslog</notify>
   <rootkit_files>./db/rootkit_files.txt</rootkit_files>
   <rootkit_trojans>./db/rootkit_trojans.txt</rootkit_trojans>
@@ -22,7 +23,6 @@
 
   <check_dev>yes</check_dev>
   <check_sys>yes</check_sys>
-  <check_nfs>yes</check_nfs>
   <check_pids>yes</check_pids>
   <check_ports>yes</check_ports>
   <check_if>yes</check_if>

--- a/src/rootcheck/rootcheck.conf
+++ b/src/rootcheck/rootcheck.conf
@@ -22,6 +22,7 @@
 
   <check_dev>yes</check_dev>
   <check_sys>yes</check_sys>
+  <check_nfs>yes</check_nfs>
   <check_pids>yes</check_pids>
   <check_ports>yes</check_ports>
   <check_if>yes</check_if>

--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -16,7 +16,7 @@
 
 short IsNFS(const char *dir_name)
 {
-#ifdef _CAN_CHECK_FS_TYPE
+#if defined(__linux__) || defined(__FreeBSD__)
     struct statfs stfs;
 
     /* ignore NFS (0x6969) or CIFS (0xFF534D42) mounts */
@@ -30,7 +30,7 @@ short IsNFS(const char *dir_name)
     else
     {
         /* Throw an error and retreat! */
-        merror(STATFS_ERORR, ARGV0, strerror(errno));
+        merror("ERROR: statfs('%s') produced error: %s", dir_name, strerror(errno));
         return(-1);
     }
 #else

--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -14,18 +14,29 @@
 
 #include "shared.h"
 
+const struct file_system_type network_file_systems[] = {
+    {.name="NFS",  .f_type=0x6969,     .flag=1},
+    {.name="CIFS", .f_type=0xFF534D42, .flag=1},
+
+    /*  The last entry must be name=NULL */
+    {.name=NULL, .f_type=0, .flag=0}
+};
+
 short IsNFS(const char *dir_name)
 {
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(Linux) || defined(FreeBSD)
     struct statfs stfs;
 
     /* ignore NFS (0x6969) or CIFS (0xFF534D42) mounts */
     if ( ! statfs(dir_name, &stfs) )
     {
-        if ( (stfs.f_type == 0x6969) || (stfs.f_type == 0xFF534D42) )
-        {
-            return(1); /* NFS/CIFS path */
+        int i;
+        for ( i=0; network_file_systems[i].name != NULL; i++ ) {
+            if(network_file_systems[i].f_type == stfs.f_type ) {
+                return network_file_systems[i].flag;
+            }
         }
+        return(0);
     }
     else
     {

--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -1,0 +1,45 @@
+/* Copyright (C) 2014 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+/* Functions to retrieve information about the filesystem
+ */
+
+
+#include "shared.h"
+
+short IsNFS(const char *dir_name)
+{
+#ifdef _CAN_CHECK_FS_TYPE
+    struct statfs stfs;
+
+    /* ignore NFS (0x6969) or CIFS (0xFF534D42) mounts */
+    if ( ! statfs(dir_name, &stfs) )
+    {
+        if ( (stfs.f_type == 0x6969) || (stfs.f_type == 0xFF534D42) )
+        {
+            return(1); /* NFS/CIFS path */
+        }
+    }
+    else
+    {
+        /* Throw an error and retreat! */
+        merror(STATFS_ERORR, ARGV0, strerror(errno));
+        return(-1);
+    }
+#else
+    verbose(
+        "INFO: Attempted to check NFS status for '%s', but we don't know how on this OS.",
+        dir_name
+    );
+#endif
+    return(0);
+}
+
+/* EOF */

--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -24,7 +24,7 @@ const struct file_system_type network_file_systems[] = {
 
 short IsNFS(const char *dir_name)
 {
-#if defined(Linux) || defined(FreeBSD)
+#if !defined(WIN32) && (defined(Linux) || defined(FreeBSD))
     struct statfs stfs;
 
     /* ignore NFS (0x6969) or CIFS (0xFF534D42) mounts */

--- a/src/syscheckd/config.c
+++ b/src/syscheckd/config.c
@@ -24,6 +24,7 @@ int Read_Syscheck_Config(const char *cfgfile)
 
     syscheck.rootcheck      = 0;
     syscheck.disabled       = 0;
+    syscheck.skip_nfs       = 0;
     syscheck.scan_on_start  = 1;
     syscheck.time           = SYSCHECK_WAIT * 2;
     syscheck.ignore         = NULL;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -238,6 +238,8 @@ static int read_dir(const char *dir_name, int opts, OSMatch *restriction)
 {
     size_t dir_size;
     char f_name[PATH_MAX + 2];
+    short is_nfs;
+
     DIR *dp;
     struct dirent *entry;
 
@@ -248,6 +250,18 @@ static int read_dir(const char *dir_name, int opts, OSMatch *restriction)
         merror(NULL_ERROR, ARGV0);
         return (-1);
     }
+
+    /* Should we check for NFS? */
+    if(syscheck.skip_nfs)
+    {
+        is_nfs = IsNFS(dir_name);
+        if(is_nfs != 0)
+        {
+            // Error will be -1, and 1 means skipped
+            return(is_nfs);
+        }
+    }
+
 
     /* Open the directory given */
     dp = opendir(dir_name);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -64,7 +64,6 @@ static void send_sk_db()
         merror("%s: INFO: Starting syscheck scan (forwarding database).", ARGV0);
         send_rootcheck_msg("Starting syscheck scan.");
     } else {
-        sleep(syscheck.tsleep + 10);
         return;
     }
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -27,6 +27,7 @@
 #include "shared.h"
 #endif
 
+#include "fs_op.h"
 #include "hash_op.h"
 #include "debug_op.h"
 #include "syscheck.h"
@@ -122,6 +123,15 @@ int realtime_adddir(const char *dir)
         return (-1);
     } else {
         int wd = 0;
+
+        short is_nfs = IsNFS(dir);
+        if( is_nfs == 1 ) {
+            merror("%s: ERROR: %s NFS Directories do not support iNotify.", ARGV0, dir);
+            return(-1);
+        }
+        else {
+            debug2("%s: DEBUG: syscheck.skip_nfs=%d, %s::is_nfs=%d", ARGV0, syscheck.skip_nfs, dir, is_nfs);
+        }
 
         wd = inotify_add_watch(syscheck.realtime->fd,
                                dir,


### PR DESCRIPTION
This implements the <skip_nfs>yes</skip_nfs> option in rootcheck and syscheck.  Since it's available, it also warns if a user attempts to iNotify on an NFS partition as that is not supported by iNotify.