### PR TITLE
Recalculate the permissions from octal to integer.

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -430,10 +430,10 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
                 }
             }
 
-            /* Get integer values */
+            /* Get octal values */
             if (c_newperm && c_oldperm) {
-                newperm = atoi(c_newperm);
-                oldperm = atoi(c_oldperm);
+                newperm = strtoul(c_newperm, 0, 8);
+                oldperm = strtoul(c_oldperm, 0, 8);
             }
 
             /* Generate size message */


### PR DESCRIPTION
Without this patch changes in file permissions are represented wrong (and confusing).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/735)
<!-- Reviewable:end -->
