### PR TITLE
fstat files that do not exist produces excessive errors from the nfs check

### DIFF
--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -41,7 +41,9 @@ short IsNFS(const char *dir_name)
     else
     {
         /* Throw an error and retreat! */
-        merror("ERROR: statfs('%s') produced error: %s", dir_name, strerror(errno));
+	if(errno != ENOENT) {
+        	merror("ERROR: statfs('%s') produced error: %s", dir_name, strerror(errno));
+	}
         return(-1);
     }
 #else


### PR DESCRIPTION
I'm not sure where OSSEC was getting the filenames, but I received a lot of log spam for files that did not exist. So, set this to noterror on files that don't exist.

2015/04/21 22:53:52 ERROR: statfs('/var/htdocs') produced error: No such file or directory
2015/04/21 22:53:52 ERROR: statfs('/home/httpd') produced error: No such file or directory
2015/04/21 22:53:52 ERROR: statfs('/usr/local/apache') produced error: No such file or directory
2015/04/21 22:53:52 ERROR: statfs('/usr/local/apache2') produced error: No such file or directory
2015/04/21 22:53:52 ERROR: statfs('/usr/local/www') produced error: No such file or directory
