### PR TITLE
Reduce system load caused by simultaneous active response processes during ossec stop.

### DIFF
--- a/active-response/firewall-drop.sh
+++ b/active-response/firewall-drop.sh
@@ -86,10 +86,7 @@ lock()
             i=`expr $i + 1`;
         fi
 
-        # Sleep 1 after 10/25 interactions
-        if [ "$i" = "10" -o "$i" = "25" ]; then
-            sleep 1;
-        fi
+        sleep $i;
 
         i=`expr $i + 1`;
 

--- a/active-response/firewalld-drop.sh
+++ b/active-response/firewalld-drop.sh
@@ -77,10 +77,7 @@ lock()
             i=`expr $i + 1`;
         fi
 
-        # Sleep 1 after 10/25 interactions
-        if [ "$i" = "10" -o "$i" = "25" ]; then
-            sleep 1;
-        fi
+        sleep $i;
 
         i=`expr $i + 1`;
 

--- a/active-response/host-deny.sh
+++ b/active-response/host-deny.sh
@@ -49,10 +49,7 @@ lock()
             i=`expr $i + 1`;
         fi
    
-        # Sleep 1 after 10/25 interactions
-        if [ "$i" = "10" -o "$i" = "25" ]; then
-            sleep 1;
-        fi
+        sleep $i;
              
         i=`expr $i + 1`;
         


### PR DESCRIPTION
This addresses issue #609 by sleeping on every lock conflict instead of the 10'th or 25'th iteration, and increasing the sleep time successively.  While this may seem non-intuitive, the total time to finish removing all addresses when ossec is stopped is significantly reduced.  Ideally this should be using an exponential backoff but a linear backoff appears to be good enough.