### PR TITLE
Allows an optionnal ``Reply-To`` mail header

### DIFF
--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -6,6 +6,7 @@
     <email_to>daniel.cid@example.com</email_to>
     <smtp_server>smtp.example.com.</smtp_server>
     <email_from>ossecm@ossec.example.com.</email_from>
+    <!-- <email_reply_to>replyto@ossec.example.com.</email_reply_to> -->
     <picviz_output>no</picviz_output>
   </global>
 

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -114,6 +114,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
 
     const char *xml_emailto = "email_to";
     const char *xml_emailfrom = "email_from";
+    const char *xml_emailreplyto = "email_reply_to";
     const char *xml_emailidsname = "email_idsname";
     const char *xml_smtpserver = "smtp_server";
     const char *xml_heloserver = "helo_server";
@@ -403,7 +404,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
         }
 
         /* For the email now
-         * email_to, email_from, idsname, smtp_Server and maxperhour.
+         * email_to, email_from, email_replyto, idsname, smtp_Server and maxperhour.
          * We will use a separate structure for that.
          */
         else if (strcmp(node[i]->element, xml_emailto) == 0) {
@@ -430,6 +431,13 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                     free(Mail->from);
                 }
                 os_strdup(node[i]->content, Mail->from);
+            }
+        } else if (strcmp(node[i]->element, xml_emailreplyto) == 0) {
+            if (Mail) {
+                if (Mail->reply_to) {
+                    free(Mail->reply_to);
+                }
+                os_strdup(node[i]->content, Mail->reply_to);
             }
         } else if (strcmp(node[i]->element, xml_emailidsname) == 0) {
             if (Mail) {

--- a/src/config/mail-config.h
+++ b/src/config/mail-config.h
@@ -21,6 +21,7 @@ typedef struct _MailConfig {
     int subject_full;
     int priority;
     char **to;
+    char *reply_to;
     char *from;
     char *idsname;
     char *smtpserver;

--- a/src/os_maild/config.c
+++ b/src/os_maild/config.c
@@ -20,6 +20,7 @@ int MailConf(int test_config, const char *cfgfile, MailConfig *Mail)
     modules |= CMAIL;
 
     Mail->to = NULL;
+    Mail->reply_to = NULL;
     Mail->from = NULL;
     Mail->idsname = NULL;
     Mail->smtpserver = NULL;

--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -24,6 +24,7 @@
 #define RCPTTO              "Rcpt To: <%s>\r\n"
 #define DATAMSG             "DATA\r\n"
 #define FROM                "From: OSSEC HIDS <%s>\r\n"
+#define REPLYTO             "Reply-To: OSSEC HIDS <%s>\r\n"
 #define TO                  "To: <%s>\r\n"
 #define CC                  "Cc: <%s>\r\n"
 #define SUBJECT             "Subject: %s\r\n"
@@ -45,7 +46,7 @@
 #define MAIL_DEBUG(x,y,z) if(MAIL_DEBUG_FLAG) merror(x,y,z)
 
 
-int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, char *idsname, FILE *fp, const struct tm *p)
+int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, char *replyto, char *idsname, FILE *fp, const struct tm *p)
 {
     FILE *sendmail = NULL;
     int socket = -1, i = 0;
@@ -184,6 +185,12 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     if (sendmail) {
         fprintf(sendmail, snd_msg);
     } else {
+        OS_SendTCP(socket, snd_msg);
+    }
+
+    if (replyto) {
+        memset(snd_msg, '\0', 128);
+        snprintf(snd_msg, 127, REPLYTO, replyto);
         OS_SendTCP(socket, snd_msg);
     }
 

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -26,6 +26,7 @@
 #define DATAMSG             "DATA\r\n"
 #define FROM                "From: OSSEC HIDS <%s>\r\n"
 #define TO                  "To: <%s>\r\n"
+#define REPLYTO             "Reply-To: OSSEC HIDS <%s>\r\n"
 /*#define CC                "Cc: <%s>\r\n"*/
 #define SUBJECT             "Subject: %s\r\n"
 #define ENDHEADER           "\r\n"
@@ -201,6 +202,13 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg)
     if (sendmail) {
         fprintf(sendmail, snd_msg);
     } else {
+        OS_SendTCP(socket, snd_msg);
+    }
+
+    /* Send reply-to if set */
+    if (mail->reply_to){
+        memset(snd_msg, '\0', 128);
+        snprintf(snd_msg, 127, REPLYTO, mail->reply_to);
         OS_SendTCP(socket, snd_msg);
     }
 

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -470,6 +470,17 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         OS_SendTCP(socket, snd_msg);
     }
 
+    /* Send reply-to if set */
+    if (mail->reply_to){
+        memset(snd_msg, '\0', 128);
+        snprintf(snd_msg, 127, REPLYTO, mail->reply_to);
+        if (sendmail) {
+            fprintf(sendmail, snd_msg);
+        } else {
+            OS_SendTCP(socket, snd_msg);
+        }
+    }
+
     /* Add CCs */
     if (mail->to[1]) {
         i = 1;


### PR DESCRIPTION
Hi all. I started writing a patch to allow adding a ``Reply-To`` header to the mails sent by Ossec.

This patch still needs testing on my side (and documentation writing), but I would like to have an early code-review in case I missed something; so here it is.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/727)
<!-- Reviewable:end -->
