### PR TITLE
PHP rule checks on apache 2.4 logs

### DIFF
--- a/etc/rules/php_rules.xml
+++ b/etc/rules/php_rules.xml
@@ -16,19 +16,19 @@
 
 <group name="apache,">
   <rule id="31401" level="0">
-    <if_sid>31301, 30101</if_sid>
+    <if_sid>31301, 30101, 30301</if_sid>
     <match>PHP Warning: </match>
     <description>PHP Warning message.</description>
   </rule>    
 
   <rule id="31402" level="0">
-    <if_sid>31301, 30101</if_sid>
+    <if_sid>31301, 30101, 30301</if_sid>
     <match>PHP Fatal error: </match>
     <description>PHP Fatal error.</description>
   </rule>    
 
   <rule id="31403" level="0">
-    <if_sid>31301, 30101</if_sid>
+    <if_sid>31301, 30101, 30301</if_sid>
     <match>PHP Parse error:</match>
     <description>PHP Parse error.</description>
   </rule>    


### PR DESCRIPTION
Currently the rules for grouping php warnings/errors are only run on apache 2.2 and nginx logs, this change adds apache 2.4 logs to the list.