### PR TITLE
Rework the sshd rules to make a bit more sense.

### DIFF
--- a/contrib/ossec-testing/tests/sshd.ini
+++ b/contrib/ossec-testing/tests/sshd.ini
@@ -89,5 +89,5 @@ decoder = sshd
 log 1 pass = Sep 16 05:46:56 junction sshd[1961]: fatal: Unable to negotiate with 108.229.36.174: no matching key exchange method found. Their offer: diffie-hellman-group1-sha1,diffie-hellman-group-exchange-sha1 [preauth]
 
 rule = 5752
-alert = 0
+alert = 2
 decoder = sshd

--- a/etc/rules/sshd_rules.xml
+++ b/etc/rules/sshd_rules.xml
@@ -342,10 +342,11 @@
     <description>ssh bad packet length</description>
   </rule>
 
-  <rule id="5750" level="2">
+  <rule id="5750" level="0">
+    <decoded_as>sshd</decoded_as>
     <if_sid>5700</if_sid>
-    <match>no matching key exchange method found.</match>
-    <description>Client did not offer an acceptable key exchange method.</description>
+    <match>Unable to negotiate with </match>
+    <description>sshd could not negotiate with client.</description>
   </rule>
 
   <rule id="5751" level="1">
@@ -355,15 +356,14 @@
     <description>No hostkey alg.</description>
   </rule>
 
-  <rule id="5752" level="0">
-    <decoded_as>sshd</decoded_as>
-    <if_sid>5700</if_sid>
-    <match>Unable to negotiate with </match>
-    <description>sshd could not negotiate with client.</description>
+  <rule id="5752" level="2">
+    <if_sid>5750</if_sid>
+    <match>no matching key exchange method found.</match>
+    <description>Client did not offer an acceptable key exchange method.</description>
   </rule>
 
   <rule id="5753" level="2">
-    <if_sid>5752</if_sid>
+    <if_sid>5750</if_sid>
     <match>no matching cipher found.</match>
     <description>sshd could not negotiate with client, no matching cipher.</description>
   </rule>


### PR DESCRIPTION
5752 -> 5750 - This seems like a better catch-all
5750 -> 5752 - Making this rely on the "new" 5750 is cleaner (more similar to 5753).
5753 now if_sids 5750

Prompted by @jesuslinares in Issue #785 