### PR TITLE
Correct logging of failed sudo attempts noted in issue #603

### DIFF
--- a/contrib/ossec-testing/tests/sudo.ini
+++ b/contrib/ossec-testing/tests/sudo.ini
@@ -7,3 +7,23 @@ rule = 5403
 alert = 4
 decoder = sudo 
 
+[Failed attempt to run sudo]
+log 1 pass = Jun 25 15:51:13 precise32 sudo:     mike : 1 incorrect password attempt ; TTY=pts/0 ; PWD=/root ; USER=root ; COMMAND=/bin/ls
+
+rule = 5401
+alert = 5
+decoder = sudo
+
+[First time user executed sudo]
+log 1 pass = Jun 25 15:48:21 precise32 sudo:  mike : TTY=pts/0 ; PWD=/home/vagrant ; USER=root ; COMMAND=/bin/su -
+
+rule = 5403
+alert = 4
+decoder = sudo
+
+[3 incorrect password attempts]
+log 1 pass = Jun 25 16:15:45 precise32 sudo:     mike : 3 incorrect password attempts ; TTY=pts/0 ; PWD=/root ; USER=root ; COMMAND=/bin/ls
+
+rule = 5404
+alert = 10
+decoder = sudo

--- a/etc/rules/syslog_rules.xml
+++ b/etc/rules/syslog_rules.xml
@@ -485,10 +485,10 @@
     <description>Initial group for sudo messages</description>
   </rule>
   
-  <rule id="5401" level="10">
+  <rule id="5401" level="5">
     <if_sid>5400</if_sid>
-    <match>3 incorrect password attempts</match>
-    <description>Three failed attempts to run sudo</description>
+    <match>incorrect password attempt</match>
+    <description>Failed attempt to run sudo</description>
   </rule>
 
   <rule id="5402" level="3">
@@ -502,7 +502,13 @@
     <options>alert_by_email</options>
     <if_fts></if_fts>
     <description>First time user executed sudo.</description>
-  </rule>                  
+  </rule>
+
+  <rule id="5404" level="10">
+    <if_sid>5401</if_sid>
+    <match>3 incorrect password attempts</match>
+    <description>Three failed attempts to run sudo</description>
+  </rule>
 </group> <!-- SYSLOG, SUDO -->
 
 


### PR DESCRIPTION
This will fix the incorrect logging of "successful login attempts" form a failed sudo attempt > 3 times.