### PR TITLE
Output alerts.json, newline delimited json, beside the alerts.log file.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,7 @@ OSSEC_USER_REM?=ossecr
 
 USE_PRELUDE?=no
 USE_ZEROMQ?=no
+USE_JSONOUT?=no
 USE_GEOIP?=no
 USE_INOTIFY=no
 
@@ -184,6 +185,10 @@ ifneq (,$(filter ${USE_ZEROMQ},auto yes y Y 1))
 	#LDFLAGS+=-L/usr/local/lib -I/usr/local/include -lzmq -lczmq
 	OSSEC_LDFLAGS+=-lzmq -lczmq -lm
 endif # USE_ZEROMQ
+
+ifneq (,$(filter ${USE_JSONOUT},auto yes y Y 1))
+	DEFINES+=-DJSONOUT_OUTPUT_ENABLED
+endif # USE_JSONOUT
 
 ifneq (,$(filter ${USE_PICVIZ},auto yes y Y 1))
 	DEFINES+=-DPICVIZ_OUTPUT_ENABLED
@@ -528,6 +533,7 @@ settings:
 	@echo "    LUA_PLAT:         ${LUA_PLAT}"
 	@echo "USE settings:"
 	@echo "    USE_ZEROMQ:       ${USE_ZEROMQ}"
+	@echo "    USE_JSONOUT:      ${USE_JSONOUT}"
 	@echo "    USE_GEOIP:        ${USE_GEOIP}"
 	@echo "    USE_PRELUDE:      ${USE_PRELUDE}"
 	@echo "    USE_OPENSSL:      ${USE_OPENSSL}"

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,6 @@ OSSEC_USER_REM?=ossecr
 
 USE_PRELUDE?=no
 USE_ZEROMQ?=no
-USE_JSONOUT?=no
 USE_GEOIP?=no
 USE_INOTIFY=no
 
@@ -185,10 +184,6 @@ ifneq (,$(filter ${USE_ZEROMQ},auto yes y Y 1))
 	#LDFLAGS+=-L/usr/local/lib -I/usr/local/include -lzmq -lczmq
 	OSSEC_LDFLAGS+=-lzmq -lczmq -lm
 endif # USE_ZEROMQ
-
-ifneq (,$(filter ${USE_JSONOUT},auto yes y Y 1))
-	DEFINES+=-DJSONOUT_OUTPUT_ENABLED
-endif # USE_JSONOUT
 
 ifneq (,$(filter ${USE_PICVIZ},auto yes y Y 1))
 	DEFINES+=-DPICVIZ_OUTPUT_ENABLED
@@ -533,7 +528,6 @@ settings:
 	@echo "    LUA_PLAT:         ${LUA_PLAT}"
 	@echo "USE settings:"
 	@echo "    USE_ZEROMQ:       ${USE_ZEROMQ}"
-	@echo "    USE_JSONOUT:      ${USE_JSONOUT}"
 	@echo "    USE_GEOIP:        ${USE_GEOIP}"
 	@echo "    USE_PRELUDE:      ${USE_PRELUDE}"
 	@echo "    USE_OPENSSL:      ${USE_OPENSSL}"

--- a/src/analysisd/alerts/getloglocation.c
+++ b/src/analysisd/alerts/getloglocation.c
@@ -16,16 +16,14 @@
 FILE *_eflog;
 FILE *_aflog;
 FILE *_fflog;
+FILE *_jflog;
 
 /* Global variables */
 static int  __crt_day;
 static char __elogfile[OS_FLSIZE + 1];
 static char __alogfile[OS_FLSIZE + 1];
 static char __flogfile[OS_FLSIZE + 1];
-
-#ifdef JSONOUT_OUTPUT_ENABLED
-char __jlogfile[OS_FLSIZE + 1];
-#endif
+static char __jlogfile[OS_FLSIZE + 1];
 
 
 void OS_InitLog()
@@ -38,18 +36,12 @@ void OS_InitLog()
     memset(__alogfile, '\0', OS_FLSIZE + 1);
     memset(__elogfile, '\0', OS_FLSIZE + 1);
     memset(__flogfile, '\0', OS_FLSIZE + 1);
-
-#ifdef JSONOUT_OUTPUT_ENABLED
     memset(__jlogfile, '\0', OS_FLSIZE + 1);
-#endif
 
     _eflog = NULL;
     _aflog = NULL;
     _fflog = NULL;
