### PR TITLE
Opening files for hashing in binary mode

### DIFF
--- a/src/os_crypto/md5/md5_op.c
+++ b/src/os_crypto/md5/md5_op.c
@@ -29,7 +29,7 @@ int OS_MD5_File(const char *fname, os_md5 output)
     memset(output, 0, 33);
     buf[1024] = '\0';
 
-    fp = fopen(fname, "r");
+    fp = fopen(fname, "rb");
     if (!fp) {
         return (-1);
     }
@@ -71,4 +71,3 @@ int OS_MD5_Str(const char *str, os_md5 output)
 
     return (0);
 }
-

--- a/src/os_crypto/md5_sha1/md5_sha1_op.c
+++ b/src/os_crypto/md5_sha1/md5_sha1_op.c
@@ -34,7 +34,7 @@ int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5out
 
     /* Use prefilter_cmd if set */
     if (prefilter_cmd == NULL) {
-        fp = fopen(fname, "r");
+        fp = fopen(fname, "rb");
         if (!fp) {
             return (-1);
         }
@@ -86,4 +86,3 @@ int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5out
 
     return (0);
 }
-

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -36,7 +36,7 @@ int OS_SHA1_File(const char *fname, os_sha1 output)
     memset(output, 0, 65);
     buf[2049] = '\0';
 
-    fp = fopen(fname, "r");
+    fp = fopen(fname, "rb");
     if (!fp) {
         return (-1);
     }
@@ -58,4 +58,3 @@ int OS_SHA1_File(const char *fname, os_sha1 output)
 
     return (0);
 }
-


### PR DESCRIPTION
Current version opens files in text mode to extract the hash. This produces an incorrect hash in Windows.

This commit should solve the issue https://github.com/ossec/ossec-hids/issues/42, since hashes aren't intencionally alterated in Windows, but certain bytes adulterate the hash digest if the file is opened in text mode.