### PR TITLE
Allow the ossec users to be created on OpenBSD

### DIFF
--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -68,7 +68,7 @@ else
 
     for U in ${USER} ${USER_MAIL} ${USER_REM}; do
         if ! grep "^${U}" /etc/passwd > /dev/null 2>&1; then
-            ${USERADD} "${U}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"
+            ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
         fi
     done
 fi

--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -68,7 +68,11 @@ else
 
     for U in ${USER} ${USER_MAIL} ${USER_REM}; do
         if ! grep "^${U}" /etc/passwd > /dev/null 2>&1; then
-            ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
+	    if [ "$UNAME" = "OpenBSD" ]; then
+               ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
+	    else
+	       ${USERADD} "${U}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"
+	    fi
         fi
     done
 fi

--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -68,7 +68,7 @@ else
 
     for U in ${USER} ${USER_MAIL} ${USER_REM}; do
         if ! grep "^${U}" /etc/passwd > /dev/null 2>&1; then
-            ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
+            ${USERADD} "${U}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"
         fi
     done
 fi


### PR DESCRIPTION
I'm not sure why this worked before, or why it stopped working, but this fixes it.
This wasn't tested on Linux or any other system due to an "oops event."

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/754)
<!-- Reviewable:end -->
