### PR TITLE
Add a small sleep to realtime syscheck 

### DIFF
--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -194,6 +194,11 @@ int realtime_process()
                 snprintf(final_name, MAX_LINE, "%s/%s",
                          (char *)OSHash_Get(syscheck.realtime->dirtb, wdchar),
                          event->name);
+		/* Need a sleep here to avoid triggering on vim edits
+  		 * (and finding the file removed)
+  		 */
+		sleep(1);
+
                 realtime_checksumfile(final_name);
             }
 


### PR DESCRIPTION
This should get rid of some file deleted false positives. Seems easier than banishing vim.
From dcid commit:  0f533bb
https://bitbucket.org/dcid/ossec-hids/commits/0f533bb5843a87d7a59a4c0b223c700252d3f446