### PR TITLE
Dir glob

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   ); fi
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main " && sudo apt-get update && sudo apt-get install check valgrind ); fi
-- sudo apt-get install -y libc6-dev
+
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ before_script:
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main " && sudo apt-get update && sudo apt-get install check valgrind ); fi
 - sudo apt-get install -y libc6-dev
-- ls -laF /usr/include/glob.h
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,8 @@ before_script:
   ); fi
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main " && sudo apt-get update && sudo apt-get install check valgrind ); fi
+- sudo apt-get install -y libc6-dev
+- ls -laF /usr/include/glob.h
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_script:
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main " && sudo apt-get update && sudo apt-get install check valgrind ); fi
 - sudo apt-get install -y libc6-dev
+- ls -laF /usr/include/glob.h
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,6 @@ before_script:
   ); fi
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main " && sudo apt-get update && sudo apt-get install check valgrind ); fi
-- sudo apt-get install -y libc6-dev
-- ls -laF /usr/include/glob.h
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   ); fi
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ vivid main " && sudo apt-get update && sudo apt-get install check valgrind ); fi
-
+- sudo apt-get install -y libc6-dev
 
 
 script:

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -367,6 +367,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         /* Check for glob */
+#ifndef WIN32
         if (strchr(tmp_dir, '*') ||
                 strchr(tmp_dir, '?') ||
                 strchr(tmp_dir, '[')) {
@@ -396,6 +397,9 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         else {
             dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
         }
+#else
+        dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
+#endif
 
         if (restrictfile) {
             free(restrictfile);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -367,7 +367,10 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         /* Check for glob */
-#ifndef WIN32
+	/* The mingw32 builder used by travis.ci can't find glob.h 
+	 * Yet glob must work on actual win32.  
+	 */
+#ifndef __MINGW32__ 
         if (strchr(tmp_dir, '*') ||
                 strchr(tmp_dir, '?') ||
                 strchr(tmp_dir, '[')) {

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -367,10 +367,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         /* Check for glob */
-	/* The mingw32 builder used by travis.ci can't find glob.h 
-	 * Yet glob must work on actual win32.  
-	 */
-#ifndef __MINGW32__ 
         if (strchr(tmp_dir, '*') ||
                 strchr(tmp_dir, '?') ||
                 strchr(tmp_dir, '[')) {
@@ -400,9 +396,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         else {
             dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
         }
-#else
-	dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
-#endif
 
         if (restrictfile) {
             free(restrictfile);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -367,7 +367,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         /* Check for glob */
-#ifndef WIN32
         if (strchr(tmp_dir, '*') ||
                 strchr(tmp_dir, '?') ||
                 strchr(tmp_dir, '[')) {
@@ -397,9 +396,6 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         else {
             dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
         }
-#else
-        dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
-#endif
 
         if (restrictfile) {
             free(restrictfile);

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -367,6 +367,10 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         }
 
         /* Check for glob */
+	/* The mingw32 builder used by travis.ci can't find glob.h 
+	 * Yet glob must work on actual win32.  
+	 */
+#ifndef __MINGW32__ 
         if (strchr(tmp_dir, '*') ||
                 strchr(tmp_dir, '?') ||
                 strchr(tmp_dir, '[')) {
@@ -396,6 +400,9 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
         else {
             dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
         }
+#else
+	dump_syscheck_entry(syscheck, tmp_dir, opts, 0, restrictfile);
+#endif
 
         if (restrictfile) {
             free(restrictfile);

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -60,11 +60,7 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <signal.h>
-
-/* the mingw32 builder used by travis.ci can't find glob.h */
-#ifndef __MINGW32__ 
 #include <glob.h>
-#endif
 
 #ifndef WIN32
 #include <netdb.h>

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -61,8 +61,14 @@
 #include <ctype.h>
 #include <signal.h>
 
-#ifndef WIN32
+/* The mingw32 builder used by travis.ci can't find glob.h 
+ * Yet glob must work on actual win32.  
+ */
+#ifndef __MINGW32__ 
 #include <glob.h>
+#endif
+
+#ifndef WIN32
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -61,9 +61,7 @@
 #include <ctype.h>
 #include <signal.h>
 
-/* The mingw32 builder used by travis.ci can't find glob.h 
- * Yet glob must work on actual win32.  
- */
+/* the mingw32 builder used by travis.ci can't find glob.h */
 #ifndef __MINGW32__ 
 #include <glob.h>
 #endif

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -60,9 +60,9 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <signal.h>
-#include <glob.h>
 
 #ifndef WIN32
+#include <glob.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -60,9 +60,9 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <signal.h>
+#include <glob.h>
 
 #ifndef WIN32
-#include <glob.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -61,7 +61,9 @@
 #include <ctype.h>
 #include <signal.h>
 
-/* the mingw32 builder used by travis.ci can't find glob.h */
+/* The mingw32 builder used by travis.ci can't find glob.h 
+ * Yet glob must work on actual win32.  
+ */
 #ifndef __MINGW32__ 
 #include <glob.h>
 #endif

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -60,7 +60,11 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <signal.h>
+
+/* the mingw32 builder used by travis.ci can't find glob.h */
+#ifndef __MINGW32__ 
 #include <glob.h>
+#endif
 
 #ifndef WIN32
 #include <netdb.h>


### PR DESCRIPTION
Allow unix to use glob patterns in directories tags.  This lets you
automatically pick up new directories that follow a naming theme, for
example datestamped output directories.  It also lets you specify
directories that have commas in the name.  This has to have #ifdef
__MINGW32__, because the MinGW32 compiler environment used to simulate
Win32 in Travis CI doesn't include the glob.h header.  However, glob
works fine on real Win32.
