### PR TITLE
Rsyslog rate-limiting message

### DIFF
--- a/contrib/ossec-testing/tests/syslog.ini
+++ b/contrib/ossec-testing/tests/syslog.ini
@@ -21,7 +21,7 @@ alert = 3
 decoder = NetworkManager
 
 [rsyslog may be dropping messages due to rate-limiting.]
-log 1 pass = Feb  5 13:07:52 plugh rsyslogd-2177: imuxsock begins to drop messages from pid 12105 due to rate-limiting
+log 1 fail = Feb  5 13:07:52 plugh rsyslogd-2177: imuxsock begins to drop messages from pid 12105 due to rate-limiting
 
 rule = 2945
 alert = 4

--- a/contrib/ossec-testing/tests/syslog.ini
+++ b/contrib/ossec-testing/tests/syslog.ini
@@ -20,4 +20,10 @@ rule = 2941
 alert = 3
 decoder = NetworkManager
 
+[rsyslog may be dropping messages due to rate-limiting.]
+log 1 pass = Feb  5 13:07:52 plugh rsyslogd-2177: imuxsock begins to drop messages from pid 12105 due to rate-limiting
+
+rule = 2945
+alert = 1
+decoder = 
 

--- a/contrib/ossec-testing/tests/syslog.ini
+++ b/contrib/ossec-testing/tests/syslog.ini
@@ -24,6 +24,6 @@ decoder = NetworkManager
 log 1 pass = Feb  5 13:07:52 plugh rsyslogd-2177: imuxsock begins to drop messages from pid 12105 due to rate-limiting
 
 rule = 2945
-alert = 1
+alert = 4
 decoder = 
 

--- a/etc/rules/syslog_rules.xml
+++ b/etc/rules/syslog_rules.xml
@@ -678,6 +678,12 @@
     <description>Uninteresting nouveau error.</description>
   </rule>
 
+  <rule id="2945" level="4">
+    <program_name>^rsyslogd</program_name>
+    <match>^imuxsock begins to drop messages </match>
+    <info>https://isc.sans.edu/diary/Are+you+losing+system+logging+information+%28and+don%27t+know+it%29%3F/15106</info>
+    <description>rsyslog may be dropping messages due to rate-limiting.</description>
+  </rule>
 
 </group>
 


### PR DESCRIPTION
It looks like ossec-logtest -U does not appreciate blank decoders.