### PR TITLE
add decoder and rules for Apache ModSecurity module

### DIFF
--- a/contrib/ossec-testing/tests/modsecurity.ini
+++ b/contrib/ossec-testing/tests/modsecurity.ini
@@ -1,0 +1,20 @@
+[ModSecurity Warning messages grouped]
+log 1 pass = [Mon Feb 09 16:47:55.974089 2015] [:error] [pid 17675] [client 172.16.10.87] ModSecurity: Warning. Operator GE matched 4 at TX:outbound_anomaly_score. [file "/etc/apache2/ModSecurity/activated_rules/modsecurity_crs_60_correlation.conf"] [line "40"] [id "981205"] [msg "Outbound Anomaly Score Exceeded (score 4): The application is not available"] [hostname "172.16.10.91"] [uri "/wordpress/wp-includes/rss-functions.php"] [unique_id "VNkA238AAQEAAEULYMwAAAAA"]
+log 2 pass = [Thu Jan 22 14:33:30.959520 2015] [:error] [pid 2406] [client 172.16.10.87] ModSecurity: Warning. Pattern match "^(?i)(?:ft|htt)ps?(.*?)\\\\?+$" at ARGS:path_prefix. [file "/etc/apache2/ModSecurity/activated_rules/modsecurity_crs_40_generic_attacks.conf"] [line "160"] [id "950119"] [rev "2"] [msg "Remote File Inclusion Attack"] [data "Matched Data: http://cirt.net/rfiinc.txt? found within ARGS:path_prefix: http://cirt.net/rfiinc.txt?"] [severity "CRITICAL"] [ver "OWASP_CRS/2.2.9"] [maturity "9"] [accuracy "9"] [tag "OWASP_CRS/WEB_ATTACK/RFI"] [hostname "172.16.10.91"] [uri "/wordpress/web/BetaBlockModules//Module/Module.php"] [unique_id "VMEmWn8AAQEAAAlmdHgAAAAI"]
+rule = 30401
+alert = 0
+decoder = apache-errorlog
+
+[ModSecurity Audit log messages grouped]
+log 1 pass = [Mon Feb 09 21:17:06.798110 2015] [:error] [pid 8608] [client 172.16.10.57] ModSecurity: Audit log: Failed writing (requested 83 bytes, written 24): No space left on device [hostname "172.16.10.91"] [uri "/403.php"] [unique_id "VNk-8n8AAQEAACGg7LEAAAAE"]
+log 2 pass = [Wed Feb 11 19:46:12.759594 2015] [:error] [pid 1130] [client 172.16.10.91] ModSecurity: Audit log: Failed to lock global mutex: Identifier removed [hostname "172.16.10.91"] [uri "/wordpress/wp-cron.php"] [unique_id "VNvLw38AAQEAAARqTXsAAAAD"]
+rule = 30403
+alert = 0
+decoder = apache-errorlog
+
+[ModSecurity rejected a query]
+log 1 pass = [Mon Feb 09 16:47:55.908176 2015] [:error] [pid 17679] [client 172.16.10.91] ModSecurity: Access denied with code 403 (phase 2). Operator EQ matched 0 at REQUEST_HEADERS. [file "/etc/apache2/ModSecurity/activated_rules/modsecurity_crs_21_protocol_anomalies.conf"] [line "47"] [id "960015"] [rev "1"] [msg "Request Missing an Accept Header"] [severity "NOTICE"] [ver "OWASP_CRS/2.2.9"] [maturity "9"] [accuracy "9"] [tag "OWASP_CRS/PROTOCOL_VIOLATION/MISSING_HEADER_ACCEPT"] [tag "WASCTC/WASC-21"] [tag "OWASP_TOP_10/A7"] [tag "PCI/6.5.10"] [hostname "172.16.10.91"] [uri "/wordpress/wp-cron.php"] [unique_id "VNkA238AAQEAAEUP9hIAAAAI"]
+log 2 pass = [Mon Feb 09 16:47:55.973954 2015] [:error] [pid 17675] [client 172.16.10.87] ModSecurity: Access denied with code 403 (phase 4). Pattern match "^5\\\\d{2}$" at RESPONSE_STATUS. [file "/etc/apache2/ModSecurity/activated_rules/modsecurity_crs_50_outbound.conf"] [line "53"] [id "970901"] [rev "2"] [msg "The application is not available"] [data "Matched Data: 500 found within RESPONSE_STATUS: 500"] [severity "ERROR"] [ver "OWASP_CRS/2.2.9"] [maturity "9"] [accuracy "9"] [tag "WASCTC/WASC-13"] [tag "OWASP_TOP_10/A6"] [tag "PCI/6.5.6"] [hostname "172.16.10.91"] [uri "/wordpress/wp-includes/rss-functions.php"] [unique_id "VNkA238AAQEAAEULYMwAAAAA"]
+rule = 30411
+alert = 7
+decoder = apache-errorlog

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1540,15 +1540,15 @@
   <regex offset="after_prematch">^ (\S+):\d+] (\S+): </regex>
   <order>srcip,id</order>
 </decoder>
-<!--
-<decoder name="apache24-modsec-errorlog-ip">
-	<parent>apache-errorlog</parent>
 
