### PR TITLE
Decoder & Rules: SSH, Clam-AV, Sysmon updated

### DIFF
--- a/contrib/ossec-testing/tests/sysmon.ini
+++ b/contrib/ossec-testing/tests/sysmon.ini
@@ -1,18 +1,18 @@
 [Sysmon EventID#1 - Suspicious svchost process]
-log 1 pass = 2014 Dec 20 14:29:48 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE
+log 1 pass = 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE
 rule = 184666
 alert = 12
-decoder = Sysmon-EventID#1
+decoder = windows
 
 [Sysmon EventID#1 - non-Suspicious svchost process]
-log 1 pass = 2014 Dec 20 12:15:13 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 12:15 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\windows\system32\svchost.exe -k defragsvc"  User: NT AUTHORITY\SYSTEM  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\System32\services.exe  ParentCommandLine: C:\Windows\System32\services.exe
+log 1 pass = 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 12:15 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\windows\system32\svchost.exe -k defragsvc"  User: NT AUTHORITY\SYSTEM  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\System32\services.exe  ParentCommandLine: C:\Windows\System32\services.exe
 rule = 184667
 alert = 0
-decoder = Sysmon-EventID#1
+decoder = windows
 
 [Windows Event]
-2015 Mar 30 15:47:04 WinEvtLog: System: INFORMATION(1): Sysmon: UserName: SYSTEM-NAME: SYSTEM-NAME: Process Create:      UtcTime: 3/30/2015 10:47:04.494 PM      ProcessGuid: {7531FA7E-D268-5519-0000-00105DF81A06}      ProcessId: 4388      Image: C:\WINDOWS\system32\cmd.exe      CommandLine: "C:\windows\system32\cmd.exe"       User: SYSTEM-NAME\UserName      LogonGuid: {7531FA7E-CFE1-5519-0000-0020F62C1906}      LogonId: 0x6192cf6      TerminalSessionId: 3      IntegrityLevel: no level      HashType: SHA1      Hash: 254E37EC33C921C5AB253F14F9274F349B3CCC2D      ParentProcessGuid: {7531FA7E-CFE2-5519-0000-0010CC5A1906}      ParentProcessId: 1008      ParentImage: C:\WINDOWS\explorer.exe      ParentCommandLine: C:\windows\Explorer.EXE
+log 1 pass = 2013 Oct 09 17:09:04 WinEvtLog: Application: INFORMATION(1): My Script: (no user): no domain: demo1.foo.example.com: test
 rule = 18101
 alert = 0
-decoder = Sysmon-EventID#1
+decoder = windows
 

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -175,8 +175,8 @@
 <decoder name="ssh-invfailed">
   <parent>sshd</parent>
   <prematch>^Failed \S+ for invalid user|^Failed \S+ for illegal user</prematch>
-  <regex offset="after_prematch">from (\S+) port \d+ \w+$</regex>
-  <order>srcip</order>
+  <regex offset="after_prematch">(\S+) from (\S+)</regex>
+  <order>srcuser,srcip</order>
 </decoder>
 
 <decoder name="ssh-failed">
@@ -203,8 +203,8 @@
 <decoder name="ssh-invalid-user">
   <parent>sshd</parent>
   <prematch>^Invalid user|^Illegal user</prematch>
-  <regex offset="after_prematch"> from (\S+)$</regex>
-  <order>srcip</order>
+  <regex offset="after_prematch">(\S+) from (\S+)$</regex>
+  <order>srcuser,srcip</order>
 </decoder>
 
 <decoder name="ssh-scan">
@@ -1835,7 +1835,226 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="windows">
   <type>windows</type>
   <prematch>^\d\d\d\d \w\w\w \d\d \d\d:\d\d:\d\d WinEvtLog: |^WinEvtLog: </prematch>
-  <regex offset="after_prematch">^\.+: (\w+)\((\d+)\): (\.+): </regex>
+</decoder>
+
+<!-- WinEvtLog: sysmon decoder -->
+<!--
+    -  v1.1 2015/11/24
+    
+    - Event 1 
+    -  Originally created by Josh Brower, Josh@DefensiveDepth.com
+    -  Updated by Wazuh for support  new logs:
+        - OLD version:  "[...] HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365 [...] "
+        - NEW version: "[...] Hashes: SHA1=9FEF303BEDF8430403915951564E0D9888F6F365 [...] "
+    
+    - Event 2-8
+    -  Created by Wazuh <ossec@wazuh.com>.
+    -  jesus@wazuh.com
+    
+    -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+-->
+
+
+<!-- 
+Event ID 1: Process Created
+  
+    -  OSSEC to Sysmon Fields Mapping:
+    
+    -  user = User
+    -  status = Image
+    -  url = Hash
+    -  extra_data = ParentImage
+  
+  - Examples Old version:
+  - 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE 
+  
+  - Examples New version*:
+  - 2015 Nov 19 18:32:31 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Process Create:  UtcTime: 2015-11-19 17:32:31.562  ProcessGuid: {0B364D7C-07AF-564E-0000-001098C90800}  ProcessId: 2188  Image: C:\Windows\System32\rundll32.exe  CommandLine: C:\Windows\system32\rundll32.exe C:\Windows\system32\inetcpl.cpl,ClearMyTracksByProcess Flags:65800 WinX:0 WinY:0 IEFrame:0000000000000000  CurrentDirectory: C:\Users\Administrator.WIN-K3UD9R5LCEL\Desktop\  User: WIN-K3UD9R5LCEL\Administrator  LogonGuid: {0B364D7C-FDDB-564D-0000-00209CA10100}  LogonId: 0x1a19c  TerminalSessionId: 1  IntegrityLevel: High  Hashes: SHA1=963B55ACC8C566876364716D5AAFA353995812A8  ParentProcessGuid: {0B364D7C-FE43-564D-0000-0010F1720200}  ParentProcessId: 576  ParentImage: C:\Program Files\Internet Explorer\iexplore.exe  ParentCommandLine: "C:\Program Files\Internet Explorer\iexplore.exe"
+  
+  - With option <HashAlgorithms>*</HashAlgorithms> the log would be:
+    ...Hashes: SHA1=8F86B5A06E440A9B60AC591F814F6A8FCA58DC1D,MD5=E3BD0CF8CD561F4D33255B2E6EB0C987,SHA256=B8BC88623FD2DCDB81A31777B4B82F7A24BA6086A8A58A00B4AF198DE8CB307D,IMPHASH=8F2AF1C4B2891D7DD75333449A5C4131  ParentProcessGuid...
+    The new decoder captures everything between "=" and "ParentProcessGuid".
+-->
+
+<decoder name="Sysmon-EventID#1">
+    <parent>windows</parent>
+    <type>windows</type>
+    <prematch>INFORMATION\(1\)\.+HashType</prematch>
+    <regex>Image: (\.*) \s*CommandLine: \.* \s*User: (\.*) \s*LogonGuid: \S* \s*LogonId: \S* \s*TerminalSessionId: \S* \s*IntegrityLevel: \.*HashType: \S* \s*Hash: (\S*) \s*ParentProcessGuid: \S* \s*ParentProcessID: \S* \s*ParentImage: (\.*) \s*ParentCommandLine:</regex>
+    <order>status,user,url,data</order>
+</decoder>
+
+<decoder name="Sysmon-EventID#1_new">
+    <parent>windows</parent>
+    <type>windows</type>
+    <prematch>INFORMATION\(1\)\.+Hashes</prematch>
+    <regex>Image: (\.*) \s*CommandLine: \.* \s*User: (\.*) \s*LogonGuid: \S* \s*LogonId: \S* \s*TerminalSessionId: \S* \s*IntegrityLevel: \.*Hashes: \S+=(\S*)\s*ParentProcessGuid: \S* \s*ParentProcessID: \S* \s*ParentImage: (\.*.\S+) \s*ParentCommandLine:</regex>
+    <order>status,user,url,data</order>
+</decoder>
+
+
+<!--
+    - Event 2-8
+    -  v1.0 2015/11/20
+    -  Created by Wazuh, Inc. <ossec@wazuh.com>.
+    -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
+-->
+
+<!--
+Event ID 2: A process changed a file creation time
+
+    -  OSSEC to Sysmon Fields Mapping:
+
+    -  status = Image
+    -  url = TargetFilename
+    -  srcport = PreviousCreationUtcTime
+    -  dstport = CreationUtcTime
+
+Example:
+2015 Nov 19 18:32:16 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(2): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: File creation time changed:  UtcTime: 2015-11-19 17:32:16.578  ProcessGuid: {0B364D7C-FE43-564D-0000-0010F1720200}  ProcessId: 576  Image: C:\Program Files\Internet Explorer\iexplore.exe  TargetFilename: C:\Users\Administrator.WIN-K3UD9R5LCEL\AppData\Roaming\Microsoft\Windows\Recent\CustomDestinations\QK9FKZ7I2DSU0MTCD160.temp  CreationUtcTime: 2015-11-19 03:28:08.281  PreviousCreationUtcTime: 2015-11-19 17:32:16.578
+-->
+<decoder name="Sysmon-EventID#2">
+    <parent>windows</parent>
+    <type>windows</type>
+    <prematch>Microsoft-Windows-Sysmon/Operational: INFORMATION\(2\)</prematch>
+    <regex offset="after_prematch">Image: (\.*)\s+TargetFilename: (\.*)\s+CreationUtcTime: (\.*)\s+PreviousCreationUtcTime: (\.*)</regex>
+    <order>status, url, dstport, srcport</order>
+</decoder>
+
+<!--
+Event ID 3: Network connection
+
+    -  OSSEC to Sysmon Fields Mapping:
+
+    -  status = Image
+    -  user = user
+    -  extra_data= Protocol
+    -  srcip = SourceIp
+    -  srcport = SourcePort
+    -  dstip = DestinationIp
+    -  dstport = DestinationPort
+
+Example:
+2015 Nov 19 20:33:25 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(3): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Network connection detected:  UtcTime: 2015-11-19 19:33:23.824  ProcessGuid: {0B364D7C-23F6-564E-0000-00100D5A1100}  ProcessId: 2028  Image: C:\Program Files (x86)\Internet Explorer\iexplore.exe  User: WIN-K3UD9R5LCEL\Administrator  Protocol: tcp  Initiated: true  SourceIsIpv6: false  SourceIp: 192.168.2.201  SourceHostname: WIN-K3UD9R5LCEL.LinDomain  SourcePort: 49192  SourcePortName:   DestinationIsIpv6: false  DestinationIp: XXX.58.XXX.206  DestinationHostname: webdest  DestinationPort: 443  DestinationPortName: https
+-->
+<decoder name="Sysmon-EventID#3">
+    <parent>windows</parent>
+    <type>windows</type>
+    <prematch>Microsoft-Windows-Sysmon/Operational: INFORMATION\(3\)</prematch>
+    <regex offset="after_prematch">Image: (\.*)\s+User: (\.*)\s+Protocol: (\S*)\s+Initiated\.+SourceIp: (\S*)\s+SourceHostname\.+SourcePort: (\S*)\s+SourcePortName:\.+DestinationIsIpv6\.+DestinationIp: (\S*)\s+DestinationHostname:\.+\s+DestinationPort: (\S*)</regex>
+    <order>status, user, extra_data, srcip, srcport, dstip, dstport</order>
+</decoder>
+
+<!--
+Event ID 4: Sysmon service state changed
+
+    -  OSSEC to Sysmon Fields Mapping:
+
+    -  status = State
+
+
+Example:
+2015 Nov 19 20:27:42 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(4): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Sysmon service state changed:  UtcTime: 2015-11-19 19:27:42.796  State: Started
+-->
+<decoder name="Sysmon-EventID#4">
+    <parent>windows</parent>
+    <type>windows</type>
+    <prematch>Microsoft-Windows-Sysmon/Operational: INFORMATION\(4\)</prematch>
+    <regex offset="after_prematch">State: (\S*)</regex>
+    <order>status</order>
+</decoder>
+
+<!--
+Event ID 5: Process terminated
+
+    -  OSSEC to Sysmon Fields Mapping:
+
+    -  status = Image
+
+
+Example:
+2015 Nov 19 20:41:57 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(5): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Process terminated:  UtcTime: 2015-11-19 19:41:57.648  ProcessGuid: {0B364D7C-2353-564E-0000-001025511000}  ProcessId: 2196  Image: C:\Windows\System32\wbem\WmiPrvSE.exe
+-->
+<decoder name="Sysmon-EventID#5">
+    <parent>windows</parent>
+    <type>windows</type>
+    <prematch>Microsoft-Windows-Sysmon/Operational: INFORMATION\(5\)</prematch>
+    <regex offset="after_prematch">Image: (\S*)</regex>
+    <order>status</order>
+</decoder>
+
+<!--
+Event ID 6: Driver loaded
+
+    -  OSSEC to Sysmon Fields Mapping:
+
+    -  status = ImageLoaded
+    -  url = Hash
+    -  action = Signed
+    -  extra_data = Signature
+
+Example:
+2015 Nov 20 11:01:41 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(6): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Driver loaded:  UtcTime: 2015-11-20 10:01:41.765  ImageLoaded: C:\Windows\System32\drivers\cdrom.sys  Hashes: SHA1=89204964B695862C31B10AB7129EC96B66C78F89  Signed: true  Signature: Microsoft Windows
+-->
+<decoder name="Sysmon-EventID#6">
+    <parent>windows</parent>
+    <type>windows</type>
+    <prematch>Microsoft-Windows-Sysmon/Operational: INFORMATION\(6\)</prematch>
+    <regex offset="after_prematch">ImageLoaded: (\S*)\s+Hashes: \S+=(\S*)\s+Signed: (\S*)\s+Signature: (\.*)</regex>
+    <order>status, url, action, extra_data</order>
+</decoder>
+
+<!--
+Event ID 7: Image loaded
+
+    -  OSSEC to Sysmon Fields Mapping:
+
+    -  status = Image
+    -  id = ImageLoaded
+    -  url = Hash
+    -  action = Signed
+    -  extra_data = Signature
+
+Example:
+2015 Nov 20 11:26:13 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(7): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: Image loaded:  UtcTime: 2015-11-20 10:26:13.672  ProcessGuid: {0B364D7C-F545-564E-0000-001085D69400}  ProcessId: 2216  Image: C:\Windows\System32\cmd.exe  ImageLoaded: C:\Windows\System32\msctf.dll  Hashes: SHA1=E425577CCFC9B92EFBBCB760D21FCAA478D3E51A  Signed: true  Signature: Microsoft Windows
+-->
+<decoder name="Sysmon-EventID#7">
+    <parent>windows</parent>
+    <type>windows</type>
+    <prematch>Microsoft-Windows-Sysmon/Operational: INFORMATION\(7\)</prematch>
+    <regex offset="after_prematch">Image: (\S*)\s+ImageLoaded: (\S*)\s+Hashes: \S+=(\S*)\s+Signed: (\S*)\s+Signature: (\.*)</regex>
+    <order>status, id, url, action, extra_data</order>
+</decoder>
+
+
+<!--
+Event ID 8: CreateRemoteThread
+
+    -  OSSEC to Sysmon Fields Mapping:
+
+    -  status = SourceImage
+    -  id = TargetImage
+    -  action = StartModule
+    -  extra_data = StartFunction
+
+Example:
+2015 Nov 20 11:25:44 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(8): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-K3UD9R5LCEL: CreateRemoteThread detected:  UtcTime: 2015-11-20 10:25:44.562  SourceProcessGuid: {0B364D7C-E952-564E-0000-00104C3B0000}  SourceProcessId: 388  SourceImage: C:\Windows\System32\csrss.exe  TargetProcessGuid: {0B364D7C-EF10-564E-0000-001010EA0700}  TargetProcessId: 1152  TargetImage: C:\Windows\System32\cmd.exe  NewThreadId: 2128  StartAddress: 0x00000000777F4910  StartModule: C:\Windows\system32\kernel32.dll  StartFunction: CtrlRoutine
+-->
+<decoder name="Sysmon-EventID#8">
+    <parent>windows</parent>
+    <type>windows</type>
+    <prematch>Microsoft-Windows-Sysmon/Operational: INFORMATION\(8\)</prematch>
+    <regex offset="after_prematch">SourceImage: (\S*)\s+\.+TargetImage: (\S*)\s+\.+StartModule: (\S*)\s+StartFunction: (\.*)</regex>
+    <order>status, id, url, extra_data</order>
+</decoder>
+<!-- sysmon decoder END -->
+
+
+<!-- WinEvtLog Generic -->
+<decoder name="windows-EvtLog">
+  <type>windows</type>
+  <parent>windows</parent>
+  <regex offset="after_parent">^\.+: (\w+)\((\d+)\): (\.+): </regex>
   <regex>(\.+): \.+: (\S+): </regex>
   <order>status, id, extra_data, user, system_name</order>
   <fts>name, location, user, system_name</fts>
@@ -2390,6 +2609,19 @@ in HTTP request too long; attack: Malformed HTTP; src: 10.10.10.4; dst:
   <program_name>^clamd</program_name>
 </decoder>
 
+<!--
+Nov 18 16:51:04 hostname clamd[511]: /usr/share/clamav-testfiles/clam.arj: ClamAV-Test-File(f58327b03afd2a727c3329ba3c0947a7:393) FOUND
+       url: '/usr/share/clamav-testfiles/clam.arj'
+       extra_data: 'ClamAV-Test-File'
+       id: 'f58327b03afd2a727c3329ba3c0947a7'
+-->
+<decoder name="clamd-found">
+  <parent>clamd</parent>
+   <prematch>FOUND</prematch>
+   <regex>(\S+):\s+(\S+)\((\S+):</regex>
+   <order>url, extra_data, id</order>
+</decoder>
+
 <decoder name="freshclam">
   <program_name>^freshclam</program_name>
 </decoder>
@@ -2733,27 +2965,6 @@ Jul 26 13:57:56 mx1.example.org outbound/smtp: 127.0.0.1 1406297159-06f4a35b4df2
   <order>srcip,action,user</order>
 </decoder>
 
-
-<!-- 
-  - Decoder for Sysmon Event ID 1: Process Created
-  - Maintained by Josh Brower, Josh@DefensiveDepth.com 
-  -
-  -  OSSEC to Sysmon Fields Mapping:
-  -  user = User
-  -  status = Image
-  -  url = Hash
-  -  extra_data = ParentImage
-  
-  - Examples:
-  - 2014 Dec 20 14:29:48 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE 
--->
-
-<decoder name="Sysmon-EventID#1">
-<type>windows</type>
-<prematch>INFORMATION\(1\)</prematch>
-<regex offset="after_prematch">Image: (\.*) \s*CommandLine: \.* \s*User: (\.*) \s*LogonGuid: \S* \s*LogonId: \S* \s*TerminalSessionId: \S* \s*IntegrityLevel: \.*HashType: \S* \s*Hash: (\S*) \s*ParentProcessGuid: \S* \s*ParentProcessID: \S* \s*ParentImage: (\.*) \s*ParentCommandLine:</regex>
-<order>status,user,url,data</order>
-</decoder>
 
 <!-- unbound
   - 2014-05-20T09:01:07.283219-04:00 arrakis unbound: [9405:0] notice: sendto failed: Can't assign requested address

--- a/etc/rules/clam_av_rules.xml
+++ b/etc/rules/clam_av_rules.xml
@@ -65,5 +65,19 @@
     <match>Incremental update failed|Error while reading database from|Update failed.</match>
     <description>Could not download the incremental virus definition updates.</description>
   </rule>
+  
+  <rule id="52510" level="6">
+    <if_sid>52500</if_sid>
+    <match>stop|Stop</match>
+    <description>Clamd stopped</description>
+    <group>virus,</group>
+  </rule>
+  
+  <rule id="52511" level="10" frequency="6">
+    <if_matched_sid>52502</if_matched_sid>
+    <same_id />
+    <description>Virus detected multiple times</description>
+    <group>virus,</group>
+  </rule>
 
 </group> <!-- clamd, freshclam -->


### PR DESCRIPTION
I have been improving the following decoders and rules:
- SSH Decoder modified to extract user name when invalid/illegal users trying to log in.
- ClamAV:
  - New decoder: Extract main fields (path, virus name, hash) when a virus is detected.
  - New rule: ClamAV Stopped.
  - New rule: Virus detected multiple times.
- Sysmon Decoder:
  - New decoders for Event 1 - 8.
  - Bug fixed: "windows" must be the parent decoder of "sysmon".

We were discussing about Sysmon decoders here: https://groups.google.com/forum/#!topic/ossec-list/eAblb28kxA0

Travis fails due to the problem with windows decoder explained here: #712.
I sent the same pull request https://github.com/ossec/ossec-hids/pull/711, but I closed it due to managment issues with our repository.

I hope it will be helpful.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/743)
<!-- Reviewable:end -->
