### PR TITLE
apache decoders updated

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1570,56 +1570,63 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 
 
 <!-- Apache decoder.
+  - Updated by jesus@wazuh.com. 2016/02/17
   - Will extract the srcip
   - Examples:
-  - [error] [client 80.230.208.105] Directory index forbidden by rule: /home/
-  - [error] [client 64.94.163.159] Client sent malformed Host header
-  - [error] [client 66.31.142.16] File does not exist: /var/www/html/default.ida
-  - [notice] Apache configured
-  - httpd[18660]: [error] [client 12.34.56.78] File does not exist: /usr/local/htdocs/cache
-  - httpd[23745]: [error] [client 12.34.56.78] PHP Notice:
-  - [Tue Sep 30 11:30:13.262255 2014] [core:error] [pid 20101] [client 99.47.227.95:34567] AH00037: Symbolic link not allowed or link target not accessible: /usr/share/awstats/icon/mime/document.png
-  - [Tue Sep 30 12:11:21.258612 2014] [ssl:error] [pid 30473] AH02032: Hostname www.example.com provided via SNI and hostname ssl://www.example.com provided via HTTP are different
-  - [Tue Sep 30 12:24:22.891366 2014] [proxy:warn] [pid 2331] [client 77.127.180.111:54082] AH01136: Unescaped URL path matched ProxyPass; ignoring unsafe nocanon, referer: http://www.easylinker.co.il/he/links.aspx?user=bguyb
-  - [Tue Sep 30 14:25:44.895897 2014] [authz_core:error] [pid 31858] [client 99.47.227.95:38870] AH01630: client denied by server configuration: /var/www/example.com/docroot/
-  - [Thu Oct 23 15:17:55.926067 2014] [ssl:info] [pid 18838] [client 36.226.119.49:2359] AH02008: SSL library error 1 in handshake (server www.example.com:443)
-  - [Thu Oct 23 15:17:55.926123 2014] [ssl:info] [pid 18838] SSL Library Error: error:1407609B:SSL routines:SSL23_GET_CLIENT_HELLO:https proxy request -- speaking HTTP to HTTPS port!?
-  - [Sun Nov 23 18:49:01.713508 2014] [:error] [pid 15816] [client 141.8.147.9:51507] PHP Notice:  A non well formed numeric value encountered in /path/to/file.php on line 123
-  -->
+  - Without ID: Will extract the srcip and srcport (when it is available)
+      - [error] [client 80.230.208.105] Directory index forbidden by rule: /home/
+      - [error] [client 64.94.163.159] Client sent malformed Host header
+      - [error] [client 66.31.142.16] File does not exist: /var/www/html/default.ida
+      - [Sun Nov 23 18:49:01.713508 2014] [:error] [pid 15816] [client 141.8.147.9:51507] PHP Notice:  A non well formed numeric value encountered in /path/to/file.php on line 123
+      - Feb 17 18:00:00 myhost httpd[18660]: [error] [client 12.34.56.78] File does not exist: /usr/local/htdocs/cache
+      - Feb 17 18:00:00 myhost httpd[23745]: [error] [client 12.34.56.78] PHP Notice:
+  - With IP + ID: Will extract the srcip, id, and srcport (when it is available)
+      - [Tue Sep 30 11:30:13.262255 2014] [core:error] [pid 20101] [client 99.47.227.95:34567] AH00037: Symbolic link not allowed or link target not accessible: /usr/share/awstats/icon/mime/document.png
+      - [Tue Sep 30 12:24:22.891366 2014] [proxy:warn] [pid 2331] [client 77.127.180.111:54082] AH01136: Unescaped URL path matched ProxyPass; ignoring unsafe nocanon, referer: http://www.easylinker.co.il/he/links.aspx?user=bguyb
+      - [Tue Sep 30 14:25:44.895897 2014] [authz_core:error] [pid 31858] [client 99.47.227.95:38870] AH01630: client denied by server configuration: /var/www/example.com/docroot/
+      - [Thu Oct 23 15:17:55.926067 2014] [ssl:info] [pid 18838] [client 36.226.119.49:2359] AH02008: SSL library error 1 in handshake (server www.example.com:443)
+      - ModSecurity
+        - [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10] ModSecurity: Access denied with code 403 (phase 2). Text...
+        - [Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10:5555] ModSecurity: Access denied with code 403 (phase 2). Text...
+  - Others
+      - [notice] Apache configured
+      - [Thu Oct 23 15:17:55.926123 2014] [ssl:info] [pid 18838] SSL Library Error: error:1407609B:SSL routines:SSL23_GET_CLIENT_HELLO:https proxy request -- speaking HTTP to HTTPS port!?
+      - [Tue Sep 30 12:11:21.258612 2014] [ssl:error] [pid 30473] AH02032: Hostname www.example.com provided via SNI and hostname ssl://www.example.com provided via HTTP are different
+-->
+
 <decoder name="apache-errorlog">
