### PR TITLE
Modified ossec-remoted to show agent ID when reported as invalid

### DIFF
--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -177,7 +177,7 @@
 #define ENCSIZE_ERROR   "%s(1405): ERROR: Message size not valid: '%s'."
 #define ENCSUM_ERROR    "%s(1406): ERROR: Checksum mismatch on message from '%s'."
 #define ENCTIME_ERROR   "%s(1407): ERROR: Duplicated counter for '%s'."
-#define ENC_IP_ERROR    "%s(1408): ERROR: Invalid ID for the source ip: '%s'."
+#define ENC_IP_ERROR    "%s(1408): ERROR: Invalid ID %s for the source ip: '%s'."
 #define ENCFILE_CHANGED "%s(1409): INFO: Authentication file changed. Updating."
 #define ENC_READ        "%s(1410): INFO: Reading authentication keys file."
 
@@ -284,4 +284,3 @@
 #define OS_AG_DISCON    "ossec: Agent disconnected: '%s'."
 
 #endif /* _ERROR_MESSAGES__H */
-

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -113,11 +113,11 @@ void HandleSecure()
                 if (check_keyupdate()) {
                     agentid = OS_IsAllowedDynamicID(&keys, buffer + 1, srcip);
                     if (agentid == -1) {
-                        merror(ENC_IP_ERROR, ARGV0, srcip);
+                        merror(ENC_IP_ERROR, ARGV0, buffer + 1, srcip);
                         continue;
                     }
                 } else {
-                    merror(ENC_IP_ERROR, ARGV0, srcip);
+                    merror(ENC_IP_ERROR, ARGV0, buffer + 1, srcip);
                     continue;
                 }
             }
@@ -174,4 +174,3 @@ void HandleSecure()
         }
     }
 }
-


### PR DESCRIPTION
This change solves the issue https://github.com/ossec/ossec-hids/issues/739 and makes OSSEC to report the ID of the agent that tries to connect but its ID doesn't match the key.