### PR TITLE
Fix call to StartMQ() in HandleClient() for syslog

### DIFF
--- a/src/remoted/syslog.c
+++ b/src/remoted/syslog.c
@@ -99,7 +99,7 @@ void HandleSyslog()
         else if (SendMSG(logr.m_queue, buffer_pt, srcip,
                          SYSLOG_MQ) < 0) {
             merror(QUEUE_ERROR, ARGV0, DEFAULTQUEUE, strerror(errno));
-            if ((logr.m_queue = StartMQ(DEFAULTQUEUE, READ)) < 0) {
+            if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
                 ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQUEUE);
             }
         }


### PR DESCRIPTION
This is similar to c63fe2de except for syslog (UDP). The StartMQ() call
is using READ instead of WRITE when an error is encountered with the
queue. The code earlier when HandleSyslog() is initially started uses
WRITE as well when calling StartMQ().