### PR TITLE
Simple Python script to list rules

### DIFF
--- a/contrib/ossec_rules_list.py
+++ b/contrib/ossec_rules_list.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# OSSEC Rules list
+# Simple script to get a short brief of every rule in OSSEC rules folder
+# pedro@wazuh.com
+
+import sys
+import re
+import os
+
+rules_directory = "/var/ossec/rules/"
+
+def GetRulesList(fulldir, filename):
+    rule_detected = 0
+    rule_description = 0
+    level = ""
+    sidid = ""
+    description = ""
+    pattern_idlevel = re.compile(r'<rule id="(.+?)".+level="(.+?)"')
+    pattern_description = re.compile(r'<description>(.+?)</description>')
+    pattern_endrule = re.compile(r'</rule>')
+    try:
+        with open(fulldir) as f:
+            lines = f.readlines()
+            for line in lines:
+                if rule_detected == 0:
+                    match = re.findall(pattern_idlevel, line)
+                    if match:
+                        rule_detected = 1
+                        sidid = match[0][0]
+                        level = match[0][1]
+                else:
+                    if rule_description == 0:
+                        match = re.findall(pattern_description, line)
+                        if match:
+                            rule_description = 1
+                            description = match[0]
+                    if rule_description == 1:
+                        match = re.findall(pattern_endrule, line)
+                        if match:
+                            print "%s - Rule %s - Level %s -> %s" % (filename,sidid,level,description)
+                            rule_detected = 0
+                            rule_description = 0
+                            level = ""
+                            sidid = ""
+                            description = ""
+    except EnvironmentError: 
+           print ("Error: OSSEC rules directory does not appear to exist")
+           
+if __name__ == "__main__":
+    print ("Reading rules from directory %s") % (rules_directory)
+    for root, directories, filenames in os.walk(rules_directory):
+        for filename in filenames:
+            if filename[-4:] == ".xml":
+                GetRulesList(os.path.join(root,filename), filename)


### PR DESCRIPTION
Simple script to get a short brief of every rule in OSSEC rules folder.

Discussed at OSSEC Mail list: https://groups.google.com/forum/#!topic/ossec-list/44VNExJ6oCw

Output example:

> mailscanner_rules.xml - Rule 3751 - Level 6 -> Multiple attempts of spam.
> hordeimp_rules.xml - Rule 9300 - Level 0 -> Grouping for the Horde imp rules.
> hordeimp_rules.xml - Rule 9301 - Level 0 -> Horde IMP informational message.
> apache_rules.xml - Rule 30412 - Level 6 -> Shellshock attack attempt
> roundcube_rules.xml - Rule 9400 - Level 0 -> Roundcube messages groupe.d

