### PR TITLE
Selective opening mode to extract file hash

### DIFF
--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -192,7 +192,7 @@ static int check_diff_file(const char *host, const char *script)
              DIFF_LAST_FILE);
 
     /* If the file is not there, rename new location to last location */
-    if (OS_MD5_File(old_location, md5sum_old) != 0) {
+    if (OS_MD5_File(old_location, md5sum_old, OS_TEXT) != 0) {
         if (rename(new_location, old_location) != 0) {
             merror(RENAME_ERROR, ARGV0, new_location, old_location, errno, strerror(errno));
         }
@@ -200,7 +200,7 @@ static int check_diff_file(const char *host, const char *script)
     }
 
     /* Get md5sum of the new file */
-    if (OS_MD5_File(new_location, md5sum_new) != 0) {
+    if (OS_MD5_File(new_location, md5sum_new, OS_TEXT) != 0) {
         merror("%s: ERROR: Invalid internal state (missing '%s').",
                ARGV0, new_location);
         return (0);

--- a/src/client-agent/intcheck_op.c
+++ b/src/client-agent/intcheck_op.c
@@ -46,12 +46,12 @@ int intcheck_file(const char *file_name, const char *dir)
 #endif
     {
         /* Generate SHA-1 of the file */
-        if (OS_SHA1_File(file_name, sf_sum) < 0) {
+        if (OS_SHA1_File(file_name, sf_sum, OS_TEXT) < 0) {
             strncpy(sf_sum, "xxx", 4);
         }
 
         /* Generate MD5 of the file */
-        if (OS_MD5_File(file_name, mf_sum) < 0) {
+        if (OS_MD5_File(file_name, mf_sum, OS_TEXT) < 0) {
             strncpy(mf_sum, "xxx", 4);
         }
     }

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -39,7 +39,7 @@ char *getsharedfiles()
     char *ret;
     os_md5 md5sum;
 
-    if (OS_MD5_File(SHAREDCFG_FILE, md5sum) != 0) {
+    if (OS_MD5_File(SHAREDCFG_FILE, md5sum, OS_TEXT) != 0) {
         md5sum[0] = 'x';
         md5sum[1] = '\0';
     }
@@ -120,7 +120,7 @@ void run_notify()
 
     /* Create message */
     if ((File_DateofChange(AGENTCONFIGINT) > 0 ) &&
-            (OS_MD5_File(AGENTCONFIGINT, md5sum) == 0)) {
+            (OS_MD5_File(AGENTCONFIGINT, md5sum, OS_TEXT) == 0)) {
         snprintf(tmp_msg, OS_SIZE_1024, "#!-%s / %s\n%s\n%s",
                  uname, md5sum, shared_files, keep_alive_random);
     } else {

--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -172,7 +172,7 @@ void *receiver_thread(__attribute__((unused)) void *none)
                         /* Nothing to be done */
                     }
 
-                    else if (OS_MD5_File(file, currently_md5) < 0) {
+                    else if (OS_MD5_File(file, currently_md5, OS_TEXT) < 0) {
                         /* Remove file */
                         unlink(file);
                         file[0] = '\0';

--- a/src/client-agent/receiver.c
+++ b/src/client-agent/receiver.c
@@ -149,7 +149,7 @@ void *receive_msg()
                     /* Nothing to be done */
                 }
 
-                else if (OS_MD5_File(file, currently_md5) < 0) {
+                else if (OS_MD5_File(file, currently_md5, OS_TEXT) < 0) {
                     /* Remove file */
                     unlink(file);
                     file[0] = '\0';

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -18,6 +18,9 @@
 #define READ    1
 #define WRITE   2
 
+#define OS_BINARY   0
+#define OS_TEXT     1
+
 /* Size limit control */
 #define OS_SIZE_8192    8192
 #define OS_SIZE_6144    6144

--- a/src/monitord/sign_log.c
+++ b/src/monitord/sign_log.c
@@ -39,21 +39,21 @@ void OS_SignLog(const char *logfile, const char *logfile_old, int log_missing)
     snprintf(logfilesum_old, OS_FLSIZE, "%s.sum", logfile_old);
 
     /* Generate MD5 of the old file */
-    if (OS_MD5_File(logfilesum_old, mf_sum_old) < 0) {
+    if (OS_MD5_File(logfilesum_old, mf_sum_old, OS_TEXT) < 0) {
         merror("%s: No previous md5 checksum found: '%s'. "
                "Starting over.", ARGV0, logfilesum_old);
         strncpy(mf_sum_old, "none", 6);
     }
 
     /* Generate SHA-1 of the old file  */
-    if (OS_SHA1_File(logfilesum_old, sf_sum_old) < 0) {
+    if (OS_SHA1_File(logfilesum_old, sf_sum_old, OS_TEXT) < 0) {
         merror("%s: No previous sha1 checksum found: '%s'. "
                "Starting over.", ARGV0, logfilesum_old);
         strncpy(sf_sum_old, "none", 6);
     }
 
     /* Generate MD5 of the current file */
-    if (OS_MD5_File(logfile, mf_sum) < 0) {
+    if (OS_MD5_File(logfile, mf_sum, OS_TEXT) < 0) {
         if (log_missing) {
             merror("%s: File '%s' not found. MD5 checksum skipped.",
                    ARGV0, logfile);
@@ -62,7 +62,7 @@ void OS_SignLog(const char *logfile, const char *logfile_old, int log_missing)
     }
 
     /* Generate SHA-1 of the current file */
-    if (OS_SHA1_File(logfile, sf_sum) < 0) {
+    if (OS_SHA1_File(logfile, sf_sum, OS_TEXT) < 0) {
         if (log_missing) {
             merror("%s: File '%s' not found. SHA1 checksum skipped.",
                    ARGV0, logfile);

--- a/src/os_crypto/md5/main.c
+++ b/src/os_crypto/md5/main.c
@@ -20,7 +20,7 @@ int main(int argc, char **argv)
     }
 
     if (strcmp(argv[1], "file") == 0) {
-        OS_MD5_File(argv[2], filesum);
+        OS_MD5_File(argv[2], filesum, OS_BINARY);
     }
 
     else if (strcmp(argv[1], "str") == 0) {

--- a/src/os_crypto/md5/md5_op.c
+++ b/src/os_crypto/md5/md5_op.c
@@ -16,9 +16,10 @@
 
 #include "md5_op.h"
 #include "md5.h"
+#include "headers/defs.h"
 
 
-int OS_MD5_File(const char *fname, os_md5 output)
+int OS_MD5_File(const char *fname, os_md5 output, int mode)
 {
     FILE *fp;
     MD5_CTX ctx;
@@ -29,7 +30,7 @@ int OS_MD5_File(const char *fname, os_md5 output)
     memset(output, 0, 33);
     buf[1024] = '\0';
 
-    fp = fopen(fname, "rb");
+    fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");
     if (!fp) {
         return (-1);
     }

--- a/src/os_crypto/md5/md5_op.h
+++ b/src/os_crypto/md5/md5_op.h
@@ -16,7 +16,7 @@
 
 typedef char os_md5[33];
 
-int OS_MD5_File(const char *fname, os_md5 output) __attribute((nonnull));
+int OS_MD5_File(const char *fname, os_md5 output, int mode) __attribute((nonnull));
 int OS_MD5_Str(const char *str, os_md5 output) __attribute((nonnull));
 
 #endif

--- a/src/os_crypto/md5_sha1/main.c
+++ b/src/os_crypto/md5_sha1/main.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv)
     }
 
     if (strcmp(argv[2], "file") == 0) {
-        OS_MD5_SHA1_File(argv[3], argv[1], filesum1, filesum2);
+        OS_MD5_SHA1_File(argv[3], argv[1], filesum1, filesum2, OS_BINARY);
     }
 
     else {

--- a/src/os_crypto/md5_sha1/md5_sha1_op.c
+++ b/src/os_crypto/md5_sha1/md5_sha1_op.c
@@ -16,7 +16,7 @@
 #include "headers/defs.h"
 
 
-int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5output, os_sha1 sha1output)
+int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5output, os_sha1 sha1output, int mode)
 {
     size_t n;
     FILE *fp;
@@ -34,7 +34,7 @@ int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5out
 
     /* Use prefilter_cmd if set */
     if (prefilter_cmd == NULL) {
-        fp = fopen(fname, "rb");
+        fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");
         if (!fp) {
             return (-1);
         }

--- a/src/os_crypto/md5_sha1/md5_sha1_op.h
+++ b/src/os_crypto/md5_sha1/md5_sha1_op.h
@@ -13,7 +13,7 @@
 #include "../md5/md5_op.h"
 #include "../sha1/sha1_op.h"
 
-int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5output, os_sha1 sha1output) __attribute((nonnull(1, 3, 4)));
+int OS_MD5_SHA1_File(const char *fname, const char *prefilter_cmd, os_md5 md5output, os_sha1 sha1output, int mode) __attribute((nonnull(1, 3, 4)));
 
 #endif
 

--- a/src/os_crypto/sha1/main.c
+++ b/src/os_crypto/sha1/main.c
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
         usage(argv);
     }
 
-    if (OS_SHA1_File(argv[1], filesum) == 0) {
+    if (OS_SHA1_File(argv[1], filesum, OS_BINARY) == 0) {
         printf("SHA1Sum for \"%s\" is: %s\n", argv[1], filesum);
     } else {
         printf("SHA1Sum for \"%s\" failed\n", argv[1]);

--- a/src/os_crypto/sha1/sha1_op.c
+++ b/src/os_crypto/sha1/sha1_op.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "sha1_op.h"
+#include "headers/defs.h"
 
 /* OpenSSL SHA-1
  * Only use if OpenSSL is not available
@@ -25,7 +26,7 @@
 #include "sha_locl.h"
 
 
-int OS_SHA1_File(const char *fname, os_sha1 output)
+int OS_SHA1_File(const char *fname, os_sha1 output, int mode)
 {
     SHA_CTX c;
     FILE *fp;
@@ -36,7 +37,7 @@ int OS_SHA1_File(const char *fname, os_sha1 output)
     memset(output, 0, 65);
     buf[2049] = '\0';
 
-    fp = fopen(fname, "rb");
+    fp = fopen(fname, mode == OS_BINARY ? "rb" : "r");
     if (!fp) {
         return (-1);
     }

--- a/src/os_crypto/sha1/sha1_op.h
+++ b/src/os_crypto/sha1/sha1_op.h
@@ -12,7 +12,7 @@
 
 typedef char os_sha1[65];
 
-int OS_SHA1_File(const char *fname, os_sha1 output) __attribute((nonnull));
+int OS_SHA1_File(const char *fname, os_sha1 output, int mode) __attribute((nonnull));
 
 #endif
 

--- a/src/remoted/manager.c
+++ b/src/remoted/manager.c
@@ -214,7 +214,7 @@ static void c_files()
             continue;
         }
 
-        if (OS_MD5_File(tmp_dir, md5sum) != 0) {
+        if (OS_MD5_File(tmp_dir, md5sum, OS_TEXT) != 0) {
             merror("%s: Error accessing file '%s'", ARGV0, tmp_dir);
             continue;
         }
@@ -243,7 +243,7 @@ static void c_files()
 
     closedir(dp);
 
-    if (OS_MD5_File(SHAREDCFG_FILE, md5sum) != 0) {
+    if (OS_MD5_File(SHAREDCFG_FILE, md5sum, OS_TEXT) != 0) {
         merror("%s: Error accessing file '%s'", ARGV0, SHAREDCFG_FILE);
         f_sum[0]->sum[0] = '\0';
     }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -121,15 +121,15 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                 struct stat statbuf_lnk;
                 if (stat(file_name, &statbuf_lnk) == 0) {
                     if (S_ISREG(statbuf_lnk.st_mode)) {
-                        if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum) < 0) {
+                        if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
                             strncpy(mf_sum, "xxx", 4);
                             strncpy(sf_sum, "xxx", 4);
                         }
                     }
                 }
-            } else if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum) < 0)
+            } else if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0)
 #else
-            if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum) < 0)
+            if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0)
 #endif
             {
                 strncpy(mf_sum, "xxx", 4);

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -372,7 +372,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     {
         if (sha1sum || md5sum) {
             /* Generate checksums of the file */
-            if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum) < 0) {
+            if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
                 strncpy(sf_sum, "xxx", 4);
                 strncpy(mf_sum, "xxx", 4);
             }
@@ -386,7 +386,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
             if (S_ISREG(statbuf_lnk.st_mode)) {
                 if (sha1sum || md5sum) {
                     /* Generate checksums of the file */
-                    if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum) < 0) {
+                    if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
                         strncpy(sf_sum, "xxx", 4);
                         strncpy(mf_sum, "xxx", 4);
                     }

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -232,7 +232,7 @@ char *seechanges_addfile(const char *filename)
     );
 
     /* If the file is not there, rename new location to last location */
-    if (OS_MD5_File(old_location, md5sum_old) != 0) {
+    if (OS_MD5_File(old_location, md5sum_old, OS_BINARY) != 0) {
         seechanges_createpath(old_location);
         if (seechanges_dupfile(filename, old_location) != 1) {
             merror(RENAME_ERROR, ARGV0, filename, old_location, errno, strerror(errno));
@@ -241,7 +241,7 @@ char *seechanges_addfile(const char *filename)
     }
 
     /* Get md5sum of the new file */
-    if (OS_MD5_File(filename, md5sum_new) != 0) {
+    if (OS_MD5_File(filename, md5sum_new, OS_BINARY) != 0) {
         return (NULL);
     }
 

--- a/src/syscheckd/win-registry.c
+++ b/src/syscheckd/win-registry.c
@@ -290,7 +290,7 @@ void os_winreg_querykey(HKEY hKey, char *p_key, char *full_key_name)
         /* Generate checksum of the values */
         fclose(checksum_fp);
 
-        if (OS_MD5_SHA1_File(SYS_REG_TMP, syscheck.prefilter_cmd, mf_sum, sf_sum) == -1) {
+        if (OS_MD5_SHA1_File(SYS_REG_TMP, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_TEXT) == -1) {
             merror(FOPEN_ERROR, ARGV0, SYS_REG_TMP, errno, strerror(errno));
             return;
         }

--- a/src/tests/test_os_crypto.c
+++ b/src/tests/test_os_crypto.c
@@ -60,7 +60,7 @@ START_TEST(test_md5file)
     close(fd);
 
     os_md5 buffer;
-    ck_assert_int_eq(OS_MD5_File(file_name, buffer), 0);
+    ck_assert_int_eq(OS_MD5_File(file_name, buffer, OS_TEXT), 0);
 
     ck_assert_str_eq(buffer, string_md5);
 }
@@ -69,7 +69,7 @@ END_TEST
 START_TEST(test_md5file_fail)
 {
     os_md5 buffer;
-    ck_assert_int_eq(OS_MD5_File("not_existing_file", buffer), -1);
+    ck_assert_int_eq(OS_MD5_File("not_existing_file", buffer, OS_TEXT), -1);
 }
 END_TEST
 
@@ -87,7 +87,7 @@ START_TEST(test_sha1file)
     close(fd);
 
     os_sha1 buffer;
-    ck_assert_int_eq(OS_SHA1_File(file_name, buffer), 0);
+    ck_assert_int_eq(OS_SHA1_File(file_name, buffer, OS_TEXT), 0);
 
     ck_assert_str_eq(buffer, string_sha1);
 }
@@ -96,7 +96,7 @@ END_TEST
 START_TEST(test_sha1file_fail)
 {
     os_sha1 buffer;
-    ck_assert_int_eq(OS_SHA1_File("not_existing_file", buffer), -1);
+    ck_assert_int_eq(OS_SHA1_File("not_existing_file", buffer, OS_TEXT), -1);
 }
 END_TEST
 
@@ -117,7 +117,7 @@ START_TEST(test_md5sha1file)
     os_md5 md5buffer;
     os_sha1 sha1buffer;
 
-    ck_assert_int_eq(OS_MD5_SHA1_File(file_name, NULL, md5buffer, sha1buffer), 0);
+    ck_assert_int_eq(OS_MD5_SHA1_File(file_name, NULL, md5buffer, sha1buffer, OS_TEXT), 0);
 
     ck_assert_str_eq(md5buffer, string_md5);
     ck_assert_str_eq(sha1buffer, string_sha1);
@@ -141,7 +141,7 @@ START_TEST(test_md5sha1cmdfile)
     os_md5 md5buffer;
     os_sha1 sha1buffer;
 
-    ck_assert_int_eq(OS_MD5_SHA1_File(file_name, "cat ", md5buffer, sha1buffer), 0);
+    ck_assert_int_eq(OS_MD5_SHA1_File(file_name, "cat ", md5buffer, sha1buffer, OS_TEXT), 0);
 
     ck_assert_str_eq(md5buffer, string_md5);
     ck_assert_str_eq(sha1buffer, string_sha1);
@@ -153,7 +153,7 @@ START_TEST(test_md5sha1cmdfile_fail)
     os_md5 md5buffer;
     os_sha1 sha1buffer;
 
-    ck_assert_int_eq(OS_MD5_SHA1_File("not_existing_file", NULL, md5buffer, sha1buffer), -1);
+    ck_assert_int_eq(OS_MD5_SHA1_File("not_existing_file", NULL, md5buffer, sha1buffer, OS_TEXT), -1);
 }
 END_TEST
 

--- a/src/tests/test_os_crypto.c
+++ b/src/tests/test_os_crypto.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "headers/defs.h"
 #include "../os_crypto/blowfish/bf_op.h"
 #include "../os_crypto/md5/md5_op.h"
 #include "../os_crypto/sha1/sha1_op.h"

--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -505,7 +505,7 @@ void send_win32_info(time_t curr_time)
     /* Create message */
     if (File_DateofChange(AGENTCONFIGINT) > 0) {
         os_md5 md5sum;
-        if (OS_MD5_File(AGENTCONFIGINT, md5sum) != 0) {
+        if (OS_MD5_File(AGENTCONFIGINT, md5sum, OS_TEXT) != 0) {
             snprintf(tmp_msg, OS_SIZE_1024, "#!-%s\n%s", __win32_uname, __win32_shared);
         } else {
             snprintf(tmp_msg, OS_SIZE_1024, "#!-%s / %s\n%s", __win32_uname, md5sum, __win32_shared);


### PR DESCRIPTION
The pull request https://github.com/ossec/ossec-hids/pull/744 solved the issue https://github.com/ossec/ossec-hids/issues/42 by opening files in binary mode. 

This change leaves the behaviour of Linux binaries unaltered, but makes the file integrity monitoring in Windows to read properly binary files. Unfortunately I discovered that it makes the reception of merged.mg to fail in Windows.

In order to make both elements to work, it's necessary to insert a parameter on every call to file hashing functions. So, OSSEC will only read files in binary mode at Syscheck routines.