### PR TITLE
if_not_sid tag

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -10,6 +10,7 @@
 /* ossec-analysisd
  * Responsible for correlation and log decoding
  */
+#define MATCHED_SID_ARRAY_SIZE 200000
 
 #ifndef ARGV0
 #define ARGV0 "ossec-analysisd"
@@ -527,6 +528,9 @@ void OS_ReadMSG_analysisd(int m_queue)
     char msg[OS_MAXSTR + 1];
     Eventinfo *lf;
 
+    int matched_sids[MATCHED_SID_ARRAY_SIZE];
+    int matched_sids_index=0;
+ 
     RuleInfo *stats_rule = NULL;
 
     /* Null to global currently pointers */
@@ -866,6 +870,28 @@ void OS_ReadMSG_analysisd(int m_queue)
                          == NULL) {
                     continue;
                 }
+
+               /* if any of the rules has a if_not_sid that match a previous matched rules will be ignored  */
+               if (matched_sids_index < MATCHED_SID_ARRAY_SIZE)
+               {
+               matched_sids[matched_sids_index] = currently_rule->sigid;
+               matched_sids_index++;
+               int break_loop = 0; //false
+               if (currently_rule->if_not_sid)
+               {
+                 int i;
+                 for (i=0; i++; i<matched_sids_index)
+                       { int not_sid = strtol(currently_rule->if_not_sid, NULL,10);
+                          if (not_sid == matched_sids[i]);
+                               {
+                                       break_loop = 1; //true
+                                       break;
+                               }
+                       }
+               if (break_loop == 1)
+                       break;
+               }
+               }
 
                 /* Ignore level 0 */
                 if (currently_rule->level == 0) {

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -95,6 +95,7 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_if_group = "if_group";
     const char *xml_if_level = "if_level";
     const char *xml_fts = "if_fts";
+    const char *xml_if_not_sid = "if_not_sid";
 
     const char *xml_if_matched_regex = "if_matched_regex";
     const char *xml_if_matched_group = "if_matched_group";
@@ -722,7 +723,14 @@ int Rules_OP_ReadRules(const char *rulefile)
                         config_ruleinfo->if_sid =
                             loadmemory(config_ruleinfo->if_sid,
                                        rule_opt[k]->content);
-                    } else if (strcasecmp(rule_opt[k]->element, xml_if_level) == 0) {
+                    }
+                    else if(strcasecmp(rule_opt[k]->element,xml_if_not_sid)==0)
+                    {
+                        config_ruleinfo->if_not_sid=
+                            loadmemory(config_ruleinfo->if_not_sid,
+                                    rule_opt[k]->content);
+                    }
+		     else if (strcasecmp(rule_opt[k]->element, xml_if_level) == 0) {
                         if (!OS_StrIsNum(rule_opt[k]->content)) {
                             merror(INVALID_CONFIG, ARGV0,
                                    "if_level",
@@ -1359,6 +1367,8 @@ RuleInfo *zerorulemember(int id, int level,
     ruleinfo_pt->if_sid = NULL;
     ruleinfo_pt->if_group = NULL;
     ruleinfo_pt->if_level = NULL;
+
+    ruleinfo_pt->if_not_sid = NULL;
 
     ruleinfo_pt->if_matched_regex = NULL;
     ruleinfo_pt->if_matched_group = NULL;

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -148,6 +148,7 @@ typedef struct _RuleInfo {
     char *if_sid;
     char *if_level;
     char *if_group;
+    char *if_not_sid;
 
     OSRegex *if_matched_regex;
     OSMatch *if_matched_group;


### PR DESCRIPTION
Hello,

this pull request is for the creation of the "\<if_not_sid\>" tag. It basically allows to setup exclusions for patterns matched within the log line. In the example below I want to match the "bar" pattern for a certain event, but for the same event I want to not raise an alert if the "foo" string is present as well.

\<group name="local,syslog,"\>

\<rule id="100002" level="0"\>
    \<if_sid\>5710\</if_sid\>
    \<match\>foo\</match\>
    \<description\>testfoo\</description\>
 \</rule\>
 
 \<rule id="100003" level="8"\>
    \<if_sid\>5710\</if_sid\>
    \<if_not_sid\>1000002\</if_not_sid\>
    \<match\>bar\</match\>
    \<description\>foo pattern exclusion\</description\>
 \</rule\>   

analysisd stores the matched sids used for comparison within an array which in my patch has a fixed size. I'm not sure this is the best option although the maximum size I think has a reasonable value.