### PR TITLE
Wait between active response flushes during shutdown to prevent the processes from entering sleep state right away.

### DIFF
--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -49,6 +49,10 @@ static void help_execd()
 /* Shut down execd properly */
 static void execd_shutdown(int sig)
 {
+    struct timespec delay;
+    delay.tv_sec = 0;
+    delay.tv_nsec = AR_FLUSH_INTERVAL;
+
     /* Remove pending active responses */
     merror(EXEC_SHUTDOWN, ARGV0);
 
@@ -63,6 +67,10 @@ static void execd_shutdown(int sig)
         /* Delete current node - already sets the pointer to next */
         OSList_DeleteCurrentlyNode(timeout_list);
         timeout_node = OSList_GetCurrentlyNode(timeout_list);
+
+        /* Delay to prevent system from being overwhelmed by locked
+           processes if there are many nodes */
+        nanosleep(&delay, NULL);
     }
 
     HandleSIG(sig);

--- a/src/os_execd/execd.c
+++ b/src/os_execd/execd.c
@@ -49,9 +49,7 @@ static void help_execd()
 /* Shut down execd properly */
 static void execd_shutdown(int sig)
 {
-    struct timespec delay;
-    delay.tv_sec = 0;
-    delay.tv_nsec = AR_FLUSH_INTERVAL;
+    int status;
 
     /* Remove pending active responses */
     merror(EXEC_SHUTDOWN, ARGV0);
@@ -63,14 +61,11 @@ static void execd_shutdown(int sig)
         list_entry = (timeout_data *)timeout_node->data;
 
         ExecCmd(list_entry->command);
+        wait(&status);
 
         /* Delete current node - already sets the pointer to next */
         OSList_DeleteCurrentlyNode(timeout_list);
         timeout_node = OSList_GetCurrentlyNode(timeout_list);
-
-        /* Delay to prevent system from being overwhelmed by locked
-           processes if there are many nodes */
-        nanosleep(&delay, NULL);
     }
 
     HandleSIG(sig);

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -27,6 +27,9 @@
 /* Execd select timeout -- in seconds */
 #define EXECD_TIMEOUT   90
 
+/* Delay between active response flushes during shutdown in nanoseconds */
+#define AR_FLUSH_INTERVAL 40000000
+
 extern int repeated_offenders_timeout[];
 
 /** Function prototypes **/

--- a/src/os_execd/execd.h
+++ b/src/os_execd/execd.h
@@ -27,9 +27,6 @@
 /* Execd select timeout -- in seconds */
 #define EXECD_TIMEOUT   90
 
-/* Delay between active response flushes during shutdown in nanoseconds */
-#define AR_FLUSH_INTERVAL 40000000
-
 extern int repeated_offenders_timeout[];
 
 /** Function prototypes **/


### PR DESCRIPTION
This further addresses issue #609 by preventing the processes from starting up simultaneously and running concurrently in the first place. While the previous patch addressed system load between processes that were already running simultaneously, this fix avoids that altogether.