### PR TITLE
Fixed deletion detection

### DIFF
--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -59,8 +59,17 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
     if (lstat(file_name, &statbuf) < 0)
 #endif
     {
-        merror("%s: Error accessing '%s'.", ARGV0, file_name);
-        return (-1);
+        if(errno == ENOTDIR){
+		/*Deletion message sending*/
+		char alert_msg[PATH_MAX+4];
+		alert_msg[PATH_MAX + 3] = '\0';
+		snprintf(alert_msg, PATH_MAX + 4, "-1 %s", file_name);
+		send_syscheck_msg(alert_msg);
+		return (0);
+	}else{
+		merror("%s: Error accessing '%s'.", ARGV0, file_name);
+		return (-1);
+	}
     }
 
     if (S_ISDIR(statbuf.st_mode)) {

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -320,10 +320,10 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     if (lstat(file_name, &statbuf) < 0)
 #endif
     {
-        char alert_msg[912 + 2];
+        char alert_msg[PATH_MAX+4];
 
-        alert_msg[912 + 1] = '\0';
-        snprintf(alert_msg, 912, "-1 %s", file_name);
+        alert_msg[PATH_MAX + 3] = '\0';
+        snprintf(alert_msg, PATH_MAX + 4, "-1 %s", file_name);
         send_syscheck_msg(alert_msg);
 
         return (-1);
@@ -366,11 +366,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     }
 
     /* Generate new checksum */
-#ifdef WIN32
     if (S_ISREG(statbuf.st_mode))
-#else
-    if (S_ISREG(statbuf.st_mode))
-#endif
     {
         if (sha1sum || md5sum) {
             /* Generate checksums of the file */


### PR DESCRIPTION
This modification creates a fix for detecting the deletion of files on each scan. This pull request is based on Gaelmullers syscheck improvements (pull request #5 ).
The second modification is for removing redundant code in run_check.c where that check is not needed as both give the same result.