-
-#ifdef JSONOUT_OUTPUT_ENABLED
     _jflog = NULL;
-#endif
 
     /* Set the umask */
     umask(0027);
@@ -147,7 +139,6 @@ int OS_GetLogLocation(const Eventinfo *lf)
         ErrorExit(LINK_ERROR, ARGV0, __alogfile, ALERTS_DAILY, errno, strerror(errno));
     }
 
-#ifdef JSONOUT_OUTPUT_ENABLED
     if (Config.jsonout_output) {
         /* Create the json logfile name */
         snprintf(__jlogfile, OS_FLSIZE, "%s/%d/%s/ossec-%s-%02d.json",
@@ -170,7 +161,6 @@ int OS_GetLogLocation(const Eventinfo *lf)
             ErrorExit(LINK_ERROR, ARGV0, __jlogfile, ALERTSJSON_DAILY, errno, strerror(errno));
         }
     }
-#endif
 
     /* For the firewall events */
     if (_fflog) {

--- a/src/analysisd/alerts/getloglocation.h
+++ b/src/analysisd/alerts/getloglocation.h
@@ -25,10 +25,7 @@ int OS_GetLogLocation(const Eventinfo *lf);
 extern FILE *_eflog;
 extern FILE *_aflog;
 extern FILE *_fflog;
-
-#ifdef JSONOUT_OUTPUT_ENABLED
-FILE *_jflog;
-#endif
+extern FILE *_jflog;
 
 #endif /* __GETLL_H */
 

--- a/src/analysisd/alerts/getloglocation.h
+++ b/src/analysisd/alerts/getloglocation.h
@@ -26,5 +26,9 @@ extern FILE *_eflog;
 extern FILE *_aflog;
 extern FILE *_fflog;
 
+#ifdef JSONOUT_OUTPUT_ENABLED
+FILE *_jflog;
+#endif
+
 #endif /* __GETLL_H */
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -31,6 +31,7 @@
 #include "fts.h"
 #include "cleanevent.h"
 #include "dodiff.h"
+#include "output/jsonout.h"
 
 #ifdef PICVIZ_OUTPUT_ENABLED
 #include "output/picviz.h"
@@ -42,10 +43,6 @@
 
 #ifdef ZEROMQ_OUTPUT_ENABLED
 #include "output/zeromq.h"
-#endif
-
-#ifdef JSONOUT_OUTPUT_ENABLED
-#include "output/jsonout.h"
 #endif
 
 /** Prototypes **/
@@ -824,6 +821,10 @@ void OS_ReadMSG_analysisd(int m_queue)
                         } else {
                             OS_Log(lf);
                         }
+                        /* Log to json file */
+                        if (Config.jsonout_output) {
+                            jsonout_output_event(lf);
+                        }
 
                     }
 
@@ -912,6 +913,10 @@ void OS_ReadMSG_analysisd(int m_queue)
                     } else {
                         OS_Log(lf);
                     }
+                    /* Log to json file */
+                    if (Config.jsonout_output) {
+                        jsonout_output_event(lf);
+                    }
                 }
 
 #ifdef PRELUDE_OUTPUT_ENABLED
@@ -927,13 +932,6 @@ void OS_ReadMSG_analysisd(int m_queue)
                 /* Log to zeromq */
                 if (Config.zeromq_output) {
                     zeromq_output_event(lf);
-                }
-#endif
-
-#ifdef JSONOUT_OUTPUT_ENABLED
-                /* Log to json file */
-                if (Config.jsonout_output) {
-                    jsonout_output_event(lf);
                 }
 #endif
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -44,6 +44,10 @@
 #include "output/zeromq.h"
 #endif
 
+#ifdef JSONOUT_OUTPUT_ENABLED
+#include "output/jsonout.h"
+#endif
+
 /** Prototypes **/
 void OS_ReadMSG(int m_queue);
 RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node);
@@ -923,6 +927,13 @@ void OS_ReadMSG_analysisd(int m_queue)
                 /* Log to zeromq */
                 if (Config.zeromq_output) {
                     zeromq_output_event(lf);
+                }
+#endif
+
+#ifdef JSONOUT_OUTPUT_ENABLED
+                /* Log to json file */
+                if (Config.jsonout_output) {
+                    jsonout_output_event(lf);
                 }
 #endif
 

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -32,6 +32,7 @@ int GlobalConf(const char *cfgfile)
     Config.prelude = 0;
     Config.zeromq_output = 0;
     Config.zeromq_output_uri = NULL;