-	<prematch offset="after_parent">[client</prematch>
-	<regex offset="after_prematch">^ (\S+)] ModSecurity: </regex>
-	<order>srcip</order>
+<decoder name="apache24-modsec-errorlog-ip">
+  <parent>apache-errorlog</parent>
+
+  <prematch offset="after_parent">[client</prematch>
+  <regex offset="after_prematch">^ (\S+)] ModSecurity: </regex>
+  <order>srcip</order>
 </decoder>
--->
+
 <decoder name="apache-errorlog-ip">
   <parent>apache-errorlog</parent>
 

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1530,17 +1530,25 @@
 </decoder>
 
 <decoder name="apache-errorlog">
-    <prematch>^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:warn] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:notice] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S*:error] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:info] </prematch>
+  <prematch>^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:warn] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:notice] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S*:error] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:info] </prematch>
 </decoder>
 
 <decoder name="apache24-errorlog-ip">
-    <parent>apache-errorlog</parent>
+  <parent>apache-errorlog</parent>
 
-    <prematch offset="after_parent">[client</prematch>
-    <regex offset="after_prematch">^ (\S+):\d+] (\S+): </regex>
-    <order>srcip,id</order>
+  <prematch offset="after_parent">[client</prematch>
+  <regex offset="after_prematch">^ (\S+):\d+] (\S+): </regex>
+  <order>srcip,id</order>
 </decoder>
+<!--
+<decoder name="apache24-modsec-errorlog-ip">
+	<parent>apache-errorlog</parent>
 
+	<prematch offset="after_parent">[client</prematch>
+	<regex offset="after_prematch">^ (\S+)] ModSecurity: </regex>
+	<order>srcip</order>
+</decoder>
+-->
 <decoder name="apache-errorlog-ip">
   <parent>apache-errorlog</parent>
 

--- a/etc/rules/apache_rules.xml
+++ b/etc/rules/apache_rules.xml
@@ -15,26 +15,26 @@
   -  Contributed by: Ahmet Ozturk
   -                  Ben Chavet <ben.chavet@lullabot.com>
   -->
-                        
+
 
 <group name="apache,">
   <rule id="30100" level="0">
     <decoded_as>apache-errorlog</decoded_as>
     <description>Apache messages grouped.</description>
-  </rule>    
+  </rule>
 
   <rule id="30101" level="0">
     <if_sid>30100</if_sid>
     <match>^[error] </match>
     <description>Apache error messages grouped.</description>
   </rule>
-  
+
   <rule id="30102" level="0">
     <if_sid>30100</if_sid>
     <match>^[warn] </match>
     <description>Apache warn messages grouped.</description>
   </rule>
-  
+
   <rule id="30103" level="0">
     <if_sid>30100</if_sid>
     <match>^[notice] </match>
@@ -98,7 +98,7 @@
     <match>File does not exist: |</match>
     <match>failed to open stream: No such file or directory|</match>
     <match>Failed opening </match>
-    <description>Attempt to access an non-existent file (those are reported on the access.log).</description> 
+    <description>Attempt to access an non-existent file (those are reported on the access.log).</description>
     <group>unknown_resource,</group>
   </rule>
 
@@ -141,14 +141,14 @@
     <description>Multiple attempts blocked by Mod Security.</description>
     <group>access_denied,</group>
   </rule>
-  
+
   <rule id="30120" level="12">
     <if_sid>30101</if_sid>
     <match>Resource temporarily unavailable:</match>
     <description>Apache without resources to run.</description>
     <group>service_availability,</group>
   </rule>
-  
+
   <rule id="30200" level="6" noalert="1">
     <match>^mod_security-message: </match>
     <description>Modsecurity alert.</description>
@@ -160,7 +160,7 @@
     <description>Modsecurity access denied.</description>
     <group>access_denied,</group>
   </rule>
-  
+
   <rule id="30202" level="10" frequency="8" timeframe="120">
     <if_matched_sid>30201</if_matched_sid>
     <description>Multiple attempts blocked by Mod Security.</description>
@@ -273,6 +273,31 @@
     <if_sid>30301</if_sid>
     <match>PHP Notice:</match>
     <description>PHP Notice in Apache log</description>
+  </rule>
+
+  <!-- Apache 2.4 ModSecurity Rules -->
+  <rule id="30401" level="0">
+    <if_sid>30301</if_sid>
+    <match>ModSecurity: Warning</match>
+    <description>ModSecurity Warning messages grouped</description>
+  </rule>
+
+  <rule id="30402" level="0">
+    <if_sid>30301</if_sid>
+    <match>ModSecurity: Access denied</match>
+    <description>ModSecurity Access denied messages grouped</description>
+  </rule>
+
+  <rule id="30403" level="0">
+    <if_sid>30301</if_sid>
+    <match>ModSecurity: Audit log:</match>
+    <description>ModSecurity Audit log messages grouped</description>
+  </rule>
+
+  <rule id="30411" level="7">
+    <if_sid>30402</if_sid>
+    <match>with code 403</match>
+    <description>ModSecurity rejected a query</description>
   </rule>
 </group> <!-- ERROR_LOG,APACHE -->
 


### PR DESCRIPTION
- only works for Apache 2.4 style format
- only one rule that triggers AR when ModSecurity blocked something
- on my system the pam.ini unit test fails but I didn't touch that