### PR TITLE
Hopefully solve a FP on OS X

### DIFF
--- a/etc/rules/syslog_rules.xml
+++ b/etc/rules/syslog_rules.xml
@@ -397,7 +397,7 @@
   
   <rule id="5301" level="5">
    <if_sid>5300</if_sid>
-   <match>authentication failure; |failed|BAD su|^-| - </match>
+   <match>authentication failure; |failed|BAD su|^-</match>
    <description>User missed the password to change UID (user id).</description> 
    <group>authentication_failed,</group>
   </rule>


### PR DESCRIPTION
As noted in issue #604, the "-" match triggers this rule for unrelated OS X log messages. I don't see a log sample that this might be correctly used for, so remove it.