### PR TITLE
Audit updates

### DIFF
--- a/src/rootcheck/db/cis_debian_linux_rcl.txt
+++ b/src/rootcheck/db/cis_debian_linux_rcl.txt
@@ -34,162 +34,162 @@ f:/proc/sys/kernel/ostype -> Linux;
 
 
 # Section 1.4 - Partition scheme.
-[CIS - Debian Linux 1.4 - Robust partition scheme - /tmp is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 1.4 - Robust partition scheme - /tmp is not on its own partition {CIS: 1.4 Debian Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/fstab -> !r:/tmp;
 
-[CIS - Debian Linux 1.4 - Robust partition scheme - /opt is not on its own partition] [all] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 1.4 - Robust partition scheme - /opt is not on its own partition {CIS: 1.4 Debian Linux}] [all] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/opt;
 f:/etc/fstab -> !r:/opt;
 
-[CIS - Debian Linux 1.4 - Robust partition scheme - /var is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 1.4 - Robust partition scheme - /var is not on its own partition {CIS: 1.4 Debian Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/fstab -> !r:/var;
 
 
 # Section 2.3 - SSH configuration
-[CIS - Debian Linux 2.3 - SSH Configuration - Protocol version 1 enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 2.3 - SSH Configuration - Protocol version 1 enabled {CIS: 2.3 Debian Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\.+1;
 
-[CIS - Debian Linux 2.3 - SSH Configuration - IgnoreRHosts disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 2.3 - SSH Configuration - IgnoreRHosts disabled {CIS: 2.3 Debian Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/ssh/sshd_config -> !r:^# && r:IgnoreRhosts\.+no;
 
-[CIS - Debian Linux 2.3 - SSH Configuration - Empty passwords permitted] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 2.3 - SSH Configuration - Empty passwords permitted {CIS: 2.3 Debian Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/ssh/sshd_config -> !r:^# && r:^PermitEmptyPasswords\.+yes;
 
-[CIS - Debian Linux 2.3 - SSH Configuration - Host based authentication enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 2.3 - SSH Configuration - Host based authentication enabled {CIS: 2.3 Debian Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/ssh/sshd_config -> !r:^# && r:HostbasedAuthentication\.+yes;
 
-[CIS - Debian Linux 2.3 - SSH Configuration - Root login allowed] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 2.3 - SSH Configuration - Root login allowed {CIS: 2.3 Debian Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/ssh/sshd_config -> !r:^# && r:PermitRootLogin\.+yes;
 
 
 # Section 2.4 Enable system accounting
-#[CIS - Debian Linux 2.4 - System Accounting - Sysstat not installed] [all] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+#[CIS - Debian Linux - 2.4 - System Accounting - Sysstat not installed {CIS: 2.4 Debian Linux}] [all] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 #f:!/etc/default/sysstat;
 #f:!/var/log/sysstat;
 
-#[CIS - Debian Linux 2.4 - System Accounting - Sysstat not enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+#[CIS - Debian Linux - 2.4 - System Accounting - Sysstat not enabled {CIS: 2.4 Debian Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 #f:!/etc/default/sysstat;
 #f:/etc/default/sysstat -> !r:^# && r:ENABLED="false";
 
 
 # Section 2.5 Install and run Bastille
-#[CIS - Debian Linux 2.5 - System harderning - Bastille is not installed] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+#[CIS - Debian Linux - 2.5 - System harderning - Bastille is not installed {CIS: 2.5 Debian Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 #f:!/etc/Bastille;
 
 
 # Section 2.6 Ensure sources.list Sanity
-[CIS - Debian Linux 2.6 - Sources list sanity - Security updates not enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 2.6 - Sources list sanity - Security updates not enabled {CIS: 2.6 Debian Linux} {PCI_DSS: 6.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:!/etc/apt/sources.list;
 f:!/etc/apt/sources.list -> !r:^# && r:http://security.debian|http://security.ubuntu;
 
 
 # Section 3 - Minimize inetd services
-[CIS - Debian Linux 3.3 - Telnet enabled on inetd] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 3.3 - Telnet enabled on inetd {CIS: 3.3 Debian Linux} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/inetd.conf -> !r:^# && r:telnet;
 
-[CIS - Debian Linux 3.4 - FTP enabled on inetd] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 3.4 - FTP enabled on inetd {CIS: 3.4 Debian Linux} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/inetd.conf -> !r:^# && r:/ftp;
 
-[CIS - Debian Linux 3.5 - rsh/rlogin/rcp enabled on inetd] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 3.5 - rsh/rlogin/rcp enabled on inetd {CIS: 3.5 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/inetd.conf -> !r:^# && r:shell|login;
 
-[CIS - Debian Linux 3.6 - tftpd enabled on inetd] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 3.6 - tftpd enabled on inetd {CIS: 3.6 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/inetd.conf -> !r:^# && r:tftp;
 
-[CIS - Debian Linux 3.7 - imap enabled on inetd] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 3.7 - imap enabled on inetd {CIS: 3.7 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/inetd.conf -> !r:^# && r:imap;
 
-[CIS - Debian Linux 3.8 - pop3 enabled on inetd] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 3.8 - pop3 enabled on inetd {CIS: 3.8 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/inetd.conf -> !r:^# && r:pop;
 
-[CIS - Debian Linux 3.9 - Ident enabled on inetd] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 3.9 - Ident enabled on inetd {CIS: 3.9 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/inetd.conf -> !r:^# && r:ident;
 
 
 # Section 4 - Minimize boot services
-[CIS - Debian Linux 4.1 - Disable inetd - Inetd enabled but no services running] [all] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.1 - Disable inetd - Inetd enabled but no services running {CIS: 4.1 Debian Linux} {PCI_DSS: 2.2.2}] [all] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 p:inetd;
 f:!/etc/inetd.conf -> !r:^# && r:wait;
 
-[CIS - Debian Linux 4.3 - GUI login enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.3 - GUI login enabled {CIS: 4.3 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/inittab -> !r:^# && r:id:5;
 
-[CIS - Debian Linux 4.6 - Disable standard boot services - Samba Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.6 - Disable standard boot services - Samba Enabled {CIS: 4.6 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/init.d/samba;
 
-[CIS - Debian Linux 4.7 - Disable standard boot services - NFS Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.7 - Disable standard boot services - NFS Enabled {CIS: 4.7 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/init.d/nfs-common;
 f:/etc/init.d/nfs-user-server;
 f:/etc/init.d/nfs-kernel-server;
 
-[CIS - Debian Linux 4.9 - Disable standard boot services - NIS Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.9 - Disable standard boot services - NIS Enabled {CIS: 4.9 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/init.d/nis;
 
-[CIS - Debian Linux 4.13 - Disable standard boot services - Web server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.13 - Disable standard boot services - Web server Enabled {CIS: 4.13 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/init.d/apache;
 f:/etc/init.d/apache2;
 
-[CIS - Debian Linux 4.15 - Disable standard boot services - DNS server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.15 - Disable standard boot services - DNS server Enabled {CIS: 4.15 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/init.d/bind;
 
-[CIS - Debian Linux 4.16 - Disable standard boot services - MySQL server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.16 - Disable standard boot services - MySQL server Enabled {CIS: 4.16 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/init.d/mysql;
 
-[CIS - Debian Linux 4.16 - Disable standard boot services - PostgreSQL server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.16 - Disable standard boot services - PostgreSQL server Enabled {CIS: 4.16 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/init.d/postgresql;
 
-[CIS - Debian Linux 4.17 - Disable standard boot services - Webmin Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.17 - Disable standard boot services - Webmin Enabled {CIS: 4.17 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/init.d/webmin;
 
-[CIS - Debian Linux 4.18 - Disable standard boot services - Squid Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 4.18 - Disable standard boot services - Squid Enabled {CIS: 4.18 Debian Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/init.d/squid;
 
 
 # Section 5 - Kernel tuning
-[CIS - Debian Linux 5.1 - Network parameters - Source routing accepted] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 5.1 - Network parameters - Source routing accepted {CIS: 5.1 Debian Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/proc/sys/net/ipv4/conf/all/accept_source_route -> 1;
 
-[CIS - Debian Linux 5.1 - Network parameters - ICMP broadcasts accepted] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 5.1 - Network parameters - ICMP broadcasts accepted {CIS: 5.1 Debian Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts -> 0;
 
-[CIS - Debian Linux 5.2 - Network parameters - IP Forwarding enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 5.2 - Network parameters - IP Forwarding enabled {CIS: 5.2 Debian Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/proc/sys/net/ipv4/ip_forward -> 1;
 f:/proc/sys/net/ipv6/ip_forward -> 1;
 
 
 # Section 7 - Permissions
-[CIS - Debian Linux 7.1 - Partition /var without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 7.1 - Partition /var without 'nodev' set {CIS: 7.1 Debian Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/fstab -> !r:^# && r:ext2|ext3 && r:/var && !r:nodev;
 
-[CIS - Debian Linux 7.1 - Partition /tmp without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 7.1 - Partition /tmp without 'nodev' set {CIS: 7.1 Debian Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/fstab -> !r:^# && r:ext2|ext3 && r:/tmp && !r:nodev;
 
-[CIS - Debian Linux 7.1 - Partition /opt without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 7.1 - Partition /opt without 'nodev' set {CIS: 7.1 Debian Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/fstab -> !r:^# && r:ext2|ext3 && r:/opt && !r:nodev;
 
-[CIS - Debian Linux 7.1 - Partition /home without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 7.1 - Partition /home without 'nodev' set {CIS: 7.1 Debian Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/fstab -> !r:^# && r:ext2|ext3 && r:/home && !r:nodev ;
 
-[CIS - Debian Linux 7.2 - Removable partition /media without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 7.2 - Removable partition /media without 'nodev' set {CIS: 7.2 Debian Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/fstab -> !r:^# && r:/media && !r:nodev;
 
-[CIS - Debian Linux 7.2 - Removable partition /media without 'nosuid' set] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 7.2 - Removable partition /media without 'nosuid' set {CIS: 7.2 Debian Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/fstab -> !r:^# && r:/media && !r:nosuid;
 
-[CIS - Debian Linux 7.3 - User-mounted removable partition /media] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 7.3 - User-mounted removable partition /media {CIS: 7.3 Debian Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/fstab -> !r:^# && r:/media && r:user;
 
 
 # Section 8 - Access and authentication
-[CIS - Debian Linux 8.8 - LILO Password not set] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 8.8 - LILO Password not set {CIS: 8.8 Debian Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/lilo.conf -> !r:^# && !r:restricted;
 f:/etc/lilo.conf -> !r:^# && !r:password=;
 
-[CIS - Debian Linux 8.8 - GRUB Password not set] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 8.8 - GRUB Password not set {CIS: 8.8 Debian Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/boot/grub/menu.lst -> !r:^# && !r:password;
 
-[CIS - Debian Linux 9.2 - Account with empty password present] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 9.2 - Account with empty password present {CIS: 9.2 Debian Linux} {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/shadow -> r:^\w+::;
 
-[CIS - Debian Linux 13.11 - Non-root account with uid 0] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
+[CIS - Debian Linux - 13.11 - Non-root account with uid 0 {CIS: 13.11 Debian Linux} {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_DebianLinux]
 f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:;

--- a/src/rootcheck/db/cis_rhel5_linux_rcl.txt
+++ b/src/rootcheck/db/cis_rhel5_linux_rcl.txt
@@ -43,67 +43,67 @@ f:/etc/redhat-release -> r:^Better && r:release 5;
 
 
 # 1.1.1 /tmp: partition
-[CIS - RHEL5 - Build considerations - Robust partition scheme - /tmp is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - - Build considerations - Robust partition scheme - /tmp is not on its own partition {CIS: 1.1.1 RHEL5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:/tmp;
 
 # 1.1.2 /tmp: nodev
-[CIS - RHEL5 1.1.2 - Partition /tmp without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.2 - Partition /tmp without 'nodev' set {CIS: 1.1.2 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/tmp && !r:nodev;
 
 # 1.1.3 /tmp: nosuid
-[CIS - RHEL5 1.1.3 - Partition /tmp without 'nosuid' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.3 - Partition /tmp without 'nosuid' set {CIS: 1.1.3 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/tmp && !r:nosuid;
 
 # 1.1.4 /tmp: noexec
-[CIS - RHEL5 1.1.4 - Partition /tmp without 'noexec' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.4 - Partition /tmp without 'noexec' set {CIS: 1.1.4 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/tmp && !r:nodev;
 
 # 1.1.5 Build considerations - Partition scheme.
-[CIS - RHEL5 - Build considerations - Robust partition scheme - /var is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - - Build considerations - Robust partition scheme - /var is not on its own partition {CIS: 1.1.5 RHEL5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r^# && !r:/var;
 
 # 1.1.6 bind mount /var/tmp to /tmp
-[CIS - RHEL5 - Build considerations - Robust partition scheme - /var/tmp is bound to /tmp] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - - Build considerations - Robust partition scheme - /var/tmp is bound to /tmp {CIS: 1.1.6 RHEL5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> r:^# && !r:/var/tmp && !r:bind;
 
 # 1.1.7 /var/log: partition
-[CIS - RHEL5 - Build considerations - Robust partition scheme - /var/log is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - - Build considerations - Robust partition scheme - /var/log is not on its own partition {CIS: 1.1.7 RHEL5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> ^# && !r:/var/log;
 
 # 1.1.8 /var/log/audit: partition
-[CIS - RHEL5 - Build considerations - Robust partition scheme - /var/log/audit is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - - Build considerations - Robust partition scheme - /var/log/audit is not on its own partition {CIS: 1.1.8 RHEL5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> ^# && !r:/var/log/audit;
 
 # 1.1.9 /home: partition
-[CIS - RHEL5 - Build considerations - Robust partition scheme - /home is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - - Build considerations - Robust partition scheme - /home is not on its own partition {CIS: 1.1.9 Debian RHEL5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> ^# && !r:/home;
 
 # 1.1.10 /home: nodev
-[CIS - RHEL5 1.1.10 -  Partition /home without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.10 -  Partition /home without 'nodev' set {CIS: 1.1.10 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/home && !r:nodev;
 
 # 1.1.11 nodev on removable media partitons (not scored)
-[CIS - RHEL5 1.1.11 - Removable partition /media without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.11 - Removable partition /media without 'nodev' set {CIS: 1.1.11 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/media && !r:nodev;
 
 # 1.1.12 noexec on removable media partitions (not scored)
-[CIS - RHEL5 1.1.12 - Removable partition /media without 'noexec' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.12 - Removable partition /media without 'noexec' set {CIS: 1.1.12 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/media && !r:noexec;
 
 # 1.1.13 nosuid on removale media partitions (not scored)
-[CIS - RHEL5 1.1.13 - Removable partition /media without 'nosuid' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.13 - Removable partition /media without 'nosuid' set {CIS: 1.1.13 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/media && !r:nosuid;
 
 # 1.1.14 /dev/shm: nodev
-[CIS - RHEL5 1.1.11 - /dev/shm without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.11 - /dev/shm without 'nodev' set {CIS: 1.1.14 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/dev/shm && !r:nodev;
 
 # 1.1.15 /dev/shm: nosuid
-[CIS - RHEL5 1.1.11 - /dev/shm without 'nosuid' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.11 - /dev/shm without 'nosuid' set {CIS: 1.1.15 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/dev/shm && !r:nosuid;
 
 # 1.1.16 /dev/shm: noexec
-[CIS - RHEL5 1.1.11 - /dev/shm without 'noexec' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.1.11 - /dev/shm without 'noexec' set {CIS: 1.1.16 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/dev/shm && !r:noexec;
 
 # 1.1.17 sticky bit on world writable directories (Scored)
@@ -139,7 +139,7 @@ f:/etc/fstab -> !r:^# && r:/dev/shm && !r:noexec;
 # 1.2.4 Disable rhnsd (not scored)
 
 # 1.2.5 Disable yum-updatesd (Scored)
-[CIS - RHEL5 1.2.5 - yum-updatesd not Disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.2.5 - yum-updatesd not Disabled {CIS: 1.2.5 RHEL5} {PCI_DSS: 6.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/fstab -> !r:^# && r:/dev/shm && !r:noexec;
 p:yum-updatesd;
 
@@ -161,23 +161,23 @@ p:yum-updatesd;
 ###############################################
 
 # 1.4.1 enable selinux in /etc/grub.conf
-[CIS - RHEL5 1.4.1 - SELinux Disabled in /etc/grub.conf] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.4.1 - SELinux Disabled in /etc/grub.conf {CIS: 1.4.1 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/grub.conf -> !r:selinux=0;
 
 # 1.4.2 Set selinux state
-[CIS - RHEL5 1.4.2 - SELinux not set to enforcing] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.4.2 - SELinux not set to enforcing {CIS: 1.4.2 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/selinux/config -> r:SELINUX=enforcing;
 
 # 1.4.3 Set seliux policy
-[CIS - RHEL5 1.4.2 - SELinux policy not set to targeted] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.4.3 - SELinux policy not set to targeted {CIS: 1.4.3 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/selinux/config -> r:SELINUXTYPE=targeted;
 
 # 1.4.4 Remove SETroubleshoot
-[CIS - RHEL5 1.4.2 - SELinux setroubleshoot enabld] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.4.4 - SELinux setroubleshoot enabld {CIS: 1.4.4 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dsetroubleshoot$;
 
 # 1.4.5 Disable MCS Translation service mcstrans
-[CIS - RHEL5 1.4.2 - SELinux mctrans enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.4.5 - SELinux mctrans enabled {CIS: 1.4.5 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dmctrans$;
 
 # 1.4.6 Check for unconfined daemons
@@ -195,15 +195,15 @@ d:$rc_dirs -> ^S\d\dmctrans$;
 # TODO (no mode tests)
 
 # 1.5.3 Set Boot Loader Password (Scored)
-[CIS - RHEL5 1.5.3 - GRUB Password not set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.5.3 - GRUB Password not set {CIS: 1.5.3 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/boot/grub/menu.lst -> !r:^# && !r:password;
 
 # 1.5.4 Require Authentication for Single-User Mode (Scored)
-[CIS - RHEL5 1.5.4 - Authenticaion for single user mode not enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.5.4 - Authenticaion for single user mode not enabled {CIS: 1.5.4 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/inittab -> !r:^# && r:S:wait;
 
 # 1.5.5 Disable Interactive Boot (Scored)
-[CIS - RHEL5 1.5.5 - Interactive Boot not disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.5.5 - Interactive Boot not disabled {CIS: 1.5.5 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/sysconfig/init -> !r:^# && r:PROMPT=no;
 
 
@@ -213,22 +213,22 @@ f:/etc/sysconfig/init -> !r:^# && r:PROMPT=no;
 ###############################################
 
 # 1.6.1 Restrict Core Dumps (Scored)
-[CIS - RHEL5 1.6.1 - Interactive Boot not disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.6.1 - Interactive Boot not disabled {CIS: 1.6.1 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/security/limits.conf -> !r:^# && !r:hard\.+core\.+0;
 
 # 1.6.2 Configure ExecShield (Scored)
-[CIS - RHEL5 1.6.2 - ExecShield not enabled ] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.6.2 - ExecShield not enabled  {CIS: 1.6.2 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/kernel/exec-shield -> 0;
 
 # 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
-[CIS - RHEL5 1.6.3 - Randomized Virtua Memory Region Placement not enabled ] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.6.3 - Randomized Virtua Memory Region Placement not enabled  {CIS: 1.6.3 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/kernel/randomize_va_space -> 0;
 
 # 1.6.4 Enable XD/NX Support on 32-bit x86 Systems (Scored)
 # TODO
 
 # 1.6.5 Disable Prelink (Scored)
-[CIS - RHEL5 1.6.5 - Prelink not disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 1.6.5 - Prelink not disabled {CIS: 1.6.5 RHEL5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/sysconfig/prelink -> !r:PRELINKING=no;
 
 
@@ -247,7 +247,7 @@ f:/etc/sysconfig/prelink -> !r:PRELINKING=no;
 
 # 2.1.1 Remove telnet-server (Scored)
 # TODO: detect it is installed at all
-[CIS - RHEL5 2.1.1 - Telnet enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 2.1.1 - Telnet enabled on xinetd {CIS: 2.1.1 RHEL5} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/xinetd.d/telnet -> !r:^# && r:disable && r:no;
 
 
@@ -255,7 +255,7 @@ f:/etc/xinetd.d/telnet -> !r:^# && r:disable && r:no;
 # TODO
 
 # 2.1.3 Remove rsh-server (Scored)
-[CIS - RHEL5 2.1.3 - rsh/rlogin/rcp enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 2.1.3 - rsh/rlogin/rcp enabled on xinetd {CIS: 2.1.3 RHEL5} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/xinetd.d/rlogin -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.d/rsh -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.d/shell -> !r:^# && r:disable && r:no;
@@ -264,25 +264,25 @@ f:/etc/xinetd.d/shell -> !r:^# && r:disable && r:no;
 # TODO
 
 # 2.1.5 Remove NIS Client (Scored)
-[CIS - RHEL5 2.1.5 - Disable standard boot services - NIS (client) Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 2.1.5 - Disable standard boot services - NIS (client) Enabled {CIS: 2.1.5 RHEL5} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dypbind$;
 
 # 2.1.6 Remove NIS Server (Scored)
-[CIS - RHEL5 2.1.5 - Disable standard boot services - NIS (server) Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 2.1.5 - Disable standard boot services - NIS (server) Enabled {CIS: 2.1.6 RHEL5} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dypserv$;
 
 # 2.1.7 Remove tftp (Scored)
 # TODO
 
 # 2.1.8 Remove tftp-server (Scored)
-[CIS - RHEL5 2.1.8 - tftpd enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 2.1.8 - tftpd enabled on xinetd {CIS: 2.1.8 RHEL5} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/xinetd.d/tftpd -> !r:^# && r:disable && r:no;
 
 # 2.1.9 Remove talk (Scored)
 # TODO
 
 # 2.1.10 Remove talk-server (Scored)
-[CIS - RHEL5 2.1.10 - talk enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 2.1.10 - talk enabled on xinetd {CIS: 2.1.10 RHEL5} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/xinetd.d/talk -> !r:^# && r:disable && r:no;
 
 # 2.1.11 Remove xinetd (Scored)
@@ -319,7 +319,7 @@ f:/etc/xinetd.d/talk -> !r:^# && r:disable && r:no;
 ###############################################
 
 # 3.1.1 Disable Avahi Server (Scored)
-[CIS - RHEL5 3.1.1 - Avahi daemon not disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.1.1 - Avahi daemon not disabled {CIS: 3.1.1 RHEL5} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 p:avahi-daemon;
 
 # 3.1.2 Service Only via Required Protocol (Not Scored)
@@ -336,11 +336,11 @@ p:avahi-daemon;
 # 3.1.6 Restrict Published Information (if publishing is required) (Not scored)
 
 # 3.2 Set Daemon umask (Scored)
-[CIS - RHEL5 3.2 - Set daemon umask - Default umask is higher than 027] [all] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.2 - Set daemon umask - Default umask is higher than 027 {CIS: 3.2 RHEL5}] [all] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/init.d/functions -> !r:^# && r:^umask && <:umask 027;
 
 # 3.3 Remove X Windows (Scored)
-[CIS - RHEL5 3.3 - X11 not disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.3 - X11 not disabled {CIS: 3.3 RHEL5} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/inittab -> !r:^# && r:id:5;
 
 # 3.4 Disable Print Server - CUPS (Not Scored)
@@ -349,13 +349,13 @@ f:/etc/inittab -> !r:^# && r:id:5;
 # TODO
 
 # 3.6 Configure Network Time Protocol (NTP) (Scored)
-#[CIS - RHEL5 3.6 - NTPD not disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+#[CIS - RHEL5 - 3.6 - NTPD not disabled {CIS: 3.6 RHEL5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 # TODO.
 
 # 3.7 Remove LDAP (Not Scored)
 
 # 3.8 Disable NFS and RPC (Not Scored)
-[CIS - RHEL5 3.8 - Disable standard boot services - NFS Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.8 - Disable standard boot services - NFS Enabled {CIS: 3.8 RHEL5} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dnfs$;
 d:$rc_dirs -> ^S\d\dnfslock$;
 
@@ -363,31 +363,31 @@ d:$rc_dirs -> ^S\d\dnfslock$;
 # TODO
 
 # 3.10 Remove FTP Server (Not Scored)
-[CIS - RHEL5 3.10 - VSFTP enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.10 - VSFTP enabled on xinetd {CIS: 3.10 RHEL5} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/xinetd.d/vsftpd -> !r:^# && r:disable && r:no;
 
 # 3.11 Remove HTTP Server (Not Scored)
-[CIS - RHEL5 3.11 - Disable standard boot services - Apache web server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.11 - Disable standard boot services - Apache web server Enabled {CIS: 3.11 RHEL5} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dhttpd$;
 
 # 3.12 Remove Dovecot (IMAP and POP3 services) (Not Scored)
-[CIS - RHEL5 3.12 - imap enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.12 - imap enabled on xinetd {CIS: 3.12 RHEL5} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/xinetd.d/cyrus-imapd -> !r:^# && r:disable && r:no;
 
-[CIS - RHEL5 3.12 - pop3 enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.12 - pop3 enabled on xinetd {CIS: 3.12 RHEL5} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/xinetd.d/dovecot -> !r:^# && r:disable && r:no;
 
 # 3.13 Remove Samba (Not Scored)
-[CIS - RHEL5 3.13 - Disable standard boot services - Samba Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.13 - Disable standard boot services - Samba Enabled {CIS: 3.13 RHEL5} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dsamba$;
 d:$rc_dirs -> ^S\d\dsmb$;
 
 # 3.14 Remove HTTP Proxy Server (Not Scored)
-[CIS - RHEL5 3.14 - Disable standard boot services - Squid Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.14 - Disable standard boot services - Squid Enabled {CIS: 3.14 RHEL5} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dsquid$;
 
 # 3.15 Remove SNMP Server (Not Scored)
-[CIS - RHEL5 3.15 - Disable standard boot services - SNMPD process Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 3.15 - Disable standard boot services - SNMPD process Enabled {CIS: 3.15 RHEL5} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dsnmpd$;
 
 # 3.16 Configure Mail Transfer Agent for Local-Only Mode (Scored)
@@ -403,12 +403,12 @@ d:$rc_dirs -> ^S\d\dsnmpd$;
 ###############################################
 
 # 4.1.1 Disable IP Forwarding (Scored)
-[CIS - RHEL5 4.1.1 - Network parameters - IP Forwarding enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.1.1 - Network parameters - IP Forwarding enabled {CIS: 4.1.1 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/ip_forward -> 1;
 f:/proc/sys/net/ipv6/ip_forward -> 1;
 
 # 4.1.2 Disable Send Packet Redirects (Scored)
-[CIS - RHEL5 4.1.2 - Network parameters - IP send redirects enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.1.2 - Network parameters - IP send redirects enabled {CIS: 4.1.2 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/conf/all/send_redirects -> 0;
 f:/proc/sys/net/ipv4/conf/default/send_redirects -> 0;
 
@@ -418,38 +418,38 @@ f:/proc/sys/net/ipv4/conf/default/send_redirects -> 0;
 ###############################################
 
 # 4.2.1 Disable Source Routed Packet Acceptance (Scored)
-[CIS - RHEL5 4.2.1 - Network parameters - Source routing accepted] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.2.1 - Network parameters - Source routing accepted {CIS: 4.2.1 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/conf/all/accept_source_route -> 1;
 
 # 4.2.2 Disable ICMP Redirect Acceptance (Scored)
-CIS - RHEL5 4.2.2 - Network parameters - ICMP redirects accepted] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.2.2 - Network parameters - ICMP redirects accepted {CIS: 4.2.2 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/conf/all/accept_redirects -> 1;
 f:/proc/sys/net/ipv4/conf/default/accept_redirects -> 1;
 
 # 4.2.3 Disable Secure ICMP Redirect Acceptance (Scored)
-[CIS - RHEL5 4.2.3 - Network parameters - ICMP secure redirects accepted] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.2.3 - Network parameters - ICMP secure redirects accepted {CIS: 4.2.3 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/conf/all/secure_redirects -> 1;
 f:/proc/sys/net/ipv4/conf/default/secure_redirects -> 1;
 
 # 4.2.4 Log Suspicious Packets (Scored)
-[CIS - RHEL5 4.2.4 - Network parameters - martians not logged] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.2.4 - Network parameters - martians not logged {CIS: 4.2.4 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/conf/all/log_martians -> 0;
 
 # 4.2.5 Enable Ignore Broadcast Requests (Scored)
-[CIS - RHEL5 4.2.5 - Network parameters - ICMP broadcasts accepted] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.2.5 - Network parameters - ICMP broadcasts accepted {CIS: 4.2.5 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts -> 0;
 
 # 4.2.6 Enable Bad Error Message Protection (Scored)
-[CIS - RHEL5 4.2.6 - Network parameters - Bad error message protection not enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.2.6 - Network parameters - Bad error message protection not enabled {CIS: 4.2.6 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/icmp_ignore_bogus_error_responses -> 0;
 
 # 4.2.7 Enable RFC-recommended Source Route Validation (Scored)
-[CIS - RHEL5 4.2.7 - Network parameters - RFC Source route validation not enabled ] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.2.7 - Network parameters - RFC Source route validation not enabled  {CIS: 4.2.7 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/conf/all/rp_filter -> 0;
 f:/proc/sys/net/ipv4/conf/default/rp_filter -> 0;
 
 # 4.2.8 Enable TCP SYN Cookies (Scored)
-[CIS - RHEL5 4.2.8 - Network parameters - SYN Cookies not enabled ] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 4.2.8 - Network parameters - SYN Cookies not enabled  {CIS: 4.2.8 RHEL5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/proc/sys/net/ipv4/tcp_syncookies -> 0;
 
 
@@ -636,7 +636,7 @@ f:/proc/sys/net/ipv4/tcp_syncookies -> 0;
 ###############################################
 
 # 6.2.1 Set SSH Protocol to 2 (Scored)
-[CIS - RHEL5 6.2.1 - SSH Configuration - Protocol version 1 enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 6.2.1 - SSH Configuration - Protocol version 1 enabled {CIS: 6.2.1 RHEL5} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\.+1;
 
 # 6.2.2 Set LogLevel to INFO (Scored)
@@ -648,19 +648,19 @@ f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\.+1;
 # 6.2.5 Set SSH MaxAuthTries to 4 or Less (Scored)
 
 # 6.2.6 Set SSH IgnoreRhosts to Yes (Scored)
-[CIS - RHEL5 6.2.6 - SSH Configuration - IgnoreRHosts disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 6.2.6 - SSH Configuration - IgnoreRHosts disabled {CIS: 6.2.6 RHEL5} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:IgnoreRhosts\.+no;
 
 # 6.2.7 Set SSH HostbasedAuthentication to No (Scored)
-[CIS - RHEL5 6.2.7 - SSH Configuration - Host based authentication enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 6.2.7 - SSH Configuration - Host based authentication enabled {CIS: 6.2.7 RHEL5} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:HostbasedAuthentication\.+yes;
 
 # 6.2.8 Disable SSH Root Login (Scored)
-[CIS - RHEL5 6.2.8 - SSH Configuration - Root login allowed] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 6.2.8 - SSH Configuration - Root login allowed {CIS: 6.2.8 RHEL5} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:PermitRootLogin\.+yes;
 
 # 6.2.9 Set SSH PermitEmptyPasswords to No (Scored)
-[CIS - RHEL5 6.2.9 - SSH Configuration - Empty passwords permitted] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 6.2.9 - SSH Configuration - Empty passwords permitted {CIS: 6.2.9 RHEL5} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:^PermitEmptyPasswords\.+yes;
 
 # 6.2.10 Do Not Allow Users to Set Environment Options (Scored)
@@ -785,7 +785,7 @@ f:/etc/ssh/sshd_config -> !r:^# && r:^PermitEmptyPasswords\.+yes;
 # 9.2.4 Verify No Legacy "+" Entries Exist in /etc/group File (Scored)
 
 # 9.2.5 Verify No UID 0 Accounts Exist Other Than root (Scored)
-[CIS - RHEL5 9.2.5 - Non-root account with uid 0] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - 9.2.5 - Non-root account with uid 0 {CIS: 9.2.5 RHEL5} {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:;
 
 # 9.2.6 Ensure root PATH Integrity (Scored)
@@ -821,24 +821,24 @@ f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:;
 # 9.2.21 Check for Presence of User .forward Files (Scored)
 
 # Other/Legacy Tests
-[CIS - RHEL5 X.X.X - Account with empty password present] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - X.X.X - Account with empty password present  {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/shadow -> r:^\w+::;
 
-[CIS - RHEL5 X.X.X - User-mounted removable partition allowed on the console] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - X.X.X - User-mounted removable partition allowed on the console] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 f:/etc/security/console.perms -> r:^<console>  \d+ <cdrom>;
 f:/etc/security/console.perms -> r:^<console>  \d+ <floppy>;
 
-[CIS - RHEL5 X.X.X - Disable standard boot services - Kudzu hardware detection Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - X.X.X - Disable standard boot services - Kudzu hardware detection Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dkudzu$;
 
-[CIS - RHEL5 X.X.X - Disable standard boot services - PostgreSQL server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - X.X.X - Disable standard boot services - PostgreSQL server Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dpostgresql$;
 
-[CIS - RHEL5 X.X.X - Disable standard boot services - MySQL server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - X.X.X - Disable standard boot services - MySQL server Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dmysqld$;
 
-[CIS - RHEL5 X.X.X - Disable standard boot services - DNS server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - X.X.X - Disable standard boot services - DNS server Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dnamed$;
 
-[CIS - RHEL5 X.X.X - Disable standard boot services - NetFS Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5]
+[CIS - RHEL5 - X.X.X - Disable standard boot services - NetFS Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL5 -]
 d:$rc_dirs -> ^S\d\dnetfs$;

--- a/src/rootcheck/db/cis_rhel7_linux_rcl.txt
+++ b/src/rootcheck/db/cis_rhel7_linux_rcl.txt
@@ -40,67 +40,67 @@ f:/etc/redhat-release -> r:^Oracle && r:release 6;
 f:/etc/redhat-release -> r:^Better && r:release 6;
 
 # 1.1.1 /tmp: partition
-[CIS - RHEL6 - Build considerations - Robust partition scheme - /tmp is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - Build considerations - Robust partition scheme - /tmp is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:/tmp;
 
 # 1.1.2 /tmp: nodev
-[CIS - RHEL6 - 1.1.2 - Partition /tmp without 'nodev' set {CIS: 1.1.2 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.2 - Partition /tmp without 'nodev' set {CIS: 1.1.2 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/tmp && !r:nodev;
 
 # 1.1.3 /tmp: nosuid
-[CIS - RHEL6 - 1.1.3 - Partition /tmp without 'nosuid' set {CIS: 1.1.3 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.3 - Partition /tmp without 'nosuid' set {CIS: 1.1.3 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/tmp && !r:nosuid;
 
 # 1.1.4 /tmp: noexec
-[CIS - RHEL6 - 1.1.4 - Partition /tmp without 'noexec' set {CIS: 1.1.4 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.4 - Partition /tmp without 'noexec' set {CIS: 1.1.4 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/tmp && !r:nodev;
 
 # 1.1.5 Build considerations - Partition scheme.
-[CIS - RHEL6 - Build considerations - Robust partition scheme - /var is not on its own partition {CIS: 1.1.5 RHEL6}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - Build considerations - Robust partition scheme - /var is not on its own partition {CIS: 1.1.5 RHEL7}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r^# && !r:/var;
 
 # 1.1.6 bind mount /var/tmp to /tmp
-[CIS - RHEL6 - Build considerations - Robust partition scheme - /var/tmp is bound to /tmp {CIS: 1.1.6 RHEL6}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - Build considerations - Robust partition scheme - /var/tmp is bound to /tmp {CIS: 1.1.6 RHEL7}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> r:^# && !r:/var/tmp && !r:bind;
 
 # 1.1.7 /var/log: partition
-[CIS - RHEL6 - Build considerations - Robust partition scheme - /var/log is not on its own partition {CIS: 1.1.7 RHEL6}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - Build considerations - Robust partition scheme - /var/log is not on its own partition {CIS: 1.1.7 RHEL7}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> ^# && !r:/var/log;
 
 # 1.1.8 /var/log/audit: partition
-[CIS - RHEL6 - Build considerations - Robust partition scheme - /var/log/audit is not on its own partition {CIS: 1.1.8 RHEL6}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - Build considerations - Robust partition scheme - /var/log/audit is not on its own partition {CIS: 1.1.8 RHEL7}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> ^# && !r:/var/log/audit;
 
 # 1.1.9 /home: partition
-[CIS - RHEL6 - Build considerations - Robust partition scheme - /home is not on its own partition {CIS: 1.1.9 RHEL6}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - Build considerations - Robust partition scheme - /home is not on its own partition {CIS: 1.1.9 RHEL7}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> ^# && !r:/home;
 
 # 1.1.10 /home: nodev
-[CIS - RHEL6 - 1.1.10 -  Partition /home without 'nodev' set {CIS: 1.1.10 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.10 -  Partition /home without 'nodev' set {CIS: 1.1.10 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/home && !r:nodev;
 
 # 1.1.11 nodev on removable media partitons (not scored)
-[CIS - RHEL6 - 1.1.11 - Removable partition /media without 'nodev' set {CIS: 1.1.11 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.11 - Removable partition /media without 'nodev' set {CIS: 1.1.11 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/media && !r:nodev;
 
 # 1.1.12 noexec on removable media partitions (not scored)
-[CIS - RHEL6 - 1.1.12 - Removable partition /media without 'noexec' set {CIS: 1.1.12 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.12 - Removable partition /media without 'noexec' set {CIS: 1.1.12 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/media && !r:noexec;
 
 # 1.1.13 nosuid on removale media partitions (not scored)
-[CIS - RHEL6 - 1.1.13 - Removable partition /media without 'nosuid' set {CIS: 1.1.13 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.13 - Removable partition /media without 'nosuid' set {CIS: 1.1.13 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/media && !r:nosuid;
 
 # 1.1.14 /dev/shm: nodev
-[CIS - RHEL6 - 1.1.14 - /dev/shm without 'nodev' set {CIS: 1.1.14 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.14 - /dev/shm without 'nodev' set {CIS: 1.1.14 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/dev/shm && !r:nodev;
 
 # 1.1.15 /dev/shm: nosuid
-[CIS - RHEL6 - 1.1.15 - /dev/shm without 'nosuid' set {CIS: 1.1.15 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.15 - /dev/shm without 'nosuid' set {CIS: 1.1.15 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/dev/shm && !r:nosuid;
 
 # 1.1.16 /dev/shm: noexec
-[CIS - RHEL6 - 1.1.16 - /dev/shm without 'noexec' set {CIS: 1.1.16 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.1.16 - /dev/shm without 'noexec' set {CIS: 1.1.16 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/fstab -> !r:^# && r:/dev/shm && !r:noexec;
 
 # 1.1.17 sticky bit on world writable directories (Scored)
@@ -152,24 +152,27 @@ f:/etc/fstab -> !r:^# && r:/dev/shm && !r:noexec;
 ###############################################
 
 # 1.4.1 enable selinux in /etc/grub.conf
-[CIS - RHEL6 - 1.4.1 - SELinux Disabled in /etc/grub.conf {CIS: 1.4.1 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.4.1 - SELinux Disabled in /etc/grub.conf {CIS: 1.4.1 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/grub.conf -> !r:selinux=0;
+f:/etc/grub2.cfg -> !r:selinux=0;
 
 # 1.4.2 Set selinux state
-[CIS - RHEL6 - 1.4.2 - SELinux not set to enforcing {CIS: 1.4.2 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.4.2 - SELinux not set to enforcing {CIS: 1.4.2 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/selinux/config -> r:SELINUX=enforcing;
 
 # 1.4.3 Set seliux policy
-[CIS - RHEL6 - 1.4.3 - SELinux policy not set to targeted {CIS: 1.4.3 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.4.3 - SELinux policy not set to targeted {CIS: 1.4.3 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/selinux/config -> r:SELINUXTYPE=targeted;
 
 # 1.4.4 Remove SETroubleshoot
-[CIS - RHEL6 - 1.4.4 - SELinux setroubleshoot enabld {CIS: 1.4.4 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.4.4 - SELinux setroubleshoot enabld {CIS: 1.4.4 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dsetroubleshoot$;
+f:/usr/share/dbus-1/services/sealert.service -> r:Exec=/usr/bin/sealert;
 
 # 1.4.5 Disable MCS Translation service mcstrans
-[CIS - RHEL6 - 1.4.5 - SELinux mctrans enabled {CIS: 1.4.5 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.4.5 - SELinux mctrans enabled {CIS: 1.4.5 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dmctrans$;
+f:/usr/lib/systemd/system/mcstransd.service -> r:ExecStart=/usr/sbin/mcstransd;
 
 # 1.4.6 Check for unconfined daemons
 # TODO
@@ -181,21 +184,16 @@ d:$rc_dirs -> ^S\d\dmctrans$;
 
 # 1.5.1 Set User/Group Owner on /etc/grub.conf
 # TODO (no mode tests)
+# stat -L -c "%u %g" /boot/grub2/grub.cfg | egrep "0 0" 
 
 # 1.5.2 Set Permissions on /etc/grub.conf (Scored)
 # TODO (no mode tests)
+#  stat -L -c "%a" /boot/grub2/grub.cfg | egrep ".00"
 
 # 1.5.3 Set Boot Loader Password (Scored)
-[CIS - RHEL6 - 1.5.3 - GRUB Password not set {CIS: 1.5.3 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
-f:/boot/grub/menu.lst -> !r:^# && !r:password;
+[CIS - RHEL7 - 1.5.3 - GRUB Password not set {CIS: 1.5.3 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/boot/grub2/grub.cfg -> !r:^# && !r:password;
 
-# 1.5.4 Require Authentication for Single-User Mode (Scored)
-[CIS - RHEL6 - 1.5.4 - Authenticaion for single user mode not enabled {CIS: 1.5.4 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
-f:/etc/inittab -> !r:^# && r:S:wait;
-
-# 1.5.5 Disable Interactive Boot (Scored)
-[CIS - RHEL6 - 1.5.5 - Interactive Boot not disabled {CIS: 1.5.5 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
-f:/etc/sysconfig/init -> !r:^# && r:PROMPT=no;
 
 
 ###############################################
@@ -203,16 +201,13 @@ f:/etc/sysconfig/init -> !r:^# && r:PROMPT=no;
 ###############################################
 
 # 1.6.1 Restrict Core Dumps (Scored)
-[CIS - RHEL6 - 1.6.1 - Interactive Boot not disabled {CIS: 1.6.1 RHEL6}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 1.6.1 - Interactive Boot not disabled {CIS: 1.6.1 RHEL7}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/security/limits.conf -> !r:^# && !r:hard\.+core\.+0;
 
-# 1.6.2 Configure ExecShield (Scored)
-[CIS - RHEL6 - 1.6.2 - ExecShield not enabled  {CIS: 1.6.2 RHEL6}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
-f:/proc/sys/kernel/exec-shield -> 0;
-
-# 1.6.3 Enable Randomized Virtual Memory Region Placement (Scored)
-[CIS - RHEL6 - 1.6.3 - Randomized Virtua Memory Region Placement not enabled  {CIS: 1.6.3 RHEL6}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
-f:/proc/sys/kernel/randomize_va_space -> 0;
+# 1.6.1 Enable Randomized Virtual Memory Region Placement (Scored)
+# Note this is also labeled 1.6.1 in the CIS benchmark. 
+[CIS - RHEL7 - 1.6.1 - Randomized Virtua Memory Region Placement not enabled  {CIS: 1.6.3 RHEL7}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/proc/sys/kernel/randomize_va_space -> 2;
 
 
 ###############################################
@@ -230,42 +225,49 @@ f:/proc/sys/kernel/randomize_va_space -> 0;
 
 # 2.1.1 Remove telnet-server (Scored)
 # TODO: detect it is installed at all
-[CIS - RHEL6 - 2.1.1 - Telnet enabled on xinetd {CIS: 2.1.1 RHEL6} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 2.1.1 - Telnet enabled on xinetd {CIS: 2.1.1 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/xinetd.d/telnet -> !r:^# && r:disable && r:no;
+f:/usr/lib/systemd/system/telnet@.service -> r:ExecStart=-/usr/sbin/in.telnetd;
 
 
 # 2.1.2 Remove telnet Clients (Scored)
 # TODO
 
 # 2.1.3 Remove rsh-server (Scored)
-[CIS - RHEL6 - 2.1.3 - rsh/rlogin/rcp enabled on xinetd {CIS: 2.1.3 RHEL6} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 2.1.3 - rsh/rlogin/rcp enabled on xinetd {CIS: 2.1.3 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/xinetd.d/rlogin -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.d/rsh -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.d/shell -> !r:^# && r:disable && r:no;
+# TODO (finish this)
+/usr/lib/systemd/system/rexec@.service
+/usr/lib/systemd/system/rlogin@.service
+/usr/lib/systemd/system/rsh@.service
+# Stoped here, adding elements tothe rest
+
 
 # 2.1.4 Remove rsh (Scored)
 # TODO
 
 # 2.1.5 Remove NIS Client (Scored)
-[CIS - RHEL6 - 2.1.5 - Disable standard boot services - NIS (client) Enabled {CIS: 2.1.5 RHEL6} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 2.1.5 - Disable standard boot services - NIS (client) Enabled {CIS: 2.1.5 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dypbind$;
 
 # 2.1.6 Remove NIS Server (Scored)
-[CIS - RHEL6 - 2.1.6 - Disable standard boot services - NIS (server) Enabled {CIS: 2.1.6 RHEL6} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 2.1.6 - Disable standard boot services - NIS (server) Enabled {CIS: 2.1.6 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dypserv$;
 
 # 2.1.7 Remove tftp (Scored)
 # TODO
 
 # 2.1.8 Remove tftp-server (Scored)
-[CIS - RHEL6 - 2.1.8 - tftpd enabled on xinetd {CIS: 2.1.8 RHEL6} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 2.1.8 - tftpd enabled on xinetd {CIS: 2.1.8 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/xinetd.d/tftpd -> !r:^# && r:disable && r:no;
 
 # 2.1.9 Remove talk (Scored)
 # TODO
 
 # 2.1.10 Remove talk-server (Scored)
-[CIS - RHEL6 - 2.1.10 - talk enabled on xinetd {CIS: 2.1.10 RHEL6} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 2.1.10 - talk enabled on xinetd {CIS: 2.1.10 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/xinetd.d/talk -> !r:^# && r:disable && r:no;
 
 # 2.1.11 Remove xinetd (Scored)
@@ -298,15 +300,17 @@ f:/etc/xinetd.d/talk -> !r:^# && r:disable && r:no;
 ###############################################
 
 # 3.1 Set Daemon umask (Scored)
-[CIS - RHEL6 - 3.1 - Set daemon umask - Default umask is higher than 027 {CIS: 3.1 RHEL6} {PCI_DSS: 2.2.2}] [all] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.1 - Set daemon umask - Default umask is higher than 027 {CIS: 3.1 RHEL7} {PCI_DSS: 2.2.2}] [all] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/init.d/functions -> !r:^# && r:^umask && <:umask 027;
+# # grep umask /etc/sysconfig/init
 
 # 3.2 Remove X Windows (Scored)
-[CIS - RHEL6 - 3.2 - X11 not disabled {CIS: 3.2 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.2 - X11 not disabled {CIS: 3.2 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/inittab -> !r:^# && r:id:5;
+#ls -l /usr/lib/systemd/system/default.target | grep graphical.target
 
 # 3.3 Disable Avahi Server (Scored)
-[CIS - RHEL6 - 3.2 - Avahi daemon not disabled {CIS: 3.3 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.2 - Avahi daemon not disabled {CIS: 3.3 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 p:avahi-daemon;
 
 # 3.4 Disable Print Server - CUPS (Not Scored)
@@ -315,13 +319,13 @@ p:avahi-daemon;
 # TODO
 
 # 3.6 Configure Network Time Protocol (NTP) (Scored)
-#[CIS - RHEL6 - 3.6 - NTPD not disabled {CIS: 1.1.1 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+#[CIS - RHEL7 - 3.6 - NTPD not disabled {CIS: 1.1.1 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 # TODO.
 
 # 3.7 Remove LDAP (Not Scored)
 
 # 3.8 Disable NFS and RPC (Not Scored)
-[CIS - RHEL6 - 3.8 - Disable standard boot services - NFS Enabled {CIS: 3.8 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.8 - Disable standard boot services - NFS Enabled {CIS: 3.8 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dnfs$;
 d:$rc_dirs -> ^S\d\dnfslock$;
 
@@ -329,31 +333,31 @@ d:$rc_dirs -> ^S\d\dnfslock$;
 # TODO
 
 # 3.10 Remove FTP Server (Not Scored)
-[CIS - RHEL6 - 3.10 - VSFTP enabled on xinetd {CIS: 3.10 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.10 - VSFTP enabled on xinetd {CIS: 3.10 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/xinetd.d/vsftpd -> !r:^# && r:disable && r:no;
 
 # 3.11 Remove HTTP Server (Not Scored)
-[CIS - RHEL6 - 3.11 - Disable standard boot services - Apache web server Enabled {CIS: 3.11 RHEL6}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.11 - Disable standard boot services - Apache web server Enabled {CIS: 3.11 RHEL7}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dhttpd$;
 
 # 3.12 Remove Dovecot (IMAP and POP3 services) (Not Scored)
-[CIS - RHEL6 - 3.12 - imap enabled on xinetd {CIS: 3.12 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.12 - imap enabled on xinetd {CIS: 3.12 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/xinetd.d/cyrus-imapd -> !r:^# && r:disable && r:no;
 
-[CIS - RHEL6 - 3.12 - pop3 enabled on xinetd {CIS: 3.12 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.12 - pop3 enabled on xinetd {CIS: 3.12 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/xinetd.d/dovecot -> !r:^# && r:disable && r:no;
 
 # 3.13 Remove Samba (Not Scored)
-[CIS - RHEL6 - 3.13 - Disable standard boot services - Samba Enabled {CIS: 3.13 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.13 - Disable standard boot services - Samba Enabled {CIS: 3.13 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dsamba$;
 d:$rc_dirs -> ^S\d\dsmb$;
 
 # 3.14 Remove HTTP Proxy Server (Not Scored)
-[CIS - RHEL6 - 3.14 - Disable standard boot services - Squid Enabled {CIS: 3.14 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.14 - Disable standard boot services - Squid Enabled {CIS: 3.14 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dsquid$;
 
 # 3.15 Remove SNMP Server (Not Scored)
-[CIS - RHEL6 - 3.15 - Disable standard boot services - SNMPD process Enabled {CIS: 3.15 RHEL6} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 3.15 - Disable standard boot services - SNMPD process Enabled {CIS: 3.15 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dsnmpd$;
 
 # 3.16 Configure Mail Transfer Agent for Local-Only Mode (Scored)
@@ -369,12 +373,12 @@ d:$rc_dirs -> ^S\d\dsnmpd$;
 ###############################################
 
 # 4.1.1 Disable IP Forwarding (Scored)
-[CIS - RHEL6 - 4.1.1 - Network parameters - IP Forwarding enabled {CIS: 4.1.1 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 4.1.1 - Network parameters - IP Forwarding enabled {CIS: 4.1.1 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/proc/sys/net/ipv4/ip_forward -> 1;
 f:/proc/sys/net/ipv6/ip_forward -> 1;
 
 # 4.1.2 Disable Send Packet Redirects (Scored)
-[CIS - RHEL6 - 4.1.2 - Network parameters - IP send redirects enabled {CIS: 4.1.2 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 4.1.2 - Network parameters - IP send redirects enabled {CIS: 4.1.2 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/proc/sys/net/ipv4/conf/all/send_redirects -> 0;
 f:/proc/sys/net/ipv4/conf/default/send_redirects -> 0;
 
@@ -384,38 +388,38 @@ f:/proc/sys/net/ipv4/conf/default/send_redirects -> 0;
 ###############################################
 
 # 4.2.1 Disable Source Routed Packet Acceptance (Scored)
-[CIS - RHEL6 - 4.2.1 - Network parameters - Source routing accepted {CIS: 4.2.1 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 4.2.1 - Network parameters - Source routing accepted {CIS: 4.2.1 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/proc/sys/net/ipv4/conf/all/accept_source_route -> 1;
 
 # 4.2.2 Disable ICMP Redirect Acceptance (Scored)
-#[CIS - RHEL6 - 4.2.2 - Network parameters - ICMP redirects accepted {CIS: 1.1.1 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+#[CIS - RHEL7 - 4.2.2 - Network parameters - ICMP redirects accepted {CIS: 1.1.1 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 #f:/proc/sys/net/ipv4/conf/all/accept_redirects -> 1;
 #f:/proc/sys/net/ipv4/conf/default/accept_redirects -> 1;
 
 # 4.2.3 Disable Secure ICMP Redirect Acceptance (Scored)
-[CIS - RHEL6 - 4.2.3 - Network parameters - ICMP secure redirects accepted {CIS: 4.2.3 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 4.2.3 - Network parameters - ICMP secure redirects accepted {CIS: 4.2.3 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/proc/sys/net/ipv4/conf/all/secure_redirects -> 1;
 f:/proc/sys/net/ipv4/conf/default/secure_redirects -> 1;
 
 # 4.2.4 Log Suspicious Packets (Scored)
-[CIS - RHEL6 - 4.2.4 - Network parameters - martians not logged {CIS: 4.2.4 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 4.2.4 - Network parameters - martians not logged {CIS: 4.2.4 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/proc/sys/net/ipv4/conf/all/log_martians -> 0;
 
 # 4.2.5 Enable Ignore Broadcast Requests (Scored)
-[CIS - RHEL6 - 4.2.5 - Network parameters - ICMP broadcasts accepted {CIS: 4.2.5 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 4.2.5 - Network parameters - ICMP broadcasts accepted {CIS: 4.2.5 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts -> 0;
 
 # 4.2.6 Enable Bad Error Message Protection (Scored)
-[CIS - RHEL6 - 4.2.6 - Network parameters - Bad error message protection not enabled {CIS: 4.2.6 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 4.2.6 - Network parameters - Bad error message protection not enabled {CIS: 4.2.6 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/proc/sys/net/ipv4/icmp_ignore_bogus_error_responses -> 0;
 
 # 4.2.7 Enable RFC-recommended Source Route Validation (Scored)
-[CIS - RHEL6 - 4.2.7 - Network parameters - RFC Source route validation not enabled  {CIS: 4.2.7 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 4.2.7 - Network parameters - RFC Source route validation not enabled  {CIS: 4.2.7 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/proc/sys/net/ipv4/conf/all/rp_filter -> 0;
 f:/proc/sys/net/ipv4/conf/default/rp_filter -> 0;
 
 # 4.2.8 Enable TCP SYN Cookies (Scored)
-[CIS - RHEL6 - 4.2.8 - Network parameters - SYN Cookies not enabled {CIS: 4.2.8 RHEL6} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 4.2.8 - Network parameters - SYN Cookies not enabled {CIS: 4.2.8 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/proc/sys/net/ipv4/tcp_syncookies -> 0;
 
 
@@ -472,8 +476,6 @@ f:/proc/sys/net/ipv4/tcp_syncookies -> 0;
 
 # 4.7 Enable IPtables (Scored)
 # TODO
-
-# 4.8 Enable IP6tables (Not Scored)
 
 
 ###############################################
@@ -585,7 +587,7 @@ f:/proc/sys/net/ipv4/tcp_syncookies -> 0;
 ###############################################
 
 # 6.2.1 Set SSH Protocol to 2 (Scored)
-[CIS - RHEL6 - 6.2.1 - SSH Configuration - Protocol version 1 enabled {CIS: 6.2.1 RHEL6} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 6.2.1 - SSH Configuration - Protocol version 1 enabled {CIS: 6.2.1 RHEL7} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\.+1;
 
 # 6.2.2 Set LogLevel to INFO (Scored)
@@ -597,19 +599,19 @@ f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\.+1;
 # 6.2.5 Set SSH MaxAuthTries to 4 or Less (Scored)
 
 # 6.2.6 Set SSH IgnoreRhosts to Yes (Scored)
-[CIS - RHEL6 - 6.2.6 - SSH Configuration - IgnoreRHosts disabled {CIS: 6.2.6 RHEL6} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 6.2.6 - SSH Configuration - IgnoreRHosts disabled {CIS: 6.2.6 RHEL7} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:IgnoreRhosts\.+no;
 
 # 6.2.7 Set SSH HostbasedAuthentication to No (Scored)
-[CIS - RHEL6 - 6.2.7 - SSH Configuration - Host based authentication enabled {CIS: 6.2.7 RHEL6} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 6.2.7 - SSH Configuration - Host based authentication enabled {CIS: 6.2.7 RHEL7} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:HostbasedAuthentication\.+yes;
 
 # 6.2.8 Disable SSH Root Login (Scored)
-[CIS - RHEL6 - 6.2.8 - SSH Configuration - Root login allowed {CIS: 6.2.8 RHEL6} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 6.2.8 - SSH Configuration - Root login allowed {CIS: 6.2.8 RHEL7} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:PermitRootLogin\.+yes;
 
 # 6.2.9 Set SSH PermitEmptyPasswords to No (Scored)
-[CIS - RHEL6 - 6.2.9 - SSH Configuration - Empty passwords permitted {CIS: 6.2.9 RHEL6} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 6.2.9 - SSH Configuration - Empty passwords permitted {CIS: 6.2.9 RHEL7} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:^PermitEmptyPasswords\.+yes;
 
 # 6.2.10 Do Not Allow Users to Set Environment Options (Scored)
@@ -627,15 +629,15 @@ f:/etc/ssh/sshd_config -> !r:^# && r:^PermitEmptyPasswords\.+yes;
 # 6.3 Configure PAM
 ###############################################
 
-# 6.3.1 Set Password Creation Requirement Parameters Using pam_cracklib (Scored)
+# 6.3.1 Upgrade Password Hashing Algorithm to SHA-512 (Scored)
+# authconfig --test | grep hashing | grep sha512
 
-# 6.3.2 Set Lockout for Failed Password Attempts (Not Scored)
+# 6.3.2 Set Password Creation Requirement Parameters Using pam_cracklib (Scored)
 
-# 6.3.3 Use pam_deny.so to Deny Services (Not Scored)
+# 6.3.3 Set Lockout for Failed Password Attempts (Not Scored)
 
-# 6.3.4 Upgrade Password Hashing Algorithm to SHA-512 (Scored)
+# 6.3.4 Limit Password Reuse (Scored)
 
-# 6.3.5 Limit Password Reuse (Scored)
 
 # 6.4 Restrict root Login to System Console (Not Scored)
 
@@ -730,7 +732,7 @@ f:/etc/ssh/sshd_config -> !r:^# && r:^PermitEmptyPasswords\.+yes;
 # 9.2.4 Verify No Legacy "+" Entries Exist in /etc/group File (Scored)
 
 # 9.2.5 Verify No UID 0 Accounts Exist Other Than root (Scored)
-[CIS - RHEL6 - 9.2.5 - Non-root account with uid 0 {CIS: 9.2.5 RHEL6} {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - 9.2.5 - Non-root account with uid 0 {CIS: 9.2.5 RHEL7} {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:;
 
 # 9.2.6 Ensure root PATH Integrity (Scored)
@@ -753,34 +755,36 @@ f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:;
 
 # 9.2.15 Check for Duplicate GIDs (Scored)
 
-# 9.2.16 Check for Duplicate User Names (Scored)
+# 9.2.16 Check That Reserved UIDs Are Assigned to System Accounts  (Scored)
 
-# 9.2.17 Check for Duplicate Group Names (Scored)
+# 9.2.17 Check for Duplicate User Names (Scored)
 
-# 9.2.18 Check for Presence of User .netrc Files (Scored)
+# 9.2.18 Check for Duplicate Group Names (Scored)
 
-# 9.2.19 Check for Presence of User .forward Files (Scored)
+# 9.2.19 Check for Presence of User .netrc Files (Scored)
+
+# 9.2.20 Check for Presence of User .forward Files (Scored)
 
 
 # Other/Legacy Tests
-[CIS - RHEL6 - X.X.X - Account with empty password present {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - X.X.X - Account with empty password present {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/shadow -> r:^\w+::;
 
-[CIS - RHEL6 - X.X.X - User-mounted removable partition allowed on the console] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - X.X.X - User-mounted removable partition allowed on the console] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/security/console.perms -> r:^<console>  \d+ <cdrom>;
 f:/etc/security/console.perms -> r:^<console>  \d+ <floppy>;
 
-[CIS - RHEL6 - X.X.X - Disable standard boot services - Kudzu hardware detection Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - X.X.X - Disable standard boot services - Kudzu hardware detection Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dkudzu$;
 
-[CIS - RHEL6 - X.X.X - Disable standard boot services - PostgreSQL server Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - X.X.X - Disable standard boot services - PostgreSQL server Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dpostgresql$;
 
-[CIS - RHEL6 - X.X.X - Disable standard boot services - MySQL server Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - X.X.X - Disable standard boot services - MySQL server Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dmysqld$;
 
-[CIS - RHEL6 - X.X.X - Disable standard boot services - DNS server Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - X.X.X - Disable standard boot services - DNS server Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dnamed$;
 
-[CIS - RHEL6 - X.X.X - Disable standard boot services - NetFS Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL6 -]
+[CIS - RHEL7 - X.X.X - Disable standard boot services - NetFS Enabled {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dnetfs$;

--- a/src/rootcheck/db/cis_rhel7_linux_rcl.txt
+++ b/src/rootcheck/db/cis_rhel7_linux_rcl.txt
@@ -239,11 +239,9 @@ f:/etc/xinetd.d/rlogin -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.d/rsh -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.d/shell -> !r:^# && r:disable && r:no;
 # TODO (finish this)
-/usr/lib/systemd/system/rexec@.service
-/usr/lib/systemd/system/rlogin@.service
-/usr/lib/systemd/system/rsh@.service
-# Stoped here, adding elements tothe rest
-
+f:/usr/lib/systemd/system/rexec@.service -> r:ExecStart;
+f:/usr/lib/systemd/system/rlogin@.service -> r:ExecStart;
+f:/usr/lib/systemd/system/rsh@.service -> r:ExecStart;
 
 # 2.1.4 Remove rsh (Scored)
 # TODO
@@ -251,10 +249,12 @@ f:/etc/xinetd.d/shell -> !r:^# && r:disable && r:no;
 # 2.1.5 Remove NIS Client (Scored)
 [CIS - RHEL7 - 2.1.5 - Disable standard boot services - NIS (client) Enabled {CIS: 2.1.5 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dypbind$;
+f:/usr/lib/systemd/system/ypbind.service -> r:Exec;
 
 # 2.1.6 Remove NIS Server (Scored)
 [CIS - RHEL7 - 2.1.6 - Disable standard boot services - NIS (server) Enabled {CIS: 2.1.6 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 d:$rc_dirs -> ^S\d\dypserv$;
+f:/usr/lib/systemd/system/ypserv.service -> r:Exec;
 
 # 2.1.7 Remove tftp (Scored)
 # TODO
@@ -262,6 +262,7 @@ d:$rc_dirs -> ^S\d\dypserv$;
 # 2.1.8 Remove tftp-server (Scored)
 [CIS - RHEL7 - 2.1.8 - tftpd enabled on xinetd {CIS: 2.1.8 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/xinetd.d/tftpd -> !r:^# && r:disable && r:no;
+f:/usr/lib/systemd/system/tftp.service -> r:Exec;
 
 # 2.1.9 Remove talk (Scored)
 # TODO
@@ -269,30 +270,40 @@ f:/etc/xinetd.d/tftpd -> !r:^# && r:disable && r:no;
 # 2.1.10 Remove talk-server (Scored)
 [CIS - RHEL7 - 2.1.10 - talk enabled on xinetd {CIS: 2.1.10 RHEL7} {PCI_DSS: 2.2.3}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/xinetd.d/talk -> !r:^# && r:disable && r:no;
+f:/usr/lib/systemd/system/ntalk.service -> r:Exec;
 
 # 2.1.11 Remove xinetd (Scored)
-# TODO
+[CIS - RHEL7 - 2.1.11 -  xinetd detected {CIS: 2.1.11 RHEL7}  [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/usr/lib/systemd/system/xinetd.service -> r:Exec;
 
 # 2.1.12 Disable chargen-dgram (Scored)
-# TODO
+[CIS - RHEL7 - 2.1.12 -  chargen-dgram enabled on xinetd {CIS: 2.1.12 RHEL7}  [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/etc/xinetd.d/chargen-dgram -> !r:^# && r:disable && r:no;
 
 # 2.1.13 Disable chargen-stream (Scored)
-# TODO
+[CIS - RHEL7 - 2.1.13 -  chargen-stream enabled on xinetd {CIS: 2.1.13 RHEL7}  [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/etc/xinetd.d/chargen-stream -> !r:^# && r:disable && r:no;
 
 # 2.1.14 Disable daytime-dgram (Scored)
-# TODO
+[CIS - RHEL7 - 2.1.14 -  daytime-dgram enabled on xinetd {CIS: 2.1.14 RHEL7}  [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/etc/xinetd.d/daytime-dgram -> !r:^# && r:disable && r:no;
 
 # 2.1.15 Disable daytime-stream (Scored)
-# TODO
+[CIS - RHEL7 - 2.1.15 -  daytime-stream enabled on xinetd {CIS: 2.1.15 RHEL7}  [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/etc/xinetd.d/daytime-stream -> !r:^# && r:disable && r:no;
+
 
 # 2.1.16 Disable echo-dgram (Scored)
-# TODO
+[CIS - RHEL7 - 2.1.16 -  echo-dgram enabled on xinetd {CIS: 2.1.16 RHEL7}  [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/etc/xinetd.d/echo-dgram -> !r:^# && r:disable && r:no;
 
 # 2.1.17 Disable echo-stream (Scored)
-# TODO
+[CIS - RHEL7 - 2.1.17 -  echo-stream enabled on xinetd {CIS: 2.1.17 RHEL7}  [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/etc/xinetd.d/echo-stream -> !r:^# && r:disable && r:no;
 
 # 2.1.18 Disable tcpmux-server (Scored)
-# TODO
+[CIS - RHEL7 - 2.1.18 -  tcpmux-server enabled on xinetd {CIS: 2.1.18 RHEL7}  [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/etc/xinetd.d/tcpmux-server -> !r:^# && r:disable && r:no;
 
 
 ###############################################
@@ -301,13 +312,12 @@ f:/etc/xinetd.d/talk -> !r:^# && r:disable && r:no;
 
 # 3.1 Set Daemon umask (Scored)
 [CIS - RHEL7 - 3.1 - Set daemon umask - Default umask is higher than 027 {CIS: 3.1 RHEL7} {PCI_DSS: 2.2.2}] [all] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
-f:/etc/init.d/functions -> !r:^# && r:^umask && <:umask 027;
-# # grep umask /etc/sysconfig/init
+f:/etc/sysconfig/init -> !r:^# && r:^umask && <:umask 027;
 
 # 3.2 Remove X Windows (Scored)
 [CIS - RHEL7 - 3.2 - X11 not disabled {CIS: 3.2 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
-f:/etc/inittab -> !r:^# && r:id:5;
-#ls -l /usr/lib/systemd/system/default.target | grep graphical.target
+f:/usr/lib/systemd/system/default.target -> r:Graphical;
+p:gdm-x-session;
 
 # 3.3 Disable Avahi Server (Scored)
 [CIS - RHEL7 - 3.2 - Avahi daemon not disabled {CIS: 3.3 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
@@ -315,12 +325,14 @@ p:avahi-daemon;
 
 # 3.4 Disable Print Server - CUPS (Not Scored)
 
-# 3.5 Remove DHCP Server (Not Scored)
-# TODO
+# 3.5 Remove DHCP Server (Scored)
+[CIS - RHEL7 - 3.5 - DHCPnot disabled {CIS: 3.5 RHEL7} [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/usr/lib/systemd/system/dhcpd.service -> r:Exec;
 
 # 3.6 Configure Network Time Protocol (NTP) (Scored)
-#[CIS - RHEL7 - 3.6 - NTPD not disabled {CIS: 1.1.1 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
-# TODO.
+[CIS - RHEL7 - 3.6 - NTPD not Configured {CIS: 3.6 RHEL7} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/etc/ntp.conf -> r:restrict default kod nomodify notrap nopeer noquery && r:^server;
+f:/etc/sysconfig/ntpd -> r:OPTIONS="-u ntp:ntp -p /var/run/ntpd.pid";
 
 # 3.7 Remove LDAP (Not Scored)
 
@@ -392,9 +404,9 @@ f:/proc/sys/net/ipv4/conf/default/send_redirects -> 0;
 f:/proc/sys/net/ipv4/conf/all/accept_source_route -> 1;
 
 # 4.2.2 Disable ICMP Redirect Acceptance (Scored)
-#[CIS - RHEL7 - 4.2.2 - Network parameters - ICMP redirects accepted {CIS: 1.1.1 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
-#f:/proc/sys/net/ipv4/conf/all/accept_redirects -> 1;
-#f:/proc/sys/net/ipv4/conf/default/accept_redirects -> 1;
+[CIS - RHEL7 - 4.2.2 - Network parameters - ICMP redirects accepted {CIS: 1.1.1 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/proc/sys/net/ipv4/conf/all/accept_redirects -> 1;
+f:/proc/sys/net/ipv4/conf/default/accept_redirects -> 1;
 
 # 4.2.3 Disable Secure ICMP Redirect Acceptance (Scored)
 [CIS - RHEL7 - 4.2.3 - Network parameters - ICMP secure redirects accepted {CIS: 4.2.3 RHEL7} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
@@ -475,7 +487,8 @@ f:/proc/sys/net/ipv4/tcp_syncookies -> 0;
 # 4.6.4 Disable TIPC (Not Scored)
 
 # 4.7 Enable IPtables (Scored)
-# TODO
+#[CIS - RHEL7 - 4.7 - Uncommon Network Protocols - Firewalld not enabled {CIS: 4.7 RHEL7} [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+#f:/usr/lib/systemd/system/firewalld.service -> TODO;
 
 
 ###############################################
@@ -591,12 +604,20 @@ f:/proc/sys/net/ipv4/tcp_syncookies -> 0;
 f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\.+1;
 
 # 6.2.2 Set LogLevel to INFO (Scored)
+[CIS - RHEL7 - 6.2.1 - SSH Configuration - Protocol version 1 enabled {CIS: 6.2.1 RHEL7} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:/etc/ssh/sshd_config -> !r:^# && !r:LogLevel\.+INFO;
 
 # 6.2.3 Set Permissions on /etc/ssh/sshd_config (Scored)
+# TODO
 
 # 6.2.4 Disable SSH X11 Forwarding (Scored)
+# TODO
 
 # 6.2.5 Set SSH MaxAuthTries to 4 or Less (Scored)
+[ CIS - RHEL7 - 6.2.5 - SSH Configuration - Set SSH MaxAuthTries to 4 or Less  {CIS - RHEL7 - 6.2.5} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
+f:$sshd_file -> !r:^# && r:MaxAuthTries && !r:3\s*$;
+f:$sshd_file -> r:^#\s*MaxAuthTries;
+f:$sshd_file -> !r:MaxAuthTries;
 
 # 6.2.6 Set SSH IgnoreRhosts to Yes (Scored)
 [CIS - RHEL7 - 6.2.6 - SSH Configuration - IgnoreRHosts disabled {CIS: 6.2.6 RHEL7} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
@@ -609,10 +630,12 @@ f:/etc/ssh/sshd_config -> !r:^# && r:HostbasedAuthentication\.+yes;
 # 6.2.8 Disable SSH Root Login (Scored)
 [CIS - RHEL7 - 6.2.8 - SSH Configuration - Root login allowed {CIS: 6.2.8 RHEL7} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:PermitRootLogin\.+yes;
+f:/etc/ssh/sshd_config -> r:^#\s*PermitRootLogin;
 
 # 6.2.9 Set SSH PermitEmptyPasswords to No (Scored)
 [CIS - RHEL7 - 6.2.9 - SSH Configuration - Empty passwords permitted {CIS: 6.2.9 RHEL7} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL7 -]
 f:/etc/ssh/sshd_config -> !r:^# && r:^PermitEmptyPasswords\.+yes;
+f:/etc/ssh/sshd_config -> r:^#\s*PermitEmptyPasswords;
 
 # 6.2.10 Do Not Allow Users to Set Environment Options (Scored)
 

--- a/src/rootcheck/db/cis_rhel_linux_rcl.txt
+++ b/src/rootcheck/db/cis_rhel_linux_rcl.txt
@@ -48,170 +48,170 @@ f:/etc/fedora-release -> r:^Fedora && r:release 5;
 
 
 # Build considerations - Partition scheme.
-[CIS - Red Hat Linux - Build considerations - Robust partition scheme - /var is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - - Build considerations - Robust partition scheme - /var is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/fstab -> !r:/var;
 
-[CIS - Red Hat Linux - Build considerations - Robust partition scheme - /home is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - - Build considerations - Robust partition scheme - /home is not on its own partition] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/fstab -> !r:/home;
 
 
 # Section 1.3 - SSH configuration
-[CIS - Red Hat Linux 1.3 - SSH Configuration - Protocol version 1 enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 1.3 - SSH Configuration - Protocol version 1 enabled {CIS: 1.3 Red Hat Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/ssh/sshd_config -> !r:^# && r:Protocol\.+1;
 
-[CIS - Red Hat Linux 1.3 - SSH Configuration - IgnoreRHosts disabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 1.3 - SSH Configuration - IgnoreRHosts disabled {CIS: 1.3 Red Hat Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/ssh/sshd_config -> !r:^# && r:IgnoreRhosts\.+no;
 
-[CIS - Red Hat Linux 1.3 - SSH Configuration - Empty passwords permitted] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 1.3 - SSH Configuration - Empty passwords permitted {CIS: 1.3 Red Hat Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/ssh/sshd_config -> !r:^# && r:^PermitEmptyPasswords\.+yes;
 
-[CIS - Red Hat Linux 1.3 - SSH Configuration - Host based authentication enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 1.3 - SSH Configuration - Host based authentication enabled {CIS: 1.3 Red Hat Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/ssh/sshd_config -> !r:^# && r:HostbasedAuthentication\.+yes;
 
-[CIS - Red Hat Linux 1.3 - SSH Configuration - Root login allowed] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 1.3 - SSH Configuration - Root login allowed {CIS: 1.3 Red Hat Linux} {PCI_DSS: 4.1}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/ssh/sshd_config -> !r:^# && r:PermitRootLogin\.+yes;
 
 
 # Section 1.4 Enable system accounting
-#[CIS - Red Hat Linux 1.4 - System Accounting - Sysstat not installed] [all] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+#[CIS - Red Hat Linux - 1.4 - System Accounting - Sysstat not installed] [all] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 #f:!/var/log/sa;
 
 
 # Section 2.5 Install and run Bastille
-#[CIS - Red Hat Linux 1.5 - System harderning - Bastille is not installed] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+#[CIS - Red Hat Linux - 1.5 - System harderning - Bastille is not installed] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 #f:!/etc/Bastille;
 
 
 # Section 2 - Minimize xinetd services
-[CIS - Red Hat Linux 2.3 - Telnet enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 2.3 - Telnet enabled on xinetd {CIS: 2.3 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/xinetd.c/telnet -> !r:^# && r:disable && r:no;
 
-[CIS - Red Hat Linux 2.4 - VSFTP enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 2.4 - VSFTP enabled on xinetd {CIS: 2.4 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/xinetd.c/vsftpd -> !r:^# && r:disable && r:no;
 
-[CIS - Red Hat Linux 2.4 - WU-FTP enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 2.4 - WU-FTP enabled on xinetd {CIS: 2.4 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/xinetd.c/wu-ftpd -> !r:^# && r:disable && r:no;
 
-[CIS - Red Hat Linux 2.5 - rsh/rlogin/rcp enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 2.5 - rsh/rlogin/rcp enabled on xinetd {CIS: 2.5 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/xinetd.c/rlogin -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.c/rsh -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.c/shell -> !r:^# && r:disable && r:no;
 
-[CIS - Red Hat Linux 2.6 - tftpd enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 2.6 - tftpd enabled on xinetd {CIS: 2.6 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/xinetd.c/tftpd -> !r:^# && r:disable && r:no;
 
-[CIS - Red Hat Linux 2.7 - imap enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 2.7 - imap enabled on xinetd {CIS: 2.7 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/xinetd.c/imap -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.c/imaps -> !r:^# && r:disable && r:no;
 
-[CIS - Red Hat Linux 2.8 - pop3 enabled on xinetd] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 2.8 - pop3 enabled on xinetd {CIS: 2.8 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/xinetd.c/ipop3 -> !r:^# && r:disable && r:no;
 f:/etc/xinetd.c/pop3s -> !r:^# && r:disable && r:no;
 
 
 # Section 3 - Minimize boot services
-[CIS - Red Hat Linux 3.1 - Set daemon umask - Default umask is higher than 027] [all] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.1 - Set daemon umask - Default umask is higher than 027 {CIS: 3.1 Red Hat Linux}] [all] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/init.d/functions -> !r:^# && r:^umask && >:umask 027;
 
-[CIS - Red Hat Linux 3.4 - GUI login enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.4 - GUI login enabled {CIS: 3.4 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/inittab -> !r:^# && r:id:5;
 
-[CIS - Red Hat Linux 3.7 - Disable standard boot services - Samba Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.7 - Disable standard boot services - Samba Enabled {CIS: 3.7 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dsamba$;
 d:$rc_dirs -> ^S\d\dsmb$;
 
-[CIS - Red Hat Linux 3.8 - Disable standard boot services - NFS Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.8 - Disable standard boot services - NFS Enabled {CIS: 3.8 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dnfs$;
 d:$rc_dirs -> ^S\d\dnfslock$;
 
-[CIS - Red Hat Linux 3.10 - Disable standard boot services - NIS Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.10 - Disable standard boot services - NIS Enabled {CIS: 3.10 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dypbind$;
 d:$rc_dirs -> ^S\d\dypserv$;
 
-[CIS - Red Hat Linux 3.13 - Disable standard boot services - NetFS Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.13 - Disable standard boot services - NetFS Enabled {CIS: 3.13 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dnetfs$;
 
-[CIS - Red Hat Linux 3.15 - Disable standard boot services - Apache web server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.15 - Disable standard boot services - Apache web server Enabled {CIS: 3.15 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dapache$;
 d:$rc_dirs -> ^S\d\dhttpd$;
 
-[CIS - Red Hat Linux 3.15 - Disable standard boot services - TUX web server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.15 - Disable standard boot services - TUX web server Enabled {CIS: 3.15 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dtux$;
 
-[CIS - Red Hat Linux 3.16 - Disable standard boot services - SNMPD process Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.16 - Disable standard boot services - SNMPD process Enabled {CIS: 3.16 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dsnmpd$;
 
-[CIS - Red Hat Linux 3.17 - Disable standard boot services - DNS server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.17 - Disable standard boot services - DNS server Enabled {CIS: 3.17 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dnamed$;
 
-[CIS - Red Hat Linux 3.18 - Disable standard boot services - MySQL server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.18 - Disable standard boot services - MySQL server Enabled {CIS: 3.18 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dmysqld$;
 
-[CIS - Red Hat Linux 3.18 - Disable standard boot services - PostgreSQL server Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.18 - Disable standard boot services - PostgreSQL server Enabled {CIS: 3.18 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dpostgresql$;
 
-[CIS - Red Hat Linux 3.19 - Disable standard boot services - Webmin Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.19 - Disable standard boot services - Webmin Enabled {CIS: 3.19 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dwebmin$;
 
-[CIS - Red Hat Linux 3.20 - Disable standard boot services - Squid Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.20 - Disable standard boot services - Squid Enabled {CIS: 3.20 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dsquid$;
 
-[CIS - Red Hat Linux 3.21 - Disable standard boot services - Kudzu hardware detection Enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 3.21 - Disable standard boot services - Kudzu hardware detection Enabled {CIS: 3.21 Red Hat Linux} {PCI_DSS: 2.2.2}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 d:$rc_dirs -> ^S\d\dkudzu$;
 
 
 # Section 4 - Kernel tuning
-[CIS - Red Hat Linux 4.1 - Network parameters - Source routing accepted] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 4.1 - Network parameters - Source routing accepted {CIS: 4.1 Red Hat Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/proc/sys/net/ipv4/conf/all/accept_source_route -> 1;
 
-[CIS - Red Hat Linux 4.1 - Network parameters - ICMP broadcasts accepted] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 4.1 - Network parameters - ICMP broadcasts accepted {CIS: 4.1 Red Hat Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/proc/sys/net/ipv4/icmp_echo_ignore_broadcasts -> 0;
 
-[CIS - Red Hat Linux 4.2 - Network parameters - IP Forwarding enabled] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 4.2 - Network parameters - IP Forwarding enabled {CIS: 4.2 Red Hat Linux}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/proc/sys/net/ipv4/ip_forward -> 1;
 f:/proc/sys/net/ipv6/ip_forward -> 1;
 
 
 # Section 6 - Permissions
-[CIS - Red Hat Linux 6.1 - Partition /var without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 6.1 - Partition /var without 'nodev' set {CIS: 6.1 Red Hat Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/fstab -> !r:^# && r:ext2|ext3 && r:/var && !r:nodev;
 
-[CIS - Red Hat Linux 6.1 - Partition /tmp without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 6.1 - Partition /tmp without 'nodev' set {CIS: 6.1 Red Hat Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/fstab -> !r:^# && r:ext2|ext3 && r:/tmp && !r:nodev;
 
-[CIS - Red Hat Linux 6.1 - Partition /opt without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 6.1 - Partition /opt without 'nodev' set {CIS: 6.1 Red Hat Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/fstab -> !r:^# && r:ext2|ext3 && r:/opt && !r:nodev;
 
-[CIS - Red Hat Linux 6.1 - Partition /home without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 6.1 - Partition /home without 'nodev' set {CIS: 6.1 Red Hat Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/fstab -> !r:^# && r:ext2|ext3 && r:/home && !r:nodev ;
 
-[CIS - Red Hat Linux 6.2 - Removable partition /media without 'nodev' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 6.2 - Removable partition /media without 'nodev' set {CIS: 6.2 Red Hat Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/fstab -> !r:^# && r:/media && !r:nodev;
 
-[CIS - Red Hat Linux 6.2 - Removable partition /media without 'nosuid' set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 6.2 - Removable partition /media without 'nosuid' set {CIS: 6.2 Red Hat Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/fstab -> !r:^# && r:/media && !r:nosuid;
 
-[CIS - Red Hat Linux 6.3 - User-mounted removable partition allowed on the console] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 6.3 - User-mounted removable partition allowed on the console {CIS: 6.3 Red Hat Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/security/console.perms -> r:^<console>  \d+ <cdrom>;
 f:/etc/security/console.perms -> r:^<console>  \d+ <floppy>;
 
 
 # Section 7 - Access and authentication
-[CIS - Red Hat Linux 7.8 - LILO Password not set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 7.8 - LILO Password not set {CIS: 7.8 Red Hat Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/lilo.conf -> !r:^# && !r:restricted;
 f:/etc/lilo.conf -> !r:^# && !r:password=;
 
-[CIS - Red Hat Linux 7.8 - GRUB Password not set] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 7.8 - GRUB Password not set {CIS: 7.8 Red Hat Linux} {PCI_DSS: 2.2.4}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/boot/grub/menu.lst -> !r:^# && !r:password;
 
-[CIS - Red Hat Linux 8.2 - Account with empty password present] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - 8.2 - Account with empty password present {CIS: 8.2 Red Hat Linux} {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/shadow -> r:^\w+::;
 
-[CIS - Red Hat Linux SN.11 - Non-root account with uid 0] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
+[CIS - Red Hat Linux - SN.11 - Non-root account with uid 0 {PCI_DSS: 10.2.5}] [any] [http://www.ossec.net/wiki/index.php/CIS_RHEL]
 f:/etc/passwd -> !r:^# && !r:^root: && r:^\w+:\w+:0:;
 
 
-# Tests specific for VMware ESX - Runs on Red Hat Linux
+# Tests specific for VMware ESX - Runs on Red Hat Linux -
 # Will not be tested anywhere else.
 [VMware ESX - Testing against the Security Harderning benchmark VI3 for ESX 3.5] [any required] [http://www.ossec.net/wiki/index.php/SecurityHardening_VMwareESX]
 f:/etc/vmware-release -> r:^VMware ESX;

--- a/src/rootcheck/db/system_audit_rcl.txt
+++ b/src/rootcheck/db/system_audit_rcl.txt
@@ -54,44 +54,44 @@ f:$php.ini -> r:^display_errors = On;
 ## Looking for common web exploits files (might indicate that you are owned).
 ## There are not specific, like the above.
 ## Using http://www.ossec.net/wiki/index.php/WebAttacks_links as a reference.
-[Web exploits (uncommon file name inside htdocs) - Possible compromise] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
+[Web exploits (uncommon file name inside htdocs) - Possible compromise  {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
 d:$web_dirs -> ^.yop$;
 
-[Web exploits (uncommon file name inside htdocs) - Possible compromise] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
+[Web exploits (uncommon file name inside htdocs) - Possible compromise {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
 d:$web_dirs -> ^id$;
 
-[Web exploits (uncommon file name inside htdocs) - Possible compromise] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
+[Web exploits (uncommon file name inside htdocs) - Possible compromise {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
 d:$web_dirs -> ^.ssh$;
 
-[Web exploits (uncommon file name inside htdocs) - Possible compromise] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
+[Web exploits (uncommon file name inside htdocs) - Possible compromise {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
 d:$web_dirs -> ^...$;
 
-[Web exploits (uncommon file name inside htdocs) - Possible compromise] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
+[Web exploits (uncommon file name inside htdocs) - Possible compromise {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://www.ossec.net/wiki/index.php/WebAttacks_links]
 d:$web_dirs -> ^.shell$;
 
 ## Looking for outdated Web applications
 ## Taken from http://sucuri.net/latest-versions
-[Web vulnerability - Outdated WordPress installation] [any] [http://sucuri.net/latest-versions]
+[Web vulnerability - Outdated WordPress installation {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://sucuri.net/latest-versions]
 d:$web_dirs -> ^version.php$ -> r:^\.wp_version && >:$wp_version = '3.2.1';
 
-[Web vulnerability - Outdated Joomla (v1.0) installation] [any] [http://sucuri.net/latest-versions]
+[Web vulnerability - Outdated Joomla (v1.0) installation {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://sucuri.net/latest-versions]
 d:$web_dirs -> ^version.php$ -> r:var \.RELEASE && r:'1.0';
 
-#[Web vulnerability - Outdated Joomla (v1.5) installation] [any] [http://sucuri.net/latest-versions]
+#[Web vulnerability - Outdated Joomla (v1.5) installation {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://sucuri.net/latest-versions]
 #d:$web_dirs -> ^version.php$ -> r:var \.RELEASE && r:'1.5' && r:'23'
 
-[Web vulnerability - Outdated osCommerce (v2.2) installation] [any] [http://sucuri.net/latest-versions]
+[Web vulnerability - Outdated osCommerce (v2.2) installation {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://sucuri.net/latest-versions]
 d:$web_dirs -> ^application_top.php$ -> r:'osCommerce 2.2-;
 
 ## Looking for known backdoors
-[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode] [any] []
+[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] []
 d:$web_dirs -> .php$ -> r:eval\(base64_decode\(\paWYo;
 
-[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode(POST] [any] []
+[Web vulnerability - Backdoors / Web based malware found - eval(base64_decode(POST {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] []
 d:$web_dirs -> .php$ -> r:eval\(base64_decode\(\S_POST;
 
-[Web vulnerability - .htaccess file compromised] [any] [http://blog.sucuri.net/2011/05/understanding-htaccess-attacks-part-1.html]
+[Web vulnerability - .htaccess file compromised {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://blog.sucuri.net/2011/05/understanding-htaccess-attacks-part-1.html]
 d:$web_dirs -> ^.htaccess$ -> r:RewriteCond \S+HTTP_REFERERS \S+google;
 
-[Web vulnerability - .htaccess file compromised - auto append] [any] [http://blog.sucuri.net/2011/05/understanding-htaccess-attacks-part-1.html]
+[Web vulnerability - .htaccess file compromised - auto append {PCI_DSS: 6.5} {PCI_DSS: 6.6} {PCI_DSS: 11.4}] [any] [http://blog.sucuri.net/2011/05/understanding-htaccess-attacks-part-1.html]
 d:$web_dirs -> ^.htaccess$ -> r:php_value auto_append_file;

--- a/src/rootcheck/db/win_applications_rcl.txt
+++ b/src/rootcheck/db/win_applications_rcl.txt
@@ -24,7 +24,7 @@
 # Multiple patterns can be specified by using " && " between them.
 # (All of them must match for it to return true).
 
-[Chat/IM/VoIP - Skype] [any] []
+[Chat/IM/VoIP - Skype {PCI_DSS: 10.6.1}] [any] []
 f:\Program Files\Skype\Phone;
 f:\Documents and Settings\All Users\Documents\My Skype Pictures;
 f:\Documents and Settings\Skype;
@@ -33,14 +33,14 @@ r:HKLM\SOFTWARE\Skype;
 r:HKEY_LOCAL_MACHINE\Software\Policies\Skype;
 p:r:Skype.exe;
 
-[Chat/IM - Yahoo] [any] []
+[Chat/IM - Yahoo {PCI_DSS: 10.6.1}] [any] []
 f:\Documents and Settings\All Users\Start Menu\Programs\Yahoo! Messenger;
 r:HKLM\SOFTWARE\Yahoo;
 
-[Chat/IM - ICQ] [any] []
+[Chat/IM - ICQ {PCI_DSS: 10.6.1}] [any] []
 r:HKEY_CURRENT_USER\Software\Mirabilis\ICQ;
 
-[Chat/IM - AOL] [any] [http://www.aol.com]
+[Chat/IM - AOL {PCI_DSS: 10.6.1}] [any] [http://www.aol.com]
 r:HKEY_LOCAL_MACHINE\SOFTWARE\America Online\AOL Instant Messenger;
 r:HKEY_CLASSES_ROOT\aim\shell\open\command;
 r:HKEY_CLASSES_ROOT\AIM.Protocol;
@@ -48,26 +48,26 @@ r:HKEY_CLASSES_ROOT\MIME\Database\Content Type\application/x-aim;
 f:\Program Files\AIM95;
 p:r:aim.exe;
 
-[Chat/IM - MSN] [any] [http://www.msn.com]
+[Chat/IM - MSN {PCI_DSS: 10.6.1}] [any] [http://www.msn.com]
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSNMessenger;
 r:HKEY_CURRENT_USER\SOFTWARE\Microsoft\MSNMessenger;
 f:\Program Files\MSN Messenger;
 f:\Program Files\Messenger;
 p:r:msnmsgr.exe;
 
-[Chat/IM - ICQ] [any] [http://www.icq.com]
+[Chat/IM - ICQ {PCI_DSS: 10.6.1}] [any] [http://www.icq.com]
 r:HKLM\SOFTWARE\Mirabilis\ICQ;
 
-[P2P - UTorrent] [any] []
+[P2P - UTorrent {PCI_DSS: 10.6.1}] [any] []
 p:r:utorrent.exe;
 
-[P2P - LimeWire] [any] []
+[P2P - LimeWire {PCI_DSS: 11.4}] [any] []
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Limewire;
 r:HKLM\software\microsoft\windows\currentversion\run -> limeshop;
 f:\Program Files\limewire;
 f:\Program Files\limeshop;
 
-[P2P/Adware - Kazaa] [any] []
+[P2P/Adware - Kazaa {PCI_DSS: 11.4}] [any] []
 f:\Program Files\kazaa;
 f:\Documents and Settings\All Users\Start Menu\Programs\kazaa;
 f:\Documents and Settings\All Users\DESKTOP\Kazaa Media Desktop.lnk;
@@ -78,7 +78,7 @@ r:HKEY_CURRENT_USER\SOFTWARE\KAZAA;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\MICROSOFT\WINDOWS\CURRENTVERSION\RUN\KAZAA;
 
 # http://vil.nai.com/vil/content/v_135023.htm
-[Adware - RxToolBar] [any] [http://vil.nai.com/vil/content/v_135023.htm]
+[Adware - RxToolBar {PCI_DSS: 11.4}] [any] [http://vil.nai.com/vil/content/v_135023.htm]
 r:HKEY_CURRENT_USER\Software\Infotechnics;
 r:HKEY_CURRENT_USER\Software\Infotechnics\RX Toolbar;
 r:HKEY_CURRENT_USER\Software\RX Toolbar;
@@ -87,7 +87,7 @@ r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RX Toolbar;
 f:\Program Files\RXToolBar;
 
 # http://btfaq.com/serve/cache/18.html
-[P2P - BitTorrent] [any] [http://btfaq.com/serve/cache/18.html]
+[P2P - BitTorrent {PCI_DSS: 10.6.1}] [any] [http://btfaq.com/serve/cache/18.html]
 f:\Program Files\BitTorrent;
 r:HKEY_CLASSES_ROOT\.torrent;
 r:HKEY_CLASSES_ROOT\MIME\Database\Content Type\application/x-bittorrent;
@@ -95,7 +95,7 @@ r:HKEY_CLASSES_ROOT\bittorrent;
 r:HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\BitTorrent;
 
 # http://www.gotomypc.com
-[Remote Access - GoToMyPC] [any] []
+[Remote Access - GoToMyPC {PCI_DSS: 10.6.1}] [any] []
 f:\Program Files\Citrix\GoToMyPC;
 f:\Program Files\Citrix\GoToMyPC\g2svc.exe;
 f:\Program Files\Citrix\GoToMyPC\g2comm.exe;
@@ -106,20 +106,20 @@ r:HKEY_LOCAL_MACHINE\system\currentcontrolset\services\gotomypc;
 p:r:g2svc.exe;
 p:r:g2pre.exe;
 
-[Spyware - Twain Tec Spyware] [any] []
+[Spyware - Twain Tec Spyware {PCI_DSS: 11.4}] [any] []
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Classes\TwaintecDll.TwaintecDllObj.1;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\twaintech;
 f:%WINDIR%\twaintec.dll;
 
 # http://www.symantec.com/security_response/writeup.jsp?docid=2004-062611-4548-99&tabid=2
-[Spyware - SpyBuddy] [any] []
+[Spyware - SpyBuddy {PCI_DSS: 11.4}] [any] []
 f:\Program Files\ExploreAnywhere\SpyBuddy\sb32mon.exe;
 f:\Program Files\ExploreAnywhere\SpyBuddy;
 f:\Program Files\ExploreAnywhere;
 f:%WINDIR%\System32\sysicept.dll;
 r:HKEY_LOCAL_MACHINE\Software\ExploreAnywhere Software\SpyBuddy;
 
-[Spyware - InternetOptimizer] [any] []
+[Spyware - InternetOptimizer {PCI_DSS: 11.4}] [any] []
 r:HKLM\SOFTWARE\Avenue Media;
 r:HKEY_CLASSES_ROOT\\safesurfinghelper.iebho.1;
 r:HKEY_CLASSES_ROOT\\safesurfinghelper.iebho;

--- a/src/rootcheck/db/win_audit_rcl.txt
+++ b/src/rootcheck/db/win_audit_rcl.txt
@@ -25,38 +25,38 @@
 # (All of them must match for it to return true).
 
 # http://technet2.microsoft.com/windowsserver/en/library/486896ba-dfa1-4850-9875-13764f749bba1033.mspx?mfr=true
-[Disabled Registry tools set] [any] []
+[Disabled Registry tools set {PCI_DSS: 10.6.1}] [any] []
 r:HKCU\Software\Microsoft\Windows\CurrentVersion\Policies\System -> DisableRegistryTools -> 1;
 r:HKLM\Software\Microsoft\Windows\CurrentVersion\Policies\System -> DisableRegistryTools -> 1;
 
 # http://support.microsoft.com/kb/825750
-[DCOM disabled] [any] []
+[DCOM disabled {PCI_DSS: 10.6.1}] [any] []
 r:HKEY_LOCAL_MACHINE\Software\Microsoft\OLE -> EnableDCOM -> N;
 
 # http://web.mit.edu/is/topics/windows/server/winmitedu/security.html
-[LM authentication allowed (weak passwords)] [any] []
+[LM authentication allowed (weak passwords) {PCI_DSS: 10.6.1} {PCI_DSS: 11.4}] [any] []
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\LSA -> LMCompatibilityLevel -> 0;
 r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\LSA -> LMCompatibilityLevel -> 1;
 
 # http://research.eeye.com/html/alerts/AL20060813.html
 # Disabled by some Malwares (sometimes by McAfee and Symantec
 # security center too).
-[Firewall/Anti Virus notification disabled] [any] []
+[Firewall/Anti Virus notification disabled {PCI_DSS: 10.6.1}] [any] []
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Security Center -> FirewallDisableNotify -> !0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Security Center -> antivirusoverride -> !0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Security Center -> firewalldisablenotify -> !0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Security Center -> firewalldisableoverride -> !0;
 
 # Checking for the microsoft firewall.
-[Microsoft Firewall disabled] [all] []
+[Microsoft Firewall disabled {PCI_DSS: 10.6.1} {PCI_DSS: 1.4}] [all] []
 r:HKEY_LOCAL_MACHINE\software\policies\microsoft\windowsfirewall\domainprofile -> enablefirewall -> 0;
 r:HKEY_LOCAL_MACHINE\software\policies\microsoft\windowsfirewall\standardprofile -> enablefirewall -> 0;
 
 #http://web.mit.edu/is/topics/windows/server/winmitedu/security.html
-[Null sessions allowed] [any] []
+[Null sessions allowed {PCI_DSS: 11.4}] [any] []
 r:HKLM\System\CurrentControlSet\Control\Lsa -> RestrictAnonymous -> 0;
 
-[Error reporting disabled] [any] [http://windowsir.blogspot.com/2007/04/something-new-to-look-for.html]
+[Error reporting disabled {PCI_DSS: 10.6.1}] [any] [http://windowsir.blogspot.com/2007/04/something-new-to-look-for.html]
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PCHealth\ErrorReporting -> DoReport -> 0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PCHealth\ErrorReporting -> IncludeKernelFaults -> 0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PCHealth\ErrorReporting -> IncludeMicrosoftApps -> 0;
@@ -65,9 +65,9 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PCHealth\ErrorReporting -> IncludeShutdo
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PCHealth\ErrorReporting -> ShowUI -> 0;
 
 # http://support.microsoft.com/default.aspx?scid=315231
-[Automatic Logon enabled] [any] [http://support.microsoft.com/default.aspx?scid=315231]
+[Automatic Logon enabled {PCI_DSS: 10.6.1}] [any] [http://support.microsoft.com/default.aspx?scid=315231]
 r:HKLM\SOFTWARE\Microsoft\WindowsNT\CurrentVersion\Winlogon -> DefaultPassword;
 r:HKLM\SOFTWARE\Microsoft\WindowsNT\CurrentVersion\Winlogon -> AutoAdminLogon -> 1;
 
-[Winpcap packet filter driver found] [any] []
+[Winpcap packet filter driver found {PCI_DSS: 10.6.1}] [any] []
 f:%WINDIR%\System32\drivers\npf.sys;

--- a/src/rootcheck/db/win_malware_rcl.txt
+++ b/src/rootcheck/db/win_malware_rcl.txt
@@ -25,19 +25,19 @@
 # (All of them must match for it to return true).
 
 # http://www.iss.net/threats/ginwui.html
-[Ginwui Backdoor] [any] [http://www.iss.net/threats/ginwui.html]
+[Ginwui Backdoor {PCI_DSS: 11.4}] [any] [http://www.iss.net/threats/ginwui.html]
 f:%WINDIR%\System32\zsyhide.dll;
 f:%WINDIR%\System32\zsydll.dll;
 r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify\zsydll;
 r:HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Windows -> AppInit_DLLs -> r:zsyhide.dll;
 
 # http://www.symantec.com/security_response/writeup.jsp?docid=2006-081312-3302-99&tabid=2
-[Wargbot Backdoor] [any] []
+[Wargbot Backdoor {PCI_DSS: 11.4}] [any] []
 f:%WINDIR%\System32\wgareg.exe;
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\wgareg;
 
 # http://www.f-prot.com/virusinfo/descriptions/sober_j.html
-[Sober Worm] [any] []
+[Sober Worm {PCI_DSS: 11.4}] [any] []
 f:%WINDIR%\System32\nonzipsr.noz;
 f:%WINDIR%\System32\clonzips.ssc;
 f:%WINDIR%\System32\clsobern.isc;
@@ -53,7 +53,7 @@ f:%WINDIR%\System32\sysmms32.lla;
 f:%WINDIR%\System32\Odin-Anon.Ger;
 
 # http://www.symantec.com/security_response/writeup.jsp?docid=2005-042611-0148-99&tabid=2
-[Hotword Trojan] [any] []
+[Hotword Trojan {PCI_DSS: 11.4}] [any] []
 f:%WINDIR%\System32\_;
 f:%WINDIR%\System32\explore.exe;
 f:%WINDIR%\System32\ svchost.exe;
@@ -64,7 +64,7 @@ f:%WINDIR%\System32\CHJO.DRV;
 f:%WINDIR%\System32\MMSYSTEM.DLX;
 f:%WINDIR%\System32\OLECLI.DL;
 
-[Beagle worm] [any] []
+[Beagle worm {PCI_DSS: 11.4}] [any] []
 f:%WINDIR%\System32\winxp.exe;
 f:%WINDIR%\System32\winxp.exeopen;
 f:%WINDIR%\System32\winxp.exeopenopen;
@@ -72,7 +72,7 @@ f:%WINDIR%\System32\winxp.exeopenopenopen;
 f:%WINDIR%\System32\winxp.exeopenopenopenopen;
 
 # http://symantec.com/security_response/writeup.jsp?docid=2007-071711-3132-99
-[Gpcoder Trojan] [any] [http://symantec.com/security_response/writeup.jsp?docid=2007-071711-3132-99]
+[Gpcoder Trojan {PCI_DSS: 11.4}] [any] [http://symantec.com/security_response/writeup.jsp?docid=2007-071711-3132-99]
 f:%WINDIR%\System32\ntos.exe;
 f:%WINDIR%\System32\wsnpoem;
 f:%WINDIR%\System32\wsnpoem\audio.dll;
@@ -80,25 +80,25 @@ f:%WINDIR%\System32\wsnpoem\video.dll;
 r:HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run -> userinit -> r:ntos.exe;
 
 # [http://www.symantec.com/security_response/writeup.jsp?docid=2006-112813-0222-99&tabid=2
-[Looked.BK Worm] [any] []
+[Looked.BK Worm {PCI_DSS: 11.4}] [any] []
 f:%WINDIR%\uninstall\rundl132.exe;
 f:%WINDIR%\Logo1_.exe;
 f:%Windir%\RichDll.dll;
 r:HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run -> load -> r:rundl132.exe;
 
-[Possible Malware - Svchost running outside system32] [all] []
+[Possible Malware - Svchost running outside system32 {PCI_DSS: 11.4}] [all] []
 p:r:svchost.exe && !%WINDIR%\System32\svchost.exe;
 f:!%WINDIR%\SysWOW64;
 
-[Possible Malware - Inetinfo running outside system32\inetsrv] [all] []
+[Possible Malware - Inetinfo running outside system32\inetsrv {PCI_DSS: 11.4}] [all] []
 p:r:inetinfo.exe && !%WINDIR%\System32\inetsrv\inetinfo.exe;
 f:!%WINDIR%\SysWOW64;
 
-[Possible Malware - Rbot/Sdbot detected] [any] []
+[Possible Malware - Rbot/Sdbot detected {PCI_DSS: 11.4}] [any] []
 f:%Windir%\System32\rdriv.sys;
 f:%Windir%\lsass.exe;
 
-[Possible Malware File] [any] []
+[Possible Malware File {PCI_DSS: 11.4}] [any] []
 f:%WINDIR%\utorrent.exe;
 f:%WINDIR%\System32\utorrent.exe;
 f:%WINDIR%\System32\Files32.vxd;


### PR DESCRIPTION
Add system audit configuration for RHEL/Centos/Cloudlnux 7, this also merges in the wazuh PCI tags to the existing rhel5, rhel6, and debian audit files.