### PR TITLE
Updated decoder.xml to include default logging settings in Windows IIS

### DIFF
--- a/contrib/ossec-testing/tests/web_rules.ini
+++ b/contrib/ossec-testing/tests/web_rules.ini
@@ -9,3 +9,21 @@ log 1 fail = 10.0.0.5 - - [1/Apr/2014:00:00:01 -0500] "POST /wp-admin HTTP/1.1" 
 rule = 31106
 alert = 6
 decoder = web-accesslog
+
+[A web page returned code 302 code]
+log 1 pass = 2015-07-28 15:07:26 1.2.3.4 GET /QOsa/Browser/Default.aspx UISessionId=SN1234123&DeviceId=SN12312232SHARP+MX-4111N 80 - 31.3.3.7 OpenSystems/1.0;+product-family="85";+product-version="123ER123" 302 0 0 624
+rule = 31108
+alert = 0
+decoder = web-accesslog-iis-default
+
+[A web page returned code 404 (not found)]
+log 1 pass = 2015-03-11 21:59:09 1.2.3.4 GET /console/faces/com_sun_web_ui/jsp/version/version_30.jsp - 80 - 31.3.3.7 Sun+Web+Console+Fingerprinter/7.15 - 404 0 2 0
+rule = 31101
+alert = 5
+decoder = web-accesslog-iis-default
+
+[A web attacked returned code 404]
+log 1 pass = 2015-03-11 22:01:59 1.2.3.4 GET /CFIDE/adminapi/customtags/l10n.cfm attributes.id=test&attributes.file=../../administrator/mail/download.cfm&filename=../lib/password.properties&attributes.locale=it&attributes.var=it&attributes.jscript=false&attributes.type=text/html&attributes.charset=UTF-8&thisTag.executionmode=end&thisTag.generatedContent=test 443 - 31.3.3.7 - - 404 0 2 0
+rule = 31104
+alert = 6
+decoder = web-accesslog-iis-default

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1691,6 +1691,27 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <order>url, srcip, id</order>
 </decoder>
 
+<!-- Windows IIS decoder for default settings
+  -  Tested with IIS 7.5 and IIS 8.5 (Windows 2008R2 and Windows 2012R2)
+  -  Will extract URL, Source IP, and HTTP response code
+  -  Examples:
+  -  IIS 7.5
+  -  2015-07-28 15:07:26 1.2.3.4 GET /QOsa/Browser/Default.aspx UISessionId=SN1234123&DeviceId=SN12312232SHARP+MX-4111N 80 - 31.3.3.7 OpenSystems/1.0;+product-family="85";+product-version="123ER123" 302 0 0 624
+  -  IIS 8.5
+  -  2015-03-11 20:28:21 1.2.3.4 GET /certsrv/Default.asp - 80 - 31.3.3.7 Mozilla/5.0+(compatible;+MSIE+9.0;+Windows+NT+6.1;+WOW64;+Trident/7.0) - 401 2 5 0
+  -  2015-03-11 21:59:09 1.2.3.4 GET /console/faces/com_sun_web_ui/jsp/version/version_30.jsp - 80 - 31.3.3.7 Sun+Web+Console+Fingerprinter/7.15 - 404 0 2 0
+  -  2015-03-11 22:01:58 1.2.3.4 GET /IISADMPWD/aexp.htr - 80 - 31.3.3.7 - - 404 0 2 0
+-->
+
+<decoder name="web-accesslog-iis-default">
+  <parent>windows-date-format</parent>
+  <type>web-log</type>
+  <use_own_name>true</use_own_name>
+  <prematch offset="after_parent">^\d+.\d+.\d+.\d+ GET |^\d+.\d+.\d+.\d+ POST </prematch>
+  <regex offset="after_prematch">(\S+ \S*) \.* (\d+.\d+.\d+.\d+) \S*\.* (\d\d\d) \S+ \S+ \S+</regex>
+  <order>url,srcip,id</order>
+</decoder>
+
 
 <!-- IIS 5 W3C FTP log format.
   - Examples:


### PR DESCRIPTION
This should work for default logging settings in IIS.  Tested with IIS 7.5 and 8.5 default settings.  I told Dan I would give this a shot in OSSEC email listserv.  So here it is! :)