### PR TITLE
Adjusting named decoder for bind 9.9 logging change

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -816,7 +816,7 @@
 <decoder name="named-query">
   <parent>named</parent>
   <prematch>: query: </prematch>
-  <regex>client (\S+)#\d+: query: (\S+) IN </regex>
+  <regex>client (\S+)#\d+\s*\S*: query: (\S+) IN </regex>
   <order>srcip,url</order>
 </decoder>
 


### PR DESCRIPTION
Bind 9.9 changed the query logging.
Before 9.9:
Apr 14 09:30:45 station7 named[5893]: client 127.0.0.1#54819: query: daisy.ubuntu.com IN AAAA + (127.0.0.1)
Since 9.9:
Apr 14 09:30:45 station7 named[5893]: client 127.0.0.1#54819 (daisy.ubuntu.com): query: daisy.ubuntu.com IN AAAA + (127.0.0.1)

The decoder has been changed to reflect this.