### PR TITLE
Don't consider an empty client.keys to be a failure condition

### DIFF
--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -343,8 +343,7 @@ int main(int argc, char **argv)
                         FILE *fp;
                         fp = fopen(KEYSFILE_PATH, "w");
                         if (!fp) {
-                            printf("ERROR: Unable to open key file: %s", KEYSFILE_PATH);
-                            exit(1);
+                            ErrorExit(FOPEN_ERROR, ARGV0, KEYSFILE_PATH, errno, strerror(errno));
                         }
                         fprintf(fp, "%s\n", key);
                         fclose(fp);

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -306,8 +306,7 @@ int main(int argc, char **argv)
 
     fp = fopen(KEYSFILE_PATH, "a");
     if (!fp) {
-        merror("%s: ERROR: Unable to open %s (key file)", ARGV0, KEYSFILE_PATH);
-        exit(1);
+        ErrorExit(FOPEN_ERROR, ARGV0, KEYSFILE_PATH, errno, strerror(errno));
     }
     fclose(fp);
 

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -36,6 +36,7 @@ static void help_remoted()
 
 int main(int argc, char **argv)
 {
+    FILE *fp;
     int i = 0, c = 0;
     uid_t uid;
     gid_t gid;
@@ -126,6 +127,13 @@ int main(int argc, char **argv)
         /* Not configured */
         exit(0);
     }
+
+    /* Touch client.keys */
+    fp = fopen(KEYSFILE_PATH, "a");
+    if (!fp) {
+        ErrorExit(FOPEN_ERROR, ARGV0, KEYSFILE_PATH, errno, strerror(errno));
+    }
+    fclose(fp);
 
     /* Check if the user and group given are valid */
     uid = Privsep_GetUser(user);


### PR DESCRIPTION
client.keys is already reloaded each time a given key is not found in memory so there's no harm in this file being empty. In fact, it's downright annoying if you're using authd because you have to wait for the first agent to register and then manually restart the server before they can start communicating. Removing this check would make the Chef cookbook less clunky.

Disclaimer: I haven't tested this at all because I've already sunk too much time into the cookbook. The change seems simple enough though.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/662)

<!-- Reviewable:end -->
