### PR TITLE
Do not show diff

### DIFF
--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -20,6 +20,9 @@
     <ignore>/etc/random-seed</ignore>
     <ignore>/etc/adjtime</ignore>
     <ignore>/etc/httpd/logs</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
   </syscheck>
 
   <rootcheck>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -90,6 +90,9 @@
     <ignore>/etc/random-seed</ignore>
     <ignore>/etc/adjtime</ignore>
     <ignore>/etc/httpd/logs</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
   </syscheck>
 
   <rootcheck>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -82,6 +82,10 @@
     <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
     <directories check_all="yes">/bin,/sbin</directories>
 
+    <!-- Never output the diff for those file -->
+    <nodiff>/etc/secrets</nodiff>
+    <nodiff>/etc/here/secrets</nodiff>
+
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
     <ignore>/etc/hosts.deny</ignore>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -82,10 +82,6 @@
     <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
     <directories check_all="yes">/bin,/sbin</directories>
 
-    <!-- Never output the diff for those file -->
-    <nodiff>/etc/secrets</nodiff>
-    <nodiff>/etc/here/secrets</nodiff>
-
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>
     <ignore>/etc/hosts.deny</ignore>
@@ -93,6 +89,9 @@
     <ignore>/etc/random-seed</ignore>
     <ignore>/etc/adjtime</ignore>
     <ignore>/etc/httpd/logs</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
   </syscheck>
 
   <rootcheck>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -47,6 +47,9 @@
     <ignore>/etc/random-seed</ignore>
     <ignore>/etc/adjtime</ignore>
     <ignore>/etc/httpd/logs</ignore>
+
+    <!-- Check the file, but never compute the diff -->
+    <nodiff>/etc/ssl/private.key</nodiff>
   </syscheck>
 
   <rootcheck>

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -467,6 +467,7 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
 
     syscheck_config *syscheck;
     syscheck = (syscheck_config *)configp;
