### PR TITLE
Use RFC2606 domain name to prevent information disclosure

### DIFF
--- a/contrib/debian-packages/ossec-hids/debian/patches/02_ossec-server.conf.patch
+++ b/contrib/debian-packages/ossec-hids/debian/patches/02_ossec-server.conf.patch
@@ -7,11 +7,11 @@ Index: ossec-hids-2.8.2/etc/ossec-server.conf
  <ossec_config>
    <global>
 -    <email_notification>yes</email_notification>
--    <email_to>daniel.cid@xxx.com</email_to>
--    <smtp_server>smtp.xxx.com.</smtp_server>
--    <email_from>ossecm@ossec.xxx.com.</email_from>
+-    <email_to>daniel.cid@example.com</email_to>
+-    <smtp_server>smtp.example.com.</smtp_server>
+-    <email_from>ossecm@ossec.example.com.</email_from>
 +    <email_notification>no</email_notification>
-+    <email_to>your_email_address@xxx.com</email_to>
++    <email_to>your_email_address@example.com</email_to>
 +    <smtp_server>smtp.your_domain.com.</smtp_server>
 +    <email_from>ossecm@ossec.your_domain.com.</email_from>
    </global>

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -730,10 +730,10 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 
 <!-- Vpopmail decoder. (by Ceg Ryan <cegryan ( at ) gmail.com>)
   - Examples:
-  - vpopmail[32485]: vchkpw-pop3: password fail abc@xxx.com:x.x.x.x
-  - vpopmail[32485]: vchkpw-2110 password fail abc@xxx.com:x.x.x.x
+  - vpopmail[32485]: vchkpw-pop3: password fail abc@example.com:x.x.x.x
+  - vpopmail[32485]: vchkpw-2110 password fail abc@example.com:x.x.x.x
   -                  vchkpw-pop3: password fail (pass: 'test') user@my_domain:1.2.3.4
-  - vpopmail[2100]: vchkpw-pop3: vpopmail user not found abc@xxx.com:x.x.x.x
+  - vpopmail[2100]: vchkpw-pop3: vpopmail user not found abc@example.com:x.x.x.x
   - vpopmail[4162]: vchkpw-pop3: vpopmail user not found support@:69.3.64.3
   -->
 <decoder name="vpopmail">

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -3,9 +3,9 @@
 <ossec_config>
   <global>
     <email_notification>yes</email_notification>
-    <email_to>daniel.cid@xxx.com</email_to>
-    <smtp_server>smtp.xxx.com.</smtp_server>
-    <email_from>ossecm@ossec.xxx.com.</email_from>
+    <email_to>daniel.cid@example.com</email_to>
+    <smtp_server>smtp.example.com.</smtp_server>
+    <email_from>ossecm@ossec.example.com.</email_from>
   </global>
 
   <rules>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -3,9 +3,9 @@
 <ossec_config>
   <global>
     <email_notification>yes</email_notification>
-    <email_to>daniel.cid@xxx.com</email_to>
-    <smtp_server>smtp.xxx.com.</smtp_server>
-    <email_from>ossecm@ossec.xxx.com.</email_from>
+    <email_to>daniel.cid@example.com</email_to>
+    <smtp_server>smtp.example.com.</smtp_server>
+    <email_from>ossecm@ossec.example.com.</email_from>
   </global>
 
   <rules>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -3,9 +3,9 @@
 <ossec_config>
   <global>
     <email_notification>yes</email_notification>
-    <email_to>daniel.cid@xxx.com</email_to>
-    <smtp_server>smtp.xxx.com.</smtp_server>
-    <email_from>ossecm@ossec.xxx.com.</email_from>
+    <email_to>daniel.cid@example.com</email_to>
+    <smtp_server>smtp.example.com.</smtp_server>
+    <email_from>ossecm@ossec.example.com.</email_from>
     <picviz_output>no</picviz_output>
   </global>
 


### PR DESCRIPTION
I am an admin of the server hosting xxx.com domain and see a lot of messages in mail log from ossecm@ossec.xxx.com to daniel.cid@xxx.com. This may lead to information disclosure and the project needs to use RFC2606 domain names.