+    Config.jsonout_output = 0;
     Config.memorysize = 1024;
     Config.mailnotify = -1;
     Config.keeplogdate = 0;

--- a/src/analysisd/output/jsonout.c
+++ b/src/analysisd/output/jsonout.c
@@ -7,13 +7,9 @@
  * Foundation.
  */
 
-#ifdef JSONOUT_OUTPUT_ENABLED
-
 #include "jsonout.h"
-
 #include "alerts/getloglocation.h"
 #include "format/to_json.h"
-
 
 void jsonout_output_event(const Eventinfo *lf)
 {
@@ -27,6 +23,3 @@ void jsonout_output_event(const Eventinfo *lf)
     free(json_alert);
     return;
 }
-
-#endif
-

--- a/src/analysisd/output/jsonout.c
+++ b/src/analysisd/output/jsonout.c
@@ -1,0 +1,32 @@
+/* Copyright (C) 2015 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifdef JSONOUT_OUTPUT_ENABLED
+
+#include "jsonout.h"
+
+#include "alerts/getloglocation.h"
+#include "format/to_json.h"
+
+
+void jsonout_output_event(const Eventinfo *lf)
+{
+    char *json_alert = Eventinfo_to_jsonstr(lf);
+
+    fprintf(_jflog,
+            "%s\n",
+            json_alert);
+
+    fflush(_jflog);
+    free(json_alert);
+    return;
+}
+
+#endif
+

--- a/src/analysisd/output/jsonout.h
+++ b/src/analysisd/output/jsonout.h
@@ -7,8 +7,6 @@
  * Foundation.
  */
 
-#ifdef JSONOUT_OUTPUT_ENABLED
-
 #ifndef _JSONOUT_H_
 #define _JSONOUT_H_
 
@@ -17,5 +15,3 @@
 void jsonout_output_event(const Eventinfo *lf);
 
 #endif /* _JSONOUT_H_ */
-
-#endif /* JSONOUT_OUTPUT_ENABLED */

--- a/src/analysisd/output/jsonout.h
+++ b/src/analysisd/output/jsonout.h
@@ -1,0 +1,21 @@
+/* Copyright (C) 2015 Trend Micro Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifdef JSONOUT_OUTPUT_ENABLED
+
+#ifndef _JSONOUT_H_
+#define _JSONOUT_H_
+
+#include "eventinfo.h"
+
+void jsonout_output_event(const Eventinfo *lf);
+
+#endif /* _JSONOUT_H_ */
+
+#endif /* JSONOUT_OUTPUT_ENABLED */

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -105,6 +105,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
     const char *xml_prelude_log_level = "prelude_log_level";
     const char *xml_zeromq_output = "zeromq_output";
     const char *xml_zeromq_output_uri = "zeromq_uri";
+    const char *xml_jsonout_output = "jsonout_output";
     const char *xml_stats = "stats";
     const char *xml_memorysize = "memory_size";
     const char *xml_white_list = "white_list";
