### PR TITLE
Let "ossec-syscheckd -t" display XML parsing errors for agent.conf on…

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -153,13 +153,7 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2)
     const char *xml_agent_profile = "profile";
 
     if (OS_ReadXML(cfgfile, &xml) < 0) {
-        if (modules & CAGENT_CONFIG) {
-#ifndef CLIENT
-            merror(XML_ERROR, __local_name, cfgfile, xml.err, xml.err_line);
-#endif
-        } else {
-            merror(XML_ERROR, __local_name, cfgfile, xml.err, xml.err_line);
-        }
+	merror(XML_ERROR, __local_name, cfgfile, xml.err, xml.err_line);
         return (OS_INVALID);
     }
 

--- a/src/shared/agent_op.c
+++ b/src/shared/agent_op.c
@@ -86,6 +86,13 @@ char *os_read_agent_name()
     /* Get name */
     if (fgets(buf, 1024, fp)) {
         char *ret = NULL;
+	int len;
+
+	// strip the newlines
+	len = strlen(buf) - 1; 
+	while (len > 0 && buf[len] == '\n') 
+	    buf[len--] = '\0'; 
+
         os_strdup(buf, ret);
         fclose(fp);
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -182,7 +182,7 @@ int main(int argc, char **argv)
                 break;
             case 'd':
                 nowDebug();
-                debug_level = 1;
+                debug_level ++;
                 break;
             case 'f':
                 run_foreground = 1;


### PR DESCRIPTION
Let "ossec-syscheckd -t" display XML parsing errors for agent.conf on agents.