### PR TITLE
Scan dir once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_script:
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main " && sudo apt-get update && sudo apt-get install check valgrind ); fi
 - sudo apt-get install -y libc6-dev
+- ls -laF /usr/include/glob.h
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,6 @@ before_script:
   ); fi
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main " && sudo apt-get update && sudo apt-get install check valgrind ); fi
-- sudo apt-get install -y libc6-dev
-- ls -laF /usr/include/glob.h
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   ); fi
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main " && sudo apt-get update && sudo apt-get install check valgrind ); fi
-
+- sudo apt-get install -y libc6-dev
 
 
 script:

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -367,7 +367,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         /* Check for glob */
-#ifndef WIN32
         if (strchr(tmp_dir, '*') ||
                 strchr(tmp_dir, '?') ||
                 strchr(tmp_dir, '[')) {
@@ -397,9 +396,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         else {
             dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
         }
-#else
-        dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
-#endif
 
         if (restrictfile) {
             free(restrictfile);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -367,6 +367,10 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         /* Check for glob */
+	/* The mingw32 builder used by travis.ci can't find glob.h 
+	 * Yet glob must work on actual win32.  
+	 */
+#ifndef __MINGW32__ 
         if (strchr(tmp_dir, '*') ||
                 strchr(tmp_dir, '?') ||
                 strchr(tmp_dir, '[')) {
@@ -396,6 +400,9 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         else {
             dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
         }
+#else
+	dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
+#endif
 
         if (restrictfile) {
             free(restrictfile);

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -60,9 +60,9 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <signal.h>
+#include <glob.h>
 
 #ifndef WIN32
-#include <glob.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -61,7 +61,9 @@
 #include <ctype.h>
 #include <signal.h>
 
-/* the mingw32 builder used by travis.ci can't find glob.h */
+/* The mingw32 builder used by travis.ci can't find glob.h 
+ * Yet glob must work on actual win32.  
+ */
 #ifndef __MINGW32__ 
 #include <glob.h>
 #endif

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -60,7 +60,11 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <signal.h>
+
+/* the mingw32 builder used by travis.ci can't find glob.h */
+#ifndef __MINGW32__ 
 #include <glob.h>
+#endif
 
 #ifndef WIN32
 #include <netdb.h>

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -28,6 +28,22 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
     char sha1s = '+';
     struct stat statbuf;
 
+    /* skip any subdir that is defined as a top level starting directory,
+     * so we only scan it once, and with the right options for that dir.
+     * for example: 
+     * <directories check_all="yes">/etc</directories>
+     * <directories check_all="yes" report_changes="yes">/etc/sysconfig</directories>
+     */
+    int i = 0;
+    while(syscheck.dir[i] != NULL) {
+	if(strcmp(syscheck.dir[i], file_name ) == 0) {
+	    debug2("%s: read_file ignoring as subdir %s", 
+		ARGV0, file_name );
+	    return(0);
+	}
+	i++;
+    }
+
     /* Check if the file should be ignored */
     if (syscheck.ignore) {
         int i = 0;


### PR DESCRIPTION
Don't decend into monitored subdirectories of monitored directories.
If you you have both /var and /var/log monitored, the /var scan won't
decend into /var/log.  /var/log is only scanned once, with the
right options.

For example, this would only scan /etc/sysconfig with report changes.
    <directories check_all="yes">/etc</directories>
    <directories check_all="yes" report_changes="yes">/etc/sysconfig</directories>

For example, this would avoid summing the log files.
    <directories check_all="yes">/var</directories>
    <directories check_owner="yes" check_perm="yes" check_sum="no">/var/log </directories>