+    unsigned int nodiff_size = 0;
 
     while (node[i]) {
         if (!node[i]->element) {
@@ -705,16 +706,15 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
 #endif
         /* Getting file/dir nodiff */
         } else if (strcmp(node[i]->element,xml_nodiff) == 0) {
-            unsigned int ign_size = 0;
 #ifdef WIN32
             /* For Windows, we attempt to expand environment variables */
-            char *new_ig = NULL;
-            os_calloc(2048, sizeof(char), new_ig);
+            char *new_nodiff = NULL;
+            os_calloc(2048, sizeof(char), new_nodiff);
 
-            ExpandEnvironmentStrings(node[i]->content, new_ig, 2047);
+            ExpandEnvironmentStrings(node[i]->content, new_nodiff, 2047);
 
             free(node[i]->content);
-            node[i]->content = new_ig;
+            node[i]->content = new_nodiff;
 #endif
             /* Add if regex */
             if (node[i]->attributes && node[i]->values) {
@@ -722,31 +722,33 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
                         (strcmp(node[i]->attributes[0], "type") == 0) &&
                         (strcmp(node[i]->values[0], "sregex") == 0)) {
                     OSMatch *mt_pt;
-
                     if (!syscheck->nodiff_regex) {
                         os_calloc(2, sizeof(OSMatch *), syscheck->nodiff_regex);
                         syscheck->nodiff_regex[0] = NULL;
                         syscheck->nodiff_regex[1] = NULL;
                     } else {
-                        while (syscheck->nodiff_regex[ign_size] != NULL) {
-                            ign_size++;
+                        while (syscheck->nodiff_regex[nodiff_size] != NULL) {
+                            nodiff_size++;
                         }
 
                         os_realloc(syscheck->nodiff_regex,
-                                   sizeof(OSMatch *) * (ign_size + 2),
+                                   sizeof(OSMatch *) * (nodiff_size + 2),
                                    syscheck->nodiff_regex);
-                        syscheck->nodiff_regex[ign_size + 1] = NULL;
+                        syscheck->nodiff_regex[nodiff_size + 1] = NULL;
                     }
                     os_calloc(1, sizeof(OSMatch),
-                              syscheck->nodiff_regex[ign_size]);
-
+                              syscheck->nodiff_regex[nodiff_size]);
+                    verbose("Found nodiff regex node %s", node[i]->content);
                     if (!OSMatch_Compile(node[i]->content,
-                                         syscheck->nodiff_regex[ign_size], 0)) {
-                        mt_pt = (OSMatch *)syscheck->nodiff_regex[ign_size];
+                                         syscheck->nodiff_regex[nodiff_size], 0)) {
+                        mt_pt = (OSMatch *)syscheck->nodiff_regex[nodiff_size];
                         merror(REGEX_COMPILE, __local_name, node[i]->content,
                                mt_pt->error);
                         return (0);
                     }
+                    verbose("Found nodiff regex node %s OK?", node[i]->content);
+                    verbose("Found nodiff regex size %d", nodiff_size);
+                    verbose("Set nodiff regex: %s", syscheck->nodiff_regex[nodiff_size]->patterns);
                 } else {
                     merror(SK_INV_ATTR, __local_name, node[i]->attributes[0]);
                     return (OS_INVALID);
@@ -760,16 +762,16 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
                     syscheck->nodiff[0] = NULL;
                     syscheck->nodiff[1] = NULL;
                 } else {
-                    while (syscheck->nodiff[ign_size] != NULL) {
-                        ign_size++;
+                    while (syscheck->nodiff[nodiff_size] != NULL) {
+                        nodiff_size++;
                     }
 
                     os_realloc(syscheck->nodiff,
-                               sizeof(char *) * (ign_size + 2),
+                               sizeof(char *) * (nodiff_size + 2),
                                syscheck->nodiff);
-                    syscheck->nodiff[ign_size + 1] = NULL;
+                    syscheck->nodiff[nodiff_size + 1] = NULL;
                 }
-                os_strdup(node[i]->content, syscheck->nodiff[ign_size]);
+                os_strdup(node[i]->content, syscheck->nodiff[nodiff_size]);
             }
         } else if (strcmp(node[i]->element, xml_auto_ignore) == 0) {
             /* auto_ignore is not read here */

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -457,6 +457,7 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
     const char *xml_scan_on_start = "scan_on_start";
     const char *xml_prefilter_cmd = "prefilter_cmd";
     const char *xml_skip_nfs = "skip_nfs";
+    const char *xml_nodiff = "nodiff";
 
     /* Configuration example
     <directories check_all="yes">/etc,/usr/bin</directories>
@@ -702,6 +703,74 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
                 os_strdup(node[i]->content, syscheck->registry_ignore[ign_size]);
             }
 #endif
+        /* Getting file/dir nodiff */
+        } else if (strcmp(node[i]->element,xml_nodiff) == 0) {
+            unsigned int ign_size = 0;
+#ifdef WIN32
+            /* For Windows, we attempt to expand environment variables */
+            char *new_ig = NULL;
+            os_calloc(2048, sizeof(char), new_ig);
+
+            ExpandEnvironmentStrings(node[i]->content, new_ig, 2047);
+
+            free(node[i]->content);
+            node[i]->content = new_ig;
+#endif
+            /* Add if regex */
+            if (node[i]->attributes && node[i]->values) {
+                if (node[i]->attributes[0] && node[i]->values[0] &&
+                        (strcmp(node[i]->attributes[0], "type") == 0) &&
+                        (strcmp(node[i]->values[0], "sregex") == 0)) {
+                    OSMatch *mt_pt;
+
+                    if (!syscheck->nodiff_regex) {
+                        os_calloc(2, sizeof(OSMatch *), syscheck->nodiff_regex);
+                        syscheck->nodiff_regex[0] = NULL;
+                        syscheck->nodiff_regex[1] = NULL;
+                    } else {
+                        while (syscheck->nodiff_regex[ign_size] != NULL) {
+                            ign_size++;
+                        }
+
+                        os_realloc(syscheck->nodiff_regex,
+                                   sizeof(OSMatch *) * (ign_size + 2),
+                                   syscheck->nodiff_regex);
+                        syscheck->nodiff_regex[ign_size + 1] = NULL;
+                    }
+                    os_calloc(1, sizeof(OSMatch),
+                              syscheck->nodiff_regex[ign_size]);
+
+                    if (!OSMatch_Compile(node[i]->content,
+                                         syscheck->nodiff_regex[ign_size], 0)) {
+                        mt_pt = (OSMatch *)syscheck->nodiff_regex[ign_size];
+                        merror(REGEX_COMPILE, __local_name, node[i]->content,
+                               mt_pt->error);
+                        return (0);
+                    }
+                } else {
+                    merror(SK_INV_ATTR, __local_name, node[i]->attributes[0]);
+                    return (OS_INVALID);
+                }
+            }
+
+            /* Add if simple entry -- check for duplicates */
+            else if (!os_IsStrOnArray(node[i]->content, syscheck->nodiff)) {
+                if (!syscheck->nodiff) {
+                    os_calloc(2, sizeof(char *), syscheck->nodiff);
+                    syscheck->nodiff[0] = NULL;
+                    syscheck->nodiff[1] = NULL;
+                } else {
+                    while (syscheck->nodiff[ign_size] != NULL) {
+                        ign_size++;
+                    }
+
+                    os_realloc(syscheck->nodiff,
+                               sizeof(char *) * (ign_size + 2),
+                               syscheck->nodiff);
+                    syscheck->nodiff[ign_size + 1] = NULL;
+                }
+                os_strdup(node[i]->content, syscheck->nodiff[ign_size]);
+            }
         } else if (strcmp(node[i]->element, xml_auto_ignore) == 0) {
             /* auto_ignore is not read here */
         } else if (strcmp(node[i]->element, xml_alert_new_files) == 0) {

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -59,6 +59,9 @@ typedef struct _config {
     char **ignore;                  /* list of files/dirs to ignore */
     OSMatch **ignore_regex;         /* regex of files/dirs to ignore */
 
+    char **nodiff;                  /* list of files/dirs to never output diff */
+    OSMatch **nodiff_regex;         /* regex of files/dirs to never output diff */
+
     char **dir;                     /* array of directories to be scanned */
     OSMatch **filerestrict;
 

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -41,18 +41,28 @@ int is_text(magic_t cookie, const void *buf, size_t len)
 }
 #endif
 
-/* Return 1 if the file has the ``nodiff`` option. 0 otherwise */
+/* Return TRUE if the file name match one of the ``nodiff`` entries.
+   Return FALSE otherwise */
 int is_nodiff(const char *filename){
-    int i = 0;
     if (syscheck.nodiff){
+        int i;
         for (i = 0; syscheck.nodiff[i] != NULL; i++){
             if (strncasecmp(syscheck.nodiff[i], filename,
                             strlen(filename)) == 0) {
-                return 1;
+                return (TRUE);
             }
         }
     }
-    return 0;
+    if (syscheck.nodiff_regex) {
+        int i;
+        for (i = 0; syscheck.nodiff_regex[i] != NULL; i++) {
+            if (OSMatch_Execute(filename, strlen(filename),
+                                syscheck.nodiff_regex[i])) {
+                 return (TRUE);
+            }
+        }
+    }
+    return (FALSE);
 }
 
 /* Generate diffs alerts */

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -373,18 +373,15 @@ char *seechanges_addfile(const char *filename)
 
     if (is_nodiff((filename))) {
         /* Dont leak sensible data with a diff hanging around */
-        snprintf(
-            diff_cmd,
-            2048,
-            "printf '<Diff truncated>' > \"%s\"",
-            diff_tmp
-        );
-
-        if (system(diff_cmd) != 0) {
-            merror("%s: ERROR: Unable to run `%s`", ARGV0, diff_cmd);
+        FILE *fdiff;
+        char* nodiff_message = "<Diff truncated because nodiff option>";
+        fdiff = fopen(diff_location, "w");
+        if (!fdiff){
+            merror("%s: ERROR: Unable to open file for writing `%s`", ARGV0, diff_location);
             goto cleanup;
         }
-
+        fwrite(nodiff_message, strlen(nodiff_message) + 1, 1, fdiff);
+        fclose(fdiff);
         /* Success */
         status = 0;
     } else {

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -138,10 +138,12 @@ int Start_win32_Syscheck()
 		ARGV0, syscheck.ignore[r]);
 
     /* Print files with no diff. */
-    if(syscheck.nodiff)
-        for (r = 0; syscheck.nodiff[r] != NULL; r++)
+    r = 0;
+    while (syscheck.nodiff[r] != NULL) {
             verbose("%s: INFO: No diff for file: '%s'",
-                ARGV0, syscheck.nodiff[r]);
+                    ARGV0, syscheck.nodiff[r]);
+            r++;
+    }
 
     /* Start up message */
     verbose(STARTUP_MSG, ARGV0, getpid());
@@ -320,10 +322,12 @@ int main(int argc, char **argv)
 		ARGV0, syscheck.ignore[r]);
 
     /* Print files with no diff. */
