### PR TITLE
Allow maild to send through a sendmail-like executable

### DIFF
--- a/src/agentlessd/main.c
+++ b/src/agentlessd/main.c
@@ -146,7 +146,8 @@ int main(int argc, char **argv)
         ErrorExit(SETUID_ERROR, ARGV0, user, errno, strerror(errno));
     }
 
-    debug1(PRIVSEP_MSG, ARGV0, dir, user);
+    debug1(CHROOT_MSG, ARGV0, dir);
+    debug1(PRIVSEP_MSG, ARGV0, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -434,7 +434,8 @@ int main_analysisd(int argc, char **argv)
     }
 
     /* Verbose message */
-    debug1(PRIVSEP_MSG, ARGV0, dir, user);
+    debug1(CHROOT_MSG, ARGV0, dir);
+    debug1(PRIVSEP_MSG, ARGV0, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -441,10 +441,14 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
         } else if (strcmp(node[i]->element, xml_smtpserver) == 0) {
 #ifndef WIN32
             if (Mail && (Mail->mn)) {
-                Mail->smtpserver = OS_GetHost(node[i]->content, 5);
-                if (!Mail->smtpserver) {
-                    merror(INVALID_SMTP, __local_name, node[i]->content);
-                    return (OS_INVALID);
+                if (node[i]->content[0] == '/') {
+                    os_strdup(node[i]->content, Mail->smtpserver);
+                } else {
+                    Mail->smtpserver = OS_GetHost(node[i]->content, 5);
+                    if (!Mail->smtpserver) {
+                        merror(INVALID_SMTP, __local_name, node[i]->content);
+                        return (OS_INVALID);
+                    }
                 }
                 free(Mail->smtpserver);
                 os_strdup(node[i]->content, Mail->smtpserver);

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -258,7 +258,8 @@
 
 /* Verbose messages */
 #define STARTUP_MSG "%s: INFO: Started (pid: %d)."
-#define PRIVSEP_MSG "%s: INFO: Chrooted to directory: %s, using user: %s"
+#define CHROOT_MSG  "%s: INFO: Chrooted to directory: %s"
+#define PRIVSEP_MSG "%s: INFO: Using user: %s"
 #define MSG_SOCKET_SIZE "%s: INFO: (unix_domain) Maximum send buffer set to: '%d'."
 
 #define NO_SYSLOG       "%s(1501): ERROR: No IP or network allowed in the access list" \

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -173,6 +173,7 @@ http://www.ossec.net/main/license/\n"
 #define EVENTS            "/logs/archives"
 #define EVENTS_DAILY      "/logs/archives/archives.log"
 #define ALERTS            "/logs/alerts"
+#define ALERTS_PATH       DEFAULTDIR ALERTS
 #define ALERTS_DAILY      "/logs/alerts/alerts.log"
 #define ALERTSJSON_DAILY  "/logs/alerts/alerts.json"
 #define FWLOGS            "/logs/firewall"

--- a/src/monitord/main.c
+++ b/src/monitord/main.c
@@ -196,7 +196,8 @@ int main(int argc, char **argv)
         ErrorExit(SETUID_ERROR, ARGV0, user, errno, strerror(errno));
     }
 
-    debug1(PRIVSEP_MSG, ARGV0, dir, user);
+    debug1(CHROOT_MSG, ARGV0, dir);
+    debug1(PRIVSEP_MSG, ARGV0, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -165,7 +165,8 @@ int main(int argc, char **argv)
     }
 
     /* Basic start up completed */
-    debug1(PRIVSEP_MSG, ARGV0, dir, user);
+    debug1(CHROOT_MSG, ARGV0, dir);
+    debug1(PRIVSEP_MSG, ARGV0, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -226,7 +226,8 @@ int main(int argc, char **argv)
     }
 
     /* Basic start up completed */
-    debug1(PRIVSEP_MSG, ARGV0, dir, user);
+    debug1(CHROOT_MSG, ARGV0, dir);
+    debug1(PRIVSEP_MSG, ARGV0, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -160,18 +160,20 @@ int main(int argc, char **argv)
         ErrorExit(SETGID_ERROR, ARGV0, group, errno, strerror(errno));
     }
 
-    /* chroot */
-    if (Privsep_Chroot(dir) < 0) {
-        ErrorExit(CHROOT_ERROR, ARGV0, dir, errno, strerror(errno));
+    if (mail.smtpserver[0] != '/') {
+        /* chroot */
+        if (Privsep_Chroot(dir) < 0) {
+            ErrorExit(CHROOT_ERROR, ARGV0, dir, errno, strerror(errno));
+        }
+        nowChroot();
+        debug1(CHROOT_MSG, ARGV0, dir);
     }
-    nowChroot();
 
     /* Change user */
     if (Privsep_SetUser(uid) < 0) {
         ErrorExit(SETUID_ERROR, ARGV0, user, errno, strerror(errno));
     }
 
-    debug1(CHROOT_MSG, ARGV0, dir);
     debug1(PRIVSEP_MSG, ARGV0, user);
 
     /* Signal manipulation */

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -171,7 +171,8 @@ int main(int argc, char **argv)
         ErrorExit(SETUID_ERROR, ARGV0, user, errno, strerror(errno));
     }
 
-    debug1(PRIVSEP_MSG, ARGV0, dir, user);
+    debug1(CHROOT_MSG, ARGV0, dir);
+    debug1(PRIVSEP_MSG, ARGV0, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -47,93 +47,83 @@
 
 int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, char *idsname, FILE *fp, const struct tm *p)
 {
-    int socket, i = 0;
+    FILE *sendmail = NULL;
+    int socket = -1, i = 0;
     char *msg;
     char snd_msg[128];
     char buffer[2049];
 
     buffer[2048] = '\0';
 
-    /* Connect to the SMTP server */
-    socket = OS_ConnectTCP(SMTP_DEFAULT_PORT, smtpserver);
-    if (socket < 0) {
-        return (socket);
-    }
-
-    /* Receive the banner */
-    msg = OS_RecvTCP(socket, OS_SIZE_1024);
-    if ((msg == NULL) || (!OS_Match(VALIDBANNER, msg))) {
-        merror(BANNER_ERROR);
-        if (msg) {
-            free(msg);
+    if (smtpserver[0] == '/') {
+        sendmail = popen(smtpserver, "w");
+        if (!sendmail) {
+            return (OS_INVALID);
         }
-        close(socket);
-        return (OS_INVALID);
-    }
-    MAIL_DEBUG("DEBUG: Received banner: '%s' %s", msg, "");
-    free(msg);
+    } else {
+        /* Connect to the SMTP server */
+        socket = OS_ConnectTCP(SMTP_DEFAULT_PORT, smtpserver);
+        if (socket < 0) {
+            return (socket);
+        }
 
-    /* Send HELO message */
-    OS_SendTCP(socket, HELOMSG);
-    msg = OS_RecvTCP(socket, OS_SIZE_1024);
-    if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
-        if (msg) {
-            /* In some cases (with virus scans in the middle)
-             * we may get two banners. Check for that in here.
-             */
-            if (OS_Match(VALIDBANNER, msg)) {
+        /* Receive the banner */
+        msg = OS_RecvTCP(socket, OS_SIZE_1024);
+        if ((msg == NULL) || (!OS_Match(VALIDBANNER, msg))) {
+            merror(BANNER_ERROR);
+            if (msg) {
                 free(msg);
+            }
+            close(socket);
+            return (OS_INVALID);
+        }
+        MAIL_DEBUG("DEBUG: Received banner: '%s' %s", msg, "");
+        free(msg);
 
-                /* Try again */
-                msg = OS_RecvTCP(socket, OS_SIZE_1024);
-                if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
-                    merror("%s:%s", HELO_ERROR, msg != NULL ? msg : "null");
-                    if (msg) {
-                        free(msg);
+        /* Send HELO message */
+        OS_SendTCP(socket, HELOMSG);
+        msg = OS_RecvTCP(socket, OS_SIZE_1024);
+        if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
+            if (msg) {
+                /* In some cases (with virus scans in the middle)
+                 * we may get two banners. Check for that in here.
+                 */
+                if (OS_Match(VALIDBANNER, msg)) {
+                    free(msg);
+
+                    /* Try again */
+                    msg = OS_RecvTCP(socket, OS_SIZE_1024);
+                    if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
+                        merror("%s:%s", HELO_ERROR, msg != NULL ? msg : "null");
+                        if (msg) {
+                            free(msg);
+                        }
+                        close(socket);
+                        return (OS_INVALID);
                     }
+                } else {
+                    merror("%s:%s", HELO_ERROR, msg);
+                    free(msg);
                     close(socket);
                     return (OS_INVALID);
                 }
             } else {
-                merror("%s:%s", HELO_ERROR, msg);
-                free(msg);
+                merror("%s:%s", HELO_ERROR, "null");
                 close(socket);
                 return (OS_INVALID);
             }
-        } else {
-            merror("%s:%s", HELO_ERROR, "null");
-            close(socket);
-            return (OS_INVALID);
         }
-    }
 
-    MAIL_DEBUG("DEBUG: Sent '%s', received: '%s'", HELOMSG, msg);
-    free(msg);
+        MAIL_DEBUG("DEBUG: Sent '%s', received: '%s'", HELOMSG, msg);
+        free(msg);
 
-    /* Build "Mail from" msg */
-    memset(snd_msg, '\0', 128);
-    snprintf(snd_msg, 127, MAILFROM, from);
-    OS_SendTCP(socket, snd_msg);
-    msg = OS_RecvTCP(socket, OS_SIZE_1024);
-    if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
-        merror(FROM_ERROR);
-        if (msg) {
-            free(msg);
-        }
-        close(socket);
-        return (OS_INVALID);
-    }
-    MAIL_DEBUG("DEBUG: Sent '%s', received: '%s'", snd_msg, msg);
-    free(msg);
-
-    /* Build "RCPT TO" msg */
-    while (to[i]) {
+        /* Build "Mail from" msg */
         memset(snd_msg, '\0', 128);
-        snprintf(snd_msg, 127, RCPTTO, to[i]);
+        snprintf(snd_msg, 127, MAILFROM, from);
         OS_SendTCP(socket, snd_msg);
         msg = OS_RecvTCP(socket, OS_SIZE_1024);
         if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
-            merror(TO_ERROR, to[i]);
+            merror(FROM_ERROR);
             if (msg) {
                 free(msg);
             }
@@ -143,31 +133,59 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
         MAIL_DEBUG("DEBUG: Sent '%s', received: '%s'", snd_msg, msg);
         free(msg);
 
-        i++;
-    }
-
-    /* Send the "DATA" msg */
-    OS_SendTCP(socket, DATAMSG);
-    msg = OS_RecvTCP(socket, OS_SIZE_1024);
-    if ((msg == NULL) || (!OS_Match(VALIDDATA, msg))) {
-        merror(DATA_ERROR);
-        if (msg) {
+        /* Build "RCPT TO" msg */
+        while (to[i]) {
+            memset(snd_msg, '\0', 128);
+            snprintf(snd_msg, 127, RCPTTO, to[i]);
+            OS_SendTCP(socket, snd_msg);
+            msg = OS_RecvTCP(socket, OS_SIZE_1024);
+            if ((msg == NULL) || (!OS_Match(VALIDMAIL, msg))) {
+                merror(TO_ERROR, to[i]);
+                if (msg) {
+                    free(msg);
+                }
+                close(socket);
+                return (OS_INVALID);
+            }
+            MAIL_DEBUG("DEBUG: Sent '%s', received: '%s'", snd_msg, msg);
             free(msg);
+
+            i++;
         }
-        close(socket);
-        return (OS_INVALID);
+
+        /* Send the "DATA" msg */
+        OS_SendTCP(socket, DATAMSG);
+        msg = OS_RecvTCP(socket, OS_SIZE_1024);
+        if ((msg == NULL) || (!OS_Match(VALIDDATA, msg))) {
+            merror(DATA_ERROR);
+            if (msg) {
+                free(msg);
+            }
+            close(socket);
+            return (OS_INVALID);
+        }
+        MAIL_DEBUG("DEBUG: Sent '%s', received: '%s'", DATAMSG, msg);
+        free(msg);
     }
-    MAIL_DEBUG("DEBUG: Sent '%s', received: '%s'", DATAMSG, msg);
-    free(msg);
 
     /* Build "From" and "To" in the e-mail header */
     memset(snd_msg, '\0', 128);
     snprintf(snd_msg, 127, TO, to[0]);
-    OS_SendTCP(socket, snd_msg);
+
+    if (sendmail) {
+        fprintf(sendmail, snd_msg);
+    } else {
+        OS_SendTCP(socket, snd_msg);
+    }
 
     memset(snd_msg, '\0', 128);
     snprintf(snd_msg, 127, FROM, from);
-    OS_SendTCP(socket, snd_msg);
+
+    if (sendmail) {
+        fprintf(sendmail, snd_msg);
+    } else {
+        OS_SendTCP(socket, snd_msg);
+    }
 
     /* Add CCs */
     if (to[1]) {
@@ -179,7 +197,12 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
 
             memset(snd_msg, '\0', 128);
             snprintf(snd_msg, 127, TO, to[i]);
-            OS_SendTCP(socket, snd_msg);
+
+            if (sendmail) {
+                fprintf(sendmail, snd_msg);
+            } else {
+                OS_SendTCP(socket, snd_msg);
+            }
 
             i++;
         }
@@ -195,47 +218,72 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     strftime(snd_msg, 127, "Date: %a, %d %b %Y %T %z\r\n", p);
 #endif
 
-    OS_SendTCP(socket, snd_msg);
+    if (sendmail) {
+        fprintf(sendmail, snd_msg);
+    } else {
+        OS_SendTCP(socket, snd_msg);
+    }
 
     if (idsname) {
         /* Send server name header */
         memset(snd_msg, '\0', 128);
         snprintf(snd_msg, 127, XHEADER, idsname);
-        OS_SendTCP(socket, snd_msg);
+
+        if (sendmail) {
+            fprintf(sendmail, snd_msg);
+        } else {
+            OS_SendTCP(socket, snd_msg);
+        }
     }
 
     /* Send subject */
     memset(snd_msg, '\0', 128);
     snprintf(snd_msg, 127, SUBJECT, subject);
-    OS_SendTCP(socket, snd_msg);
-    OS_SendTCP(socket, ENDHEADER);
+
+    if (sendmail) {
+        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, ENDHEADER);
+    } else {
+        OS_SendTCP(socket, snd_msg);
+        OS_SendTCP(socket, ENDHEADER);
+    }
 
     /* Send body */
     fseek(fp, 0, SEEK_SET);
     while (fgets(buffer, 2048, fp) != NULL) {
-        OS_SendTCP(socket, buffer);
+        if (sendmail) {
+            fprintf(sendmail, buffer);
+        } else {
+            OS_SendTCP(socket, buffer);
+        }
     }
 
-    /* Send end of data \r\n.\r\n */
-    OS_SendTCP(socket, ENDDATA);
-    msg = OS_RecvTCP(socket, OS_SIZE_1024);
+    if (sendmail) {
+        if (pclose(sendmail) == -1) {
+            merror(WAITPID_ERROR, ARGV0, errno, strerror(errno));
+        }
+    } else {
+        /* Send end of data \r\n.\r\n */
+        OS_SendTCP(socket, ENDDATA);
+        msg = OS_RecvTCP(socket, OS_SIZE_1024);
 
-    /* Check msg, since it may be null */
-    if (msg) {
-        free(msg);
-    }
+        /* Check msg, since it may be null */
+        if (msg) {
+            free(msg);
+        }
 
-    /* Quit and close socket */
-    OS_SendTCP(socket, QUITMSG);
-    msg = OS_RecvTCP(socket, OS_SIZE_1024);
+        /* Quit and close socket */
+        OS_SendTCP(socket, QUITMSG);
+        msg = OS_RecvTCP(socket, OS_SIZE_1024);
 
-    if (msg) {
-        free(msg);
+        if (msg) {
+            free(msg);
+        }
+
+        close(socket);
     }
 
     memset_secure(snd_msg, '\0', 128);
-    close(socket);
-
     return (0);
 }
 

--- a/src/reportd/report.c
+++ b/src/reportd/report.c
@@ -185,7 +185,8 @@ int main(int argc, char **argv)
         ErrorExit(SETUID_ERROR, ARGV0, user, errno, strerror(errno));
     }
 
-    debug1(PRIVSEP_MSG, ARGV0, dir, user);
+    debug1(CHROOT_MSG, ARGV0, dir);
+    debug1(PRIVSEP_MSG, ARGV0, user);
 
     /* Signal manipulation */
     StartSIG(ARGV0);

--- a/src/shared/file-queue.c
+++ b/src/shared/file-queue.c
@@ -53,7 +53,7 @@ static void GetFile_Queue(file_queue *fileq)
     } else {
         snprintf(fileq->file_name, MAX_FQUEUE,
                  "%s/%d/%s/ossec-alerts-%02d.log",
-                 ALERTS,
+                 isChroot() ? ALERTS : ALERTS_PATH,
                  fileq->year,
                  fileq->mon,
                  fileq->day);


### PR DESCRIPTION
Users have long called for TLS support when sending mail from OSSEC. This is not trivial to add directly but this commit enables that support by delegating the task to a sendmail-like executable such as SSMTP or Msmtp.

maild detects this mode of operation by checking for a / at the start of the smtp_server setting. It uses popen to launch the executable and passes the raw message to it via stdin. sendmail's -t argument tells
it to parse the headers given in the message so smtp_server will typically be set to something like `/usr/sbin/sendmail -t`.

In order for this to work, maild needs to be started without chrooting as it traditionally has done. It will therefore no longer chroot if it detects a / at the start of smtp_server.

It is best to view this commit with `--ignore-all-space` as there are far few changes than the regular diff would imply.