### PR TITLE
Small fix to enable monitoring of 64bit registry view

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -122,6 +122,7 @@
 #define SK_DUP          "%s(1756): ERROR: Duplicated directory given: '%s'."
 #define SK_INV_REG      "%s(1757): ERROR: Invalid syscheck registry entry: '%s'."
 #define SK_REG_OPEN     "%s(1758): ERROR: Unable to open registry key: '%s'."
+#define SK_REG_OPEN64   "%s(1759): ERROR: Unable to open registry key using 64 bit registry: '%s'."
 
 
 /* Analysisd */

--- a/src/rootcheck/win-common.c
+++ b/src/rootcheck/win-common.c
@@ -388,11 +388,15 @@ int __os_winreg_open_key(char *subkey, char *full_key_name,
     HKEY oshkey;
 
 
-    if(RegOpenKeyEx(rk_sub_tree, subkey, 0, KEY_READ,&oshkey) != ERROR_SUCCESS)
+    int REG64MASK = (KEY_READ | KEY_WOW64_64KEY);
+    int REG32MASK = (KEY_READ | KEY_WOW64_32KEY);
+
+    if((RegOpenKeyEx(rk_sub_tree, subkey, 0, REG64MASK, &oshkey) ||
+        (RegOpenKeyEx(rk_sub_tree, subkey, 0, REG32MASK, &oshkey))
+        ) != ERROR_SUCCESS)
     {
         return(0);
     }
-
 
     /* If option is set, return the value of query key */
     if(reg_option)

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -413,11 +413,17 @@ void os_winreg_open_key(char *subkey, char *full_key_name)
     }
 
 
-    if(RegOpenKeyEx(sub_tree, subkey, 0, KEY_READ, &oshkey) != ERROR_SUCCESS)
+    if(RegOpenKeyEx(sub_tree, subkey, 0, (KEY_READ | KEY_WOW64_64KEY), &oshkey) != ERROR_SUCCESS)
+    {
+        merror(SK_REG_OPEN64, ARGV0, subkey);
+        return;
+    }
+
+    if(RegOpenKeyEx(sub_tree, subkey, 0, (KEY_READ | KEY_WOW64_32KEY), &oshkey) != ERROR_SUCCESS)
     {
         merror(SK_REG_OPEN, ARGV0, subkey);
         return;
-    }
+    } 
 
     os_winreg_querykey(oshkey, subkey, full_key_name);
     RegCloseKey(oshkey);


### PR DESCRIPTION
Hi,

firstly let me apologise - I'm not a coder and I've never used git before so please be patient :)

The attached changes modifies the calls to *RegOpenKeyEx*. The code is effecively duplicated to allow modifications to the *samDesired* parameter - the first call uses the KEY_WOW64_64KEY  access mask (bitwise OR'ed with the existing KEY_READ mask) to request access to the 64bit registry view the second specifically requests access to the 32bit registry view using the KEY_WOW63_32KEY access mask. Both are ignored on 32 bit systems which will probably cause some duplication. Maybe someone with slightly more clue than I can see an easy way to get round the issue... or maybe point me in the direction of how to address that issue. 

Also it's worth noting that in order to get the windows agent to build (./gen_win.sh && cd ../win-pkg/ && ./make.sh) I had to comment out lines 347 to 360 in win-pkg/seechange.c - these lines call symlink functions which aren't supported on Windoze. 

Hope that helps in some way. The 64bit registry monitoring is a huge issue for me, we have almost no 32bit Windows left in our environment and plenty of sensitive 64bit systems!

Secnerd