### PR TITLE
Sysmon EventID#1 Decoder & Rules

### DIFF
--- a/contrib/ossec-testing/tests/sysmon.ini
+++ b/contrib/ossec-testing/tests/sysmon.ini
@@ -1,0 +1,11 @@
+[Sysmon EventID#1 - Suspicious svchost process]
+log 1 pass = 2014 Dec 20 14:29:48 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE
+rule = 184666
+alert = 12
+decoder = Sysmon-EventID#1
+
+[Sysmon EventID#1 - non-Suspicious svchost process]
+log 1 pass = 2014 Dec 20 12:15:13 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 12:15 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\windows\system32\svchost.exe -k defragsvc"  User: NT AUTHORITY\SYSTEM  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\System32\services.exe  ParentCommandLine: C:\Windows\System32\services.exe
+rule = 184667
+alert = 0
+decoder = Sysmon-EventID#1

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -2595,6 +2595,27 @@ Author and (c): Michael Starks, 2014 -->
   <order>srcuser</order>
 </decoder>
 
+<!-- 
+  - Decoder for Sysmon Event ID 1: Process Created
+  - Maintained by Josh Brower, Josh@DefensiveDepth.com 
+  -
+  -  OSSEC to Sysmon Fields Mapping:
+  -  user = User
+  -  status = Image
+  -  url = Hash
+  -  extra_data = ParentImage
+  
+  - Examples:
+  - 2014 Dec 20 14:29:48 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE 
+-->
+
+<decoder name="Sysmon-EventID#1">
+<type>windows</type>
+<prematch>INFORMATION\(1\)</prematch>
+<regex offset="after_prematch">Image: (\.*) \s*CommandLine: \.* \s*User: (\.*) \s*LogonGuid: \S* \s*LogonId: \S* \s*TerminalSessionId: \S* \s*IntegrityLevel: \S* \s*HashType: \S* \s*Hash: (\S*) \s*ParentProcessGuid: \S* \s*ParentProcessID: \S* \s*ParentImage: (\.*) \s*ParentCommandLine:</regex>
+<order>status,user,url,data</order>
+</decoder>
+
 
 <!-- unbound
   - 2014-05-20T09:01:07.283219-04:00 arrakis unbound: [9405:0] notice: sendto failed: Can't assign requested address

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -69,6 +69,7 @@
     <include>attack_rules.xml</include>
     <include>systemd_rules.xml</include>
     <include>firewalld_rules.xml</include>
+    <include>sysmon_rules.xml</include>
     <include>local_rules.xml</include>
   </rules>
 

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -67,6 +67,7 @@
     <include>asterisk_rules.xml</include>
     <include>ossec_rules.xml</include>
     <include>attack_rules.xml</include>
+    <include>sysmon_rules.xml</include>    
     <include>local_rules.xml</include>
   </rules>
 

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -28,6 +28,7 @@
     <include>spamd_rules.xml</include>
     <include>msauth_rules.xml</include>
     <include>attack_rules.xml</include>
+    <include>sysmon_rules.xml</include>
   </rules>  
 
   <syscheck>

--- a/etc/rules/sysmon_rules.xml
+++ b/etc/rules/sysmon_rules.xml
@@ -1,0 +1,173 @@
+<!--Maintained by Josh Brower, Josh@DefensiveDepth.com -->
+<!--Licensed under the MIT License: http://opensource.org/licenses/MIT-->
+
+<!-- Ruleset to detect Windows Process Anomalies - 
+  -  Uses Sysmon Event ID 1 logs & associated decoder.
+  -  Currently only looks at Parent Image Anomalies.
+  -  Windows Process Attributes documentation here: http://defensivedepth.com/windows-processes
+  -
+  -  OSSEC to Sysmon (Event ID 1) Fields Mapping:
+  -  user = User
+  -  status = Image
+  -  url = Hash
+  -  extra_data = ParentImage
+  -->
+  
+<group name="sysmon_process-anomalies">
+  
+ <rule id="184666" level="12">
+  <if_sid>18100</if_sid>
+  <status>svchost.exe</status>
+  <description>Sysmon - Suspicious Process - svchost.exe</description>
+ </rule>
+
+ <rule id="184667" level="0">
+  <if_sid>184666</if_sid>
+  <extra_data>\services.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - svchost.exe</description>
+ </rule>
+
+
+<rule id="184676" level="12">
+  <if_sid>18100</if_sid>
+  <status>lsm.exe</status>
+  <description>Sysmon - Suspicious Process - lsm.exe</description>
+</rule>
+
+<rule id="184677" level="0">
+  <if_sid>184676</if_sid>
+  <extra_data>wininit.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - lsm.exe</description>
+</rule>
+
+<rule id="184678" level="12">
+  <if_sid>18100</if_sid>
+  <extra_data>lsm.exe</extra_data>
+  <description>Sysmon - Suspicious Process - lsm.exe is a Parent Image</description>
+</rule>
+
+
+<rule id="184686" level="12">
+  <if_sid>18100</if_sid>
+  <status>csrss.exe</status>
+  <description>Sysmon - Suspicious Process - csrss.exe</description>
+</rule>
+
+<rule id="184687" level="0">
+  <if_sid>184686</if_sid>
+  <extra_data>smss.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - csrss.exe</description>
+</rule>
+
+
+<rule id="184696" level="12">
+  <if_sid>18100</if_sid>
+  <status>lsass.exe</status>
+  <description>Sysmon - Suspicious Process - lsass</description>
+</rule>
+
+<rule id="184697" level="0">
+  <if_sid>184696</if_sid>
+  <extra_data>wininit.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - lsass.exe</description>
+</rule>
+
+<rule id="184698" level="12">
+  <if_sid>18100</if_sid>
+  <extra_data>lsass.exe</extra_data>
+  <description>Sysmon - Suspicious Process - lsass.exe is a Parent Image</description>
+</rule>
+
+
+<rule id="184706" level="12">
+  <if_sid>18100</if_sid>
+  <status>winlogon.exe</status>
+  <description>Sysmon - Suspicious Process - winlogon.exe</description>
+</rule>
+
+<rule id="184707" level="0">
+  <if_sid>184706</if_sid>
+  <extra_data>smss.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - winlogon.exe</description>
+</rule>
+
+
+<rule id="184716" level="12">
+  <if_sid>18100</if_sid>
+  <status>wininit.exe</status>
+  <description>Sysmon - Suspicious Process - wininit</description>
+</rule>
+
+<rule id="184717" level="0">
+  <if_sid>184716</if_sid>
+  <extra_data>smss.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - wininit.exe</description>
+</rule>
+
+
+<rule id="184726" level="12">
+  <if_sid>18100</if_sid>
+  <status>smss.exe</status>
+  <description>Sysmon - Suspicious Process - smss.exe</description>
+</rule>
+
+<rule id="184727" level="0">
+  <if_sid>184726</if_sid>
+  <extra_data>system</extra_data>
+  <description>Sysmon - Legitimate Parent Image - smss.exe</description>
+</rule>
+
+
+<rule id="184736" level="12">
+  <if_sid>18100</if_sid>
+  <status>taskhost.exe</status>
+  <description>Sysmon - Suspicious Process - taskhost.exe</description>
+</rule>
+
+<rule id="184737" level="0">
+  <if_sid>184736</if_sid>
+  <extra_data>services.exe|svchost.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - taskhost.exe</description>
+</rule>
+
+
+<rule id="184746" level="12">
+  <if_sid>18100</if_sid>
+  <status>/services.exe</status>
+  <description>Sysmon - Suspicious Process - services.exe</description>
+</rule>
+
+<rule id="184747" level="0">
+  <if_sid>184746</if_sid>
+  <extra_data>wininit.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - services.exe</description>
+</rule>
+
+
+<rule id="184766" level="12">
+  <if_sid>18100</if_sid>
+  <status>dllhost.exe</status>
+  <description>Sysmon - Suspicious Process - dllhost.exe</description>
+</rule>
+
+<rule id="184767" level="0">
+  <if_sid>184766</if_sid>
+  <extra_data>svchost.exe|services.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - dllhost.exe</description>
+</rule>
+
+
+<rule id="184776" level="12">
+  <if_sid>18100</if_sid>
+  <status>\explorer.exe</status>
+  <description>Sysmon - Suspicious Process - explorer.exe</description>
+</rule>
+
+<rule id="184777" level="0">
+  <if_sid>184776</if_sid>
+  <extra_data>userinit.exe</extra_data>
+  <description>Sysmon - Legitimate Parent Image - explorer.exe</description>
+</rule>
+</group> <!-- sysmon_process-anomalies -->
+
+<!-- EOF -->

--- a/etc/templates/config/rules.template
+++ b/etc/templates/config/rules.template
@@ -60,5 +60,6 @@
     <include>openbsd_rules.xml</include>
     <include>clam_av_rules.xml</include>
     <include>dropbear_rules.xml</include>
+    <include>sysmon_rules.xml</include>
     <include>local_rules.xml</include>
   </rules>  


### PR DESCRIPTION
Adds decoder for [Sysmon] (https://technet.microsoft.com/en-us/sysinternals/dn798348) Event ID 1 logs as well as a ruleset to detect Windows Process Anomalies.

See [this topic] (https://groups.google.com/forum/#!topic/ossec-list/clj2j_8QjEc) for more info.