### PR TITLE
- Fix #642, ossec-authd maxagents

### DIFF
--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -44,7 +44,7 @@ char *OS_AddNewAgent(const char *name, const char *ip, const char *id)
         while (IDExist(nid)) {
             i++;
             snprintf(nid, 6, "%d", i);
-            if (i >= 4000) {
+            if (i >= (MAX_AGENTS + 1024)) {
                 return (NULL);
             }
         }


### PR DESCRIPTION
This brings ossec-authd into parity with whatever the MAX_AGENTS
setting is at build time from a hard coded limit of 4000.