### PR TITLE
Update ssh_asa-fwsmconfig_diff

### DIFF
--- a/src/agentlessd/scripts/ssh_asa-fwsmconfig_diff
+++ b/src/agentlessd/scripts/ssh_asa-fwsmconfig_diff
@@ -77,7 +77,7 @@ if {[string compare $pass "x"] == 0} {
 
 # SSH to the box and pass the directories to check
 if [catch {
-    spawn ssh -c des $hostname
+    spawn ssh -q -c des $hostname
 } loc_error] {
     send_user "ERROR: Opening connection: $loc_error.\n"
     exit 1;
@@ -183,10 +183,15 @@ send_user "\nSTORE: now\n"
 
 send "term pager 0\r"
 
-# Exclude uptime from the output
-send "show version | grep -v Configuration last| up\r"
-send "show running-config\r"
+# Exclude written by name and current date/time from the running-config output.
+send "more system:running-config | grep -v Written\r"
+# Sleep 1.1 seconds to prevent inconsistent number of line feeds near eof.
+sleep 1.1
+# Exclude uptime and botnet traffic filter expiration days from the output.
+send "show version | grep -v Configuration last| up|Botnet\r"
 send "$commands\r"
+# Sleep .3 seconds to prevent inconsistent number of line feeds near eof.
+sleep .3
 send "exit\r"
 
 expect {


### PR DESCRIPTION
Changed 'send "show running-config"' to 'send "more system:running-config"'.  This allows OSSEC to detect changes to preshared keys, such as RADIUS and Tunnel-Groups.  Revealing this information allows OSSEC to do a more thorough job of inspecting the running configuration for changes.  Previously, this information was masked behind five asterisks.

Reversed the order of the output and inserted two sleep commands.  This eliminated false positive alerts due to an inconsistent number of line feeds at the end of the file.  Adding two sleep commands and moving the larger portion of the data to the top of the file has eliminated the issue in my testing.