@@ -259,6 +260,21 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
         } else if (strcmp(node[i]->element, xml_zeromq_output_uri) == 0) {
             if (Config) {
                 Config->zeromq_output_uri = strdup(node[i]->content);
+            }
+        }
+        /* jsonout output */
+        else if (strcmp(node[i]->element, xml_jsonout_output) == 0) {
+            if (strcmp(node[i]->content, "yes") == 0) {
+                if (Config) {
+                    Config->jsonout_output = 1;
+                }
+            } else if (strcmp(node[i]->content, "no") == 0) {
+                if (Config) {
+                    Config->jsonout_output = 0;
+                }
+            } else {
+                merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
+                return (OS_INVALID);
             }
         }
         /* Log all */

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -36,6 +36,9 @@ typedef struct __Config {
     u_int8_t zeromq_output;
     char *zeromq_output_uri;
 
+    /* JSONOUT Export */
+    u_int8_t jsonout_output;
+
     /* Picviz support */
     u_int8_t picviz;
     char *picviz_socket;

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -170,12 +170,13 @@ http://www.ossec.net/main/license/\n"
 #endif
 
 /* Log directories */
-#define EVENTS          "/logs/archives"
-#define EVENTS_DAILY    "/logs/archives/archives.log"
-#define ALERTS          "/logs/alerts"
-#define ALERTS_DAILY    "/logs/alerts/alerts.log"
-#define FWLOGS          "/logs/firewall"
-#define FWLOGS_DAILY    "/logs/firewall/firewall.log"
+#define EVENTS            "/logs/archives"
+#define EVENTS_DAILY      "/logs/archives/archives.log"
+#define ALERTS            "/logs/alerts"
+#define ALERTS_DAILY      "/logs/alerts/alerts.log"
+#define ALERTSJSON_DAILY  "/logs/alerts/alerts.json"
+#define FWLOGS            "/logs/firewall"
+#define FWLOGS_DAILY      "/logs/firewall/firewall.log"
 
 /* Stats directories */
 #define STATWQUEUE  "/stats/weekly-average"

--- a/src/monitord/manage_files.c
+++ b/src/monitord/manage_files.c
@@ -91,7 +91,6 @@ void manage_files(int cday, int cmon, int cyear)
     OS_SignLog(alogfile, alogfile_old, 1);
     OS_CompressLog(alogfile);
 
-#ifdef JSONOUT_OUTPUT_ENABLED
     /* alert logfile  */
     snprintf(ajlogfile, OS_FLSIZE, "%s/%d/%s/ossec-%s-%02d.json",
              ALERTS,
@@ -125,7 +124,6 @@ void manage_files(int cday, int cmon, int cyear)
         OS_SignLog(ajlogfile, ajlogfile_old, 1);
         OS_CompressLog(ajlogfile);
     }
-#endif
 
     /* firewall events */
     snprintf(flogfile, OS_FLSIZE, "%s/%d/%s/ossec-%s-%02d.log",

--- a/src/monitord/manage_files.c
+++ b/src/monitord/manage_files.c
@@ -30,6 +30,9 @@ void manage_files(int cday, int cmon, int cyear)
     char alogfile[OS_FLSIZE + 1];
     char alogfile_old[OS_FLSIZE + 1];
 
+    char ajlogfile[OS_FLSIZE + 1];
+    char ajlogfile_old[OS_FLSIZE + 1];
+
     char flogfile[OS_FLSIZE + 1];
     char flogfile_old[OS_FLSIZE + 1];
 
@@ -46,6 +49,8 @@ void manage_files(int cday, int cmon, int cyear)
     memset(elogfile_old, '\0', OS_FLSIZE + 1);
     memset(alogfile, '\0', OS_FLSIZE + 1);
     memset(alogfile_old, '\0', OS_FLSIZE + 1);
+    memset(ajlogfile, '\0', OS_FLSIZE + 1);
+    memset(ajlogfile_old, '\0', OS_FLSIZE + 1);
     memset(flogfile, '\0', OS_FLSIZE + 1);
     memset(flogfile_old, '\0', OS_FLSIZE + 1);
 
@@ -85,6 +90,42 @@ void manage_files(int cday, int cmon, int cyear)
              pp_old->tm_mday);
     OS_SignLog(alogfile, alogfile_old, 1);
     OS_CompressLog(alogfile);
+
+#ifdef JSONOUT_OUTPUT_ENABLED
+    /* alert logfile  */
+    snprintf(ajlogfile, OS_FLSIZE, "%s/%d/%s/ossec-%s-%02d.json",
+             ALERTS,
+             cyear,
+             months[cmon],
+             "alerts",
+             cday);
+    /* alert logfile old  */
+    snprintf(ajlogfile_old, OS_FLSIZE, "%s/%d/%s/ossec-%s-%02d.json",
+             ALERTS,
+             pp_old->tm_year + 1900,
+             months[pp_old->tm_mon],
+             "alerts",
+             pp_old->tm_mday);
+
+    int exists = 0;
+    FILE *fopnetest;
+
+    if ((fopnetest = fopen(ajlogfile, "r"))) {
+        exists = 1;
+        fclose(fopnetest);
+    }
+
+    if ((fopnetest = fopen(ajlogfile_old, "r"))) {
+        exists = 1;
+        fclose(fopnetest);
+    }
+
+    if (exists) {
+        /* Only if there is a file to operate on. */
+        OS_SignLog(ajlogfile, ajlogfile_old, 1);
+        OS_CompressLog(ajlogfile);
+    }
+#endif
 
     /* firewall events */
     snprintf(flogfile, OS_FLSIZE, "%s/%d/%s/ossec-%s-%02d.log",


### PR DESCRIPTION
Install as normal

    ./install.sh

Enable jsonout in global section of ossec.conf:

    <jsonout_output>yes</jsonout_output>

View the current output file at ossec/logs/alerts/alerts.json