### PR TITLE
Patch rootkit_trojans.txt for s-nail systems.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -228,6 +228,10 @@ UseRootcheck()
         echo "    <system_audit>$INSTALLDIR/etc/shared/cis_rhel_linux_rcl.txt</system_audit>" >> $NEWCONFIG
         echo "    <system_audit>$INSTALLDIR/etc/shared/cis_rhel5_linux_rcl.txt</system_audit>" >> $NEWCONFIG
         echo "  </rootcheck>" >> $NEWCONFIG
+	# Patch for systems that use s-nail instead of GNU Mailutils (such as Arch Linux).
+	if strings /usr/bin/mail | grep "x-shsh bash" 1> /dev/null; then
+	  sed -i 's/mail        !bash|/mail        !/' ./src/rootcheck/db/rootkit_trojans.txt
+	fi
     else
       echo "" >> $NEWCONFIG
       echo "  <rootcheck>" >> $NEWCONFIG


### PR DESCRIPTION
Arch Linux, by default, uses S-nail for the <code>mail</code> binary. In turn, OSSEC will alert with trojan false-positives for system-wide <code>mail</code> binaries. A deeper look into https://gitlab.com/s-nail/s-nail/blob/master/mime.types confirms that <i>"This is the set of MIME types that will become compiled into S-nail."</i> thus the "bash" string within the S-nail <code>mail</code> binary is merely a built-in MIME type. As such, the current rootkit_trojans.txt is rendered ineffective.

This simple patch will confirm whether or not the system has an S-nail <code>mail</code> binary and, if so, apply the appropriate change to rootkit_trojans.txt.

Note: this was tested using the successful "Quick Install" method and not with Arch's AUR packages which, unfortunately, appear to be problematic with at least one being broken.