-    if(syscheck.nodiff)
-        for (r = 0; syscheck.nodiff[r] != NULL; r++)
+    r = 0;
+    while (syscheck.nodiff[r] != NULL) {
             verbose("%s: INFO: No diff for file: '%s'",
-                ARGV0, syscheck.nodiff[r]);
+                    ARGV0, syscheck.nodiff[r]);
+            r++;
+    }
 
     /* Check directories set for real time */
     r = 0;

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -137,6 +137,12 @@ int Start_win32_Syscheck()
 	    verbose("%s: INFO: ignoring: '%s'",
 		ARGV0, syscheck.ignore[r]);
 
+    /* Print files with no diff. */
+    if(syscheck.nodiff)
+        for (r = 0; syscheck.nodiff[r] != NULL; r++)
+            verbose("%s: INFO: No diff for file: '%s'",
+                ARGV0, syscheck.nodiff[r]);
+
     /* Start up message */
     verbose(STARTUP_MSG, ARGV0, getpid());
 
@@ -312,6 +318,12 @@ int main(int argc, char **argv)
 	for (r = 0; syscheck.ignore[r] != NULL; r++)
 	    verbose("%s: INFO: ignoring: '%s'",
 		ARGV0, syscheck.ignore[r]);
+
+    /* Print files with no diff. */
+    if(syscheck.nodiff)
+        for (r = 0; syscheck.nodiff[r] != NULL; r++)
+            verbose("%s: INFO: No diff for file: '%s'",
+                ARGV0, syscheck.nodiff[r]);
 
     /* Check directories set for real time */
     r = 0;


### PR DESCRIPTION
Sensitive data may leak through the diff attached to alerts when some file changes. This pull request add a ``nodiff`` option, which allows to explicitely set files for which we never want to output a diff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/765)
<!-- Reviewable:end -->