-  <program_name>^httpd</program_name>
+    <program_name>^httpd</program_name>
 </decoder>
 
 <decoder name="apache-errorlog">
-  <prematch>^[warn] |^[notice] |^[error] </prematch>
+    <prematch>^[warn] |^[notice] |^[error] </prematch>
 </decoder>
 
 <decoder name="apache-errorlog">
-  <prematch>^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:warn] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:notice] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S*:error] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:info] </prematch>
+    <prematch>^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:warn] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:notice] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S*:error] |^[\w+ \w+ \d+ \d+:\d+:\d+.\d+ \d+] [\S+:info] </prematch>
+</decoder>
+
+
+<decoder name="apache24-errorlog-ip-port">
+    <parent>apache-errorlog</parent>
+    <prematch offset="after_parent">[client \S+:\d+] \S+:</prematch>
+    <regex offset="after_parent">[client (\S+):(\d+)] (\S+): </regex>
+    <order>srcip,srcport,id</order>
 </decoder>
 
 <decoder name="apache24-errorlog-ip">
-  <parent>apache-errorlog</parent>
-
-  <prematch offset="after_parent">[client</prematch>
-  <regex offset="after_prematch">^ (\S+):\d+] (\S+): </regex>
-  <order>srcip,id</order>
+    <parent>apache-errorlog</parent>
+    <prematch offset="after_parent">[client \S+] \S+:</prematch>
+    <regex offset="after_parent">[client (\S+)] (\S+): </regex>
+    <order>srcip,id</order>
 </decoder>
 
-<decoder name="apache24-modsec-errorlog-ip">
-  <parent>apache-errorlog</parent>
-
-  <prematch offset="after_parent">[client</prematch>
-  <regex offset="after_prematch">^ (\S+)] ModSecurity: </regex>
-  <order>srcip</order>
-</decoder>
 
 <decoder name="apache-errorlog-ip">
-  <parent>apache-errorlog</parent>
-
-  <prematch offset="after_parent">^[client</prematch>
-  <regex offset="after_prematch">^ (\S+)] </regex>
-  <order>srcip</order>
+    <parent>apache-errorlog</parent>
+    <prematch offset="after_parent">[client</prematch>
+    <regex offset="after_prematch">^ (\S+):(\d+)] |^ (\S+)] </regex>
+    <order>srcip,srcport</order>
 </decoder>
 
 


### PR DESCRIPTION
The following logs don't extract any field:

```
[error] [client 80.230.208.105] Directory index forbidden by rule: /home/
[error] [client 64.94.163.159] Client sent malformed Host header
[error] [client 66.31.142.16] File does not exist: /var/www/html/default.ida
[Sun Nov 23 18:49:01.713508 2014] [:error] [pid 15816] [client 141.8.147.9:51507] PHP Notice:  A non well formed numeric value encountered in /path/to/file.php on line 123
Feb 17 18:00:00 myhost httpd[18660]: [error] [client 12.34.56.78] File does not exist: /usr/local/htdocs/cache
Feb 17 18:00:00 myhost httpd[23745]: [error] [client 12.34.56.78] PHP Notice:

[Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10] ModSecurity: Access denied with code 403 (phase 2). Text...
```
These logs don't extract srcport:
```
[Tue Sep 30 11:30:13.262255 2014] [core:error] [pid 20101] [client 99.47.227.95:34567] AH00037: Symbolic link not allowed or link target not accessible: /usr/share/awstats/icon/mime/document.png
[Tue Sep 30 12:24:22.891366 2014] [proxy:warn] [pid 2331] [client 77.127.180.111:54082] AH01136: Unescaped URL path matched ProxyPass; ignoring unsafe nocanon, referer: http://www.easylinker.co.il/he/links.aspx?user=bguyb
[Tue Sep 30 14:25:44.895897 2014] [authz_core:error] [pid 31858] [client 99.47.227.95:38870] AH01630: client denied by server configuration: /var/www/example.com/docroot/
[Thu Oct 23 15:17:55.926067 2014] [ssl:info] [pid 18838] [client 36.226.119.49:2359] AH02008: SSL library error 1 in handshake (server www.example.com:443)
[Tue Feb 16 04:02:21.018764 2016] [:error] [pid 3223] [client 10.10.10.10:5555] ModSecurity: Access denied with code 403 (phase 2). Text...
```
**With the new decoders this is solved**. It is especially interesting that a ModSecurity log without port was decoded without extract any field.

More info: https://groups.google.com/forum/#!topic/ossec-list/pOF9SRdQdrs