### PR TITLE
Rule and test for bind9 TKEY DoS (CVE-2015-5477)

### DIFF
--- a/contrib/ossec-testing/tests/named.ini
+++ b/contrib/ossec-testing/tests/named.ini
@@ -8,3 +8,10 @@ log 5 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.3#1036: query (ca
 rule = 12108 
 alert = 0
 decoder = named 
+
+[Possible BIND9 TKEY denial of service]
+log 1 pass = Aug  2 10:32:48 dns named[2717]: client 192.168.1.25#42212 (example.com): view north_america: query: example.com ANY TKEY + (192.168.2.35)
+rule = 12187
+alert = 10
+decoder = named
+

--- a/etc/rules/named_rules.xml
+++ b/etc/rules/named_rules.xml
@@ -314,4 +314,11 @@
     <description>Parsing of a configuration file has failed.</description>
   </rule>
 
+  <rule id="12187" level="10">
+    <if_sid>12100</if_sid>
+    <match> ANY TKEY </match>
+    <description>Possible BIND9 TKEY denial of service.</description>
+    <info type='cve'>2015-5477</info>  
+  </rule>
+
 </group> <!-- SYSLOG,NAMED -->


### PR DESCRIPTION
Using the log sample from the Sucuri blog: 
https://blog.sucuri.net/2015/08/bind9-denial-of-service-exploit-in-the-wild.html

