### PR TITLE
Binding src IP to 'local_ip' config value in agentd.

### DIFF
--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -84,10 +84,13 @@ int connect_server(int initial_id)
         /* IPv6 address */
         if (strchr(tmp_str, ':') != NULL) {
             verbose("%s: INFO: Using IPv6 (%s).", ARGV0, tmp_str);
-            agt->sock = OS_ConnectUDP(agt->port, tmp_str, 1);
+            agt->sock = OS_ConnectUDP(agt->port, tmp_str, 1, NULL);
         } else {
             verbose("%s: INFO: Using IPv4 (%s).", ARGV0, tmp_str);
-            agt->sock = OS_ConnectUDP(agt->port, tmp_str, 0);
+            if(agt->lip) {
+                verbose("%s: INFO: Bind to src ip: %s", ARGV0, agt->lip);
+            }
+            agt->sock = OS_ConnectUDP(agt->port, tmp_str, 0, agt->lip);
         }
 
         if (agt->sock < 0) {

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -234,7 +234,7 @@ int main(int argc, char **argv)
     }
 
     /* Connect via TCP */
-    sock = OS_ConnectTCP(port, ipaddress, 0);
+    sock = OS_ConnectTCP(port, ipaddress, 0, NULL);
     if (sock <= 0) {
         merror("%s: Unable to connect to %s:%d", ARGV0, ipaddress, port);
         exit(1);

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -50,7 +50,7 @@ void OS_CSyslogD(SyslogConfig **syslog_config)
     s = 0;
     while (syslog_config[s]) {
         syslog_config[s]->socket = OS_ConnectUDP(syslog_config[s]->port,
-                                   syslog_config[s]->server, 0);
+                                   syslog_config[s]->server, 0, NULL);
         if (syslog_config[s]->socket < 0) {
             merror(CONNS_ERROR, ARGV0, syslog_config[s]->server);
         } else {

--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -55,7 +55,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     buffer[2048] = '\0';
 
     /* Connect to the SMTP server */
-    socket = OS_ConnectTCP(SMTP_DEFAULT_PORT, smtpserver, 0);
+    socket = OS_ConnectTCP(SMTP_DEFAULT_PORT, smtpserver, 0, NULL);
     if (socket < 0) {
         return (socket);
     }

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -55,7 +55,7 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg)
     char final_to[512];
 
     /* Connect to the SMTP server */
-    socket = OS_ConnectTCP(SMTP_DEFAULT_PORT, mail->smtpserver, 0);
+    socket = OS_ConnectTCP(SMTP_DEFAULT_PORT, mail->smtpserver, 0, NULL);
     if (socket < 0) {
         return (socket);
     }
@@ -260,7 +260,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     }
 
     /* Connect to the SMTP server */
-    socket = OS_ConnectTCP(SMTP_DEFAULT_PORT, mail->smtpserver, 0);
+    socket = OS_ConnectTCP(SMTP_DEFAULT_PORT, mail->smtpserver, 0, NULL);
     if (socket < 0) {
         return (socket);
     }

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -33,8 +33,8 @@ int OS_getsocketsize(int ossock);
 /* OS_Connect
  * Connect to a TCP/UDP socket
  */
-int OS_ConnectTCP(u_int16_t _port, const char *_ip, int ipv6);
-int OS_ConnectUDP(u_int16_t _port, const char *_ip, int ipv6);
+int OS_ConnectTCP(u_int16_t _port, const char *_ip, int ipv6, const char *_lip);
+int OS_ConnectUDP(u_int16_t _port, const char *_ip, int ipv6, const char *_lip);
 
 /* OS_RecvUDP
  * Receive a UDP packet. Return NULL if failed

--- a/src/tests/test_os_net.c
+++ b/src/tests/test_os_net.c
@@ -32,7 +32,7 @@ START_TEST(test_tcpv4_local)
 
     ck_assert_int_ge((server_root_socket = OS_Bindporttcp(PORT, IPV4, 0)), 0);
 
-    ck_assert_int_ge((client_socket = OS_ConnectTCP(PORT, IPV4, 0)) , 0);
+    ck_assert_int_ge((client_socket = OS_ConnectTCP(PORT, IPV4, 0, NULL)) , 0);
 
     ck_assert_int_ge((server_client_socket = OS_AcceptTCP(server_root_socket, ipbuffer, BUFFERSIZE)), 0);
 
@@ -67,7 +67,7 @@ START_TEST(test_tcpv4_inet)
 
     ck_assert_int_ge((server_root_socket = OS_Bindporttcp(PORT, NULL, 0)), 0);
 
-    ck_assert_int_ge((client_socket = OS_ConnectTCP(PORT, IPV4, 0)) , 0);
+    ck_assert_int_ge((client_socket = OS_ConnectTCP(PORT, IPV4, 0, NULL)) , 0);
 
     ck_assert_int_ge((server_client_socket = OS_AcceptTCP(server_root_socket, ipbuffer, BUFFERSIZE)), 0);
 
@@ -102,7 +102,7 @@ START_TEST(test_tcpv6)
 
     ck_assert_int_ge((server_root_socket = OS_Bindporttcp(PORT, IPV6, 1)), 0);
 
-    ck_assert_int_ge((client_socket = OS_ConnectTCP(PORT, IPV6, 1)) , 0);
+    ck_assert_int_ge((client_socket = OS_ConnectTCP(PORT, IPV6, 1, NULL)) , 0);
 
     ck_assert_int_ge((server_client_socket = OS_AcceptTCP(server_root_socket, ipbuffer, BUFFERSIZE)), 0);
 
@@ -153,7 +153,7 @@ START_TEST(test_udpv4)
 
     ck_assert_int_ge((server_socket = OS_Bindportudp(PORT, IPV4, 0)), 0);
 
-    ck_assert_int_ge((client_socket = OS_ConnectUDP(PORT, IPV4, 0)) , 0);
+    ck_assert_int_ge((client_socket = OS_ConnectUDP(PORT, IPV4, 0, NULL)) , 0);
 
     //TODO: ck_assert_int_eq(OS_SendUDP(client_socket, SENDSTRING), 0);
     ck_assert_int_eq(OS_SendUDPbySize(client_socket, strlen(SENDSTRING), SENDSTRING), 0);
@@ -184,7 +184,7 @@ START_TEST(test_udpv6)
 
     ck_assert_int_ge((server_socket = OS_Bindportudp(PORT, IPV6, 1)), 0);
 
-    ck_assert_int_ge((client_socket = OS_ConnectUDP(PORT, IPV6, 1)) , 0);
+    ck_assert_int_ge((client_socket = OS_ConnectUDP(PORT, IPV6, 1, NULL)) , 0);
 
     //TODO: ck_assert_int_eq(OS_SendUDP(client_socket, SENDSTRING), 0);
     ck_assert_int_eq(OS_SendUDPbySize(client_socket, strlen(SENDSTRING), SENDSTRING), 0);


### PR DESCRIPTION
In mulihomed host environment we have a big problem with binding agent to correct ip. By default agentd used ip-addr of interface, from which sented ip-packets. If we have tunnel or dynamic ip, server will be reject such packets.

I prepared and tested little patch for solve this problem by use 'local_ip' config value:
```
<ossec_config>
  <client>
    <server-ip>10.0.0.82</server-ip>
    <local_ip>192.168.0.101</local_ip>
  </client>
....
```