### PR TITLE
WIP: Allow file change before syscheck raise an alert

### DIFF
--- a/etc/rules/ossec_rules.xml
+++ b/etc/rules/ossec_rules.xml
@@ -211,6 +211,13 @@
     <group>syscheck,agentless</group>
   </rule>
 
+  <rule id="556" level="2">
+    <category>ossec</category>
+    <decoded_as>syscheck_allowed</decoded_as>
+    <description>Integrity checksum changed (allowed).</description>
+    <group>syscheck,</group>
+  </rule>
+
   <!-- Hostinfo rules -->  
   <rule id="580" level="8">
     <category>ossec</category>

--- a/etc/rules/ossec_rules.xml
+++ b/etc/rules/ossec_rules.xml
@@ -211,7 +211,7 @@
     <group>syscheck,agentless</group>
   </rule>
 
-  <rule id="556" level="2">
+  <rule id="556" level="3">
     <category>ossec</category>
     <decoded_as>syscheck_allowed</decoded_as>
     <description>Integrity checksum changed (allowed).</description>

--- a/src/Makefile
+++ b/src/Makefile
@@ -379,6 +379,7 @@ install-common: build
 	install -d -m 0770 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/alerts
 	install -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/ossec
 	install -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/syscheck
+	install -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/syscheck-allowchange
 	install -d -m 0750 -o ${OSSEC_USER} -g ${OSSEC_GROUP} ${PREFIX}/queue/diff
 
 	install -d -m 0550 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -755,6 +755,15 @@ void OS_ReadMSG_analysisd(int m_queue)
                 lf->size = strlen(lf->log);
             }
 
+            /* Allowchange event decoding */
+            else if (msg[0] == ALLOWCHANGE_MQ) {
+                if (!DecodeAllowchange(lf)) {
+                    /* We don't process allowchange events further */
+                    goto CLMEM;
+                }
+                lf->size = strlen(lf->log);
+            }
+
             /* Host information special decoder */
             else if (msg[0] == HOSTINFO_MQ) {
                 if (!DecodeHostinfo(lf)) {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -32,6 +32,7 @@
 #include "cleanevent.h"
 #include "dodiff.h"
 #include "output/jsonout.h"
+#include "decoders/syscheck-allow.h"
 
 #ifdef PICVIZ_OUTPUT_ENABLED
 #include "output/picviz.h"

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -691,6 +691,7 @@ int SetDecodeXML()
     addDecoder2list(SYSCHECK_MOD);
     addDecoder2list(SYSCHECK_MOD2);
     addDecoder2list(SYSCHECK_MOD3);
+    addDecoder2list(SYSCHECK_ALLOWED);
     addDecoder2list(SYSCHECK_NEW);
     addDecoder2list(SYSCHECK_DEL);
     addDecoder2list(HOSTINFO_NEW);

--- a/src/analysisd/decoders/syscheck-allow.c
+++ b/src/analysisd/decoders/syscheck-allow.c
@@ -1,0 +1,110 @@
+/* Copyright (C) 2009 Trend Micro Inc.
+ * All right reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+/* Syscheck decoder */
+
+#include "eventinfo.h"
+#include "os_regex/os_regex.h"
+#include "config.h"
+#include "decoder.h"
+
+/* We write allowed filenames in a database located at /queue/syscheck-allowchange/<agent>
+ * Each line represents an entry which is structured as
+ *     <is_valid> <validity_timestamp> <path>
+ * where <is_valid> is either the char '0' or '1',
+ * and indicate whereas this entry have already been consummed.
+ */
+
+
+/* Determine if this filename have at least one allowed change, and
+   consumme it */
+static int consumeAllowchange(const char *filename, Eventinfo *lf){
+    FILE *db_file;
+    char db_filename[OS_FLSIZE];
+    char line[OS_FLSIZE*2];
+    int allowed = 0;
+    time_t current;
+    snprintf(db_filename, OS_FLSIZE , "%s/%s", ALLOWCHANGE_DIR, lf->hostname);
+    db_file = fopen(db_filename, "r+");
+    rewind(db_file);
+    if (!db_file) {
+        verbose("failed to open %s", db_filename);
+        return 0;
+    }
+    current = time(0);
+
+
+    while (fgets(line, OS_FLSIZE*2, db_file) != NULL) {
+        /* Attempt to parse the line */
+        int validity;
+        time_t until;
+        char path[OS_FLSIZE];
+        sscanf(line, "%d %d %s", &validity, &until, path);
+        if (validity) {
+            if (until > current) {
+                if (strcmp(path, filename) == 0){
+                    int len = strlen(line);
+                    /* Rewrite current entry */
+                    fseek(db_file, -len, SEEK_CUR);
+                    fprintf(db_file, "0");
+                    fclose(db_file);
+                    return until;
+                }
+            }
+        }
+    }
+
+    fclose(db_file);
+    return allowed;
+}
+
+/* Save an Allowchange record in our "database"
+*/
+static int produceAllowchange(time_t timestamp, const char *filename, Eventinfo *lf){
+    FILE *db_file;
+    char db_filename[OS_FLSIZE];
+    snprintf(db_filename, OS_FLSIZE , "%s/%s", ALLOWCHANGE_DIR, lf->hostname);
+    verbose("opening %s", db_filename);
+    db_file = fopen(db_filename, "a");
+    if (db_file) {
+        fprintf(db_file, "%d %d %s\n", 1, timestamp, filename);
+        fclose(db_file);
+        return timestamp;
+    }
+    verbose("failed to write to %s", db_filename);
+    return 0;
+}
+
+
+
+/* A special decoder to read an AllowChange event */
+int DecodeAllowchange(Eventinfo *lf)
+{
+    int status;
+    time_t timestamp;
+    char *f_name;
+
+    /* Allowchange messages must be in the following format:
+     * timestamp filename
+     */
+    f_name = strchr(lf->log, ' ');
+    if (f_name == NULL) {
+        merror(SK_INV_MSG, ARGV0);
+        return (0);
+    }
+
+    /* Zero to get the timestamp */
+    *f_name = '\0';
+    f_name++;
+
+    /* Get timestamp */
+    timestamp = atoi(lf->log);
+    produceAllowchange(timestamp, f_name, lf);
+    return timestamp;
+}

--- a/src/analysisd/decoders/syscheck-allow.c
+++ b/src/analysisd/decoders/syscheck-allow.c
@@ -32,13 +32,15 @@ static int consumeAllowchange(const char *filename, Eventinfo *lf){
     time_t current;
     snprintf(db_filename, OS_FLSIZE , "%s/%s", ALLOWCHANGE_DIR, lf->hostname);
     db_file = fopen(db_filename, "r+");
-    rewind(db_file);
     if (!db_file) {
-        verbose("failed to open %s", db_filename);
-        return 0;
+        db_file = fopen(db_filename, "w+");
+        if (!db_file) {
+            verbose("failed to open %s", db_filename);
+            return 0;
+        }
     }
+    rewind(db_file);
     current = time(0);
-
 
     while (fgets(line, OS_FLSIZE*2, db_file) != NULL) {
         /* Attempt to parse the line */

--- a/src/analysisd/decoders/syscheck-allow.c
+++ b/src/analysisd/decoders/syscheck-allow.c
@@ -47,7 +47,7 @@ static int consumeAllowchange(const char *filename, Eventinfo *lf){
         int validity;
         time_t until;
         char path[OS_FLSIZE];
-        sscanf(line, "%d %d %s", &validity, &until, path);
+        sscanf(line, "%d %ld %s", &validity, &until, path);
         if (validity) {
             if (until > current) {
                 if (strcmp(path, filename) == 0){

--- a/src/analysisd/decoders/syscheck-allow.c
+++ b/src/analysisd/decoders/syscheck-allow.c
@@ -24,7 +24,7 @@
 
 /* Determine if this filename have at least one allowed change, and
    consumme it */
-static int consumeAllowchange(const char *filename, Eventinfo *lf){
+int consumeAllowchange(const char *filename, Eventinfo *lf){
     FILE *db_file;
     char db_filename[OS_FLSIZE];
     char line[OS_FLSIZE*2];
@@ -68,18 +68,17 @@ static int consumeAllowchange(const char *filename, Eventinfo *lf){
 
 /* Save an Allowchange record in our "database"
 */
-static int produceAllowchange(time_t timestamp, const char *filename, Eventinfo *lf){
+int produceAllowchange(time_t timestamp, const char *filename, Eventinfo *lf){
     FILE *db_file;
     char db_filename[OS_FLSIZE];
     snprintf(db_filename, OS_FLSIZE , "%s/%s", ALLOWCHANGE_DIR, lf->hostname);
-    verbose("opening %s", db_filename);
     db_file = fopen(db_filename, "a");
     if (db_file) {
-        fprintf(db_file, "%d %d %s\n", 1, timestamp, filename);
+        fprintf(db_file, "%d %ld %s\n", 1, timestamp, filename);
         fclose(db_file);
         return timestamp;
     }
-    verbose("failed to write to %s", db_filename);
+    verbose("Failed to open %s", db_filename);
     return 0;
 }
 
@@ -88,7 +87,6 @@ static int produceAllowchange(time_t timestamp, const char *filename, Eventinfo 
 /* A special decoder to read an AllowChange event */
 int DecodeAllowchange(Eventinfo *lf)
 {
-    int status;
     time_t timestamp;
     char *f_name;
 

--- a/src/analysisd/decoders/syscheck-allow.h
+++ b/src/analysisd/decoders/syscheck-allow.h
@@ -1,0 +1,10 @@
+#ifndef __SYSCHECK_ALLOW_H
+#define __SYSCHECK_ALLOW_H
+
+#include "shared.h"
+
+int consumeAllowchange(const char *filename, Eventinfo *lf);
+int produceAllowchange(time_t timestamp, const char *filename, Eventinfo *lf);
+int DecodeAllowchange(Eventinfo *lf);
+
+#endif

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -39,7 +39,6 @@ typedef struct __sdb {
     int id3;
     int idn;
     int idd;
-    int id_allowed;
 
     /* Syscheck rule */
     OSDecoderInfo  *syscheck_dec;
@@ -89,7 +88,6 @@ void SyscheckInit()
     sdb.id3 = getDecoderfromlist(SYSCHECK_MOD3);
     sdb.idn = getDecoderfromlist(SYSCHECK_NEW);
     sdb.idd = getDecoderfromlist(SYSCHECK_DEL);
-    sdb.id_allowed = getDecoderfromlist(SYSCHECK_ALLOWED);
 
     debug1("%s: SyscheckInit completed.", ARGV0);
     return;
@@ -677,7 +675,8 @@ int DecodeSyscheck(Eventinfo *lf)
 
     /* Check if the file have been allowed to change */
     if (consumeAllowchange(f_name, lf)){
-        lf->decoder_info = sdb.id_allowed;
+        lf->decoder_info->id = getDecoderfromlist(SYSCHECK_ALLOWED);
+        lf->decoder_info->name = SYSCHECK_ALLOWED;
     }
     return status;
 }

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -128,7 +128,7 @@ static int __iscompleted(const char *agent)
 
 
 static int consumeAllow(const char *filename){
-    verbose("is %s allowed ?\n", filename);
+    verbose("is %s allowed ?", filename);
     return 0;
 }
 
@@ -686,3 +686,29 @@ int DecodeSyscheck(Eventinfo *lf)
     return status;
 }
 
+/* A special decoder to read an AllowChange event */
+int DecodeAllowchange(Eventinfo *lf)
+{
+    int status;
+    int timestamp;
+    char *f_name;
+
+    verbose("incoming %s", lf->log);
+    /* Every allow change message must be in the following format:
+     * timestamp filename
+     */
+    f_name = strchr(lf->log, ' ');
+    if (f_name == NULL) {
+        merror(SK_INV_MSG, ARGV0);
+        return (0);
+    }
+
+    /* Zero to get the timestamp */
+    *f_name = '\0';
+    f_name++;
+
+    /* Get timestamp */
+    timestamp = atoi(lf->log);
+    verbose("successfully read allowchange for %s until %d from %s", f_name, timestamp, lf->hostname);
+    return timestamp;
+}

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -14,7 +14,7 @@
 #include "config.h"
 #include "alerts/alerts.h"
 #include "decoder.h"
-#include "syscheck-allow.c" /* I don't like this either */
+#include "syscheck-allow.h"
 
 typedef struct __sdb {
     char buf[OS_MAXSTR + 1];
@@ -178,7 +178,6 @@ static FILE *DB_File(const char *agent, int *agent_id)
 
     /* Get agent file */
     snprintf(sdb.buf, OS_FLSIZE , "%s/%s", SYSCHECK_DIR, agent);
-    verbose("opening %s", sdb.buf);
     /* r+ to read and write. Do not truncate */
     sdb.agent_fps[i] = fopen(sdb.buf, "r+");
     if (!sdb.agent_fps[i]) {
@@ -306,9 +305,8 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
         }
 
         /* Check the number of changes */
-        if (!Config.syscheck_auto_ignore) {
-            sdb.syscheck_dec->id = sdb.id1;
-        } else {
+        sdb.syscheck_dec->id = sdb.id1;
+        if (Config.syscheck_auto_ignore) {
             switch (p) {
                 case 0:
                     sdb.syscheck_dec->id = sdb.id1;

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -232,6 +232,7 @@ int _setlevels(RuleNode *node, int nnode);
 #define SYSCHECK_MOD3   "syscheck_integrity_changed_3rd"
 #define SYSCHECK_NEW    "syscheck_new_entry"
 #define SYSCHECK_DEL    "syscheck_deleted"
+#define SYSCHECK_ALLOWED "syscheck_allowed"
 
 /* Global variables */
 extern int _max_freq;

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -126,6 +126,7 @@ http://www.ossec.net/main/license/\n"
 /* Syscheck data */
 #define SYSCHECK        "syscheck"
 #define SYSCHECK_REG    "syscheck-registry"
+#define ALLOWCHANGE     "syscheck-allowchange"
 
 /* Rule path */
 #define RULEPATH        "/rules"

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -117,6 +117,9 @@ http://www.ossec.net/main/license/\n"
 /* Rootcheck directory */
 #define ROOTCHECK_DIR    "/queue/rootcheck"
 
+/* Allowchange directory */
+#define ALLOWCHANGE_DIR     "/queue/syscheck-allowchange"
+
 /* Diff queue */
 #define DIFF_DIR        "/queue/diff"
 #define DIFF_DIR_PATH   DEFAULTDIR DIFF_DIR

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -32,6 +32,7 @@
 #define OS_FLSIZE       OS_SIZE_256     /* Maximum file size            */
 #define OS_HEADER_SIZE  OS_SIZE_128     /* Maximum header size          */
 #define OS_LOG_HEADER   OS_SIZE_256     /* Maximum log header size      */
+#define OS_MAXPATH      OS_SIZE_1024    /* Maximum filepath length      */
 #define IPSIZE          INET6_ADDRSTRLEN /* IP Address size             */
 
 /* Some global names */

--- a/src/headers/mq_op.h
+++ b/src/headers/mq_op.h
@@ -17,6 +17,7 @@
 #define SECURE_MQ       '4'
 #define SYSCHECK_MQ     '8'
 #define ROOTCHECK_MQ    '9'
+#define ALLOWCHANGE_MQ  'c'
 
 /* Queues for additional log types */
 #define MYSQL_MQ        'a'

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -72,7 +72,7 @@ static void read_internal(int debug_level)
 static int allowChange(char* filename, time_t timestamp)
 {
     char msg[1024*2];
-    sprintf(msg, "%d %s", timestamp, filename);
+    sprintf(msg, "%ld %s", timestamp, filename);
     if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
         ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQPATH);
     }

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -76,11 +76,10 @@ static int allowChange(char* filename, time_t timestamp)
     if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
         ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQPATH);
     }
-    sleep(1);
     if (SendMSG(syscheck.queue, msg, ALLOWCHANGE, ALLOWCHANGE_MQ) < 0) {
         merror(QUEUE_SEND, ARGV0);
     }
-    printf("send_allowchange_msg: %s to %s\n", msg, DEFAULTQPATH);
+    debug1("%s: send_allowchange_msg: %s to %s\n", ARGV0, msg, DEFAULTQPATH);
     return 0;
 }
 

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -407,4 +407,3 @@ int main(int argc, char **argv)
 }
 
 #endif /* !WIN32 */
-

--- a/src/syscheckd/syscheck.c
+++ b/src/syscheckd/syscheck.c
@@ -71,15 +71,16 @@ static void read_internal(int debug_level)
  */
 static int allowChange(char* filename, time_t timestamp)
 {
-
+    char msg[1024*2];
+    sprintf(msg, "%d %s", timestamp, filename);
     if ((syscheck.queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
         ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQPATH);
     }
     sleep(1);
-    if (SendMSG(syscheck.queue, filename, SYSCHECK, ALLOWCHANGE_MQ) < 0) {
+    if (SendMSG(syscheck.queue, msg, ALLOWCHANGE, ALLOWCHANGE_MQ) < 0) {
         merror(QUEUE_SEND, ARGV0);
     }
-    printf("send_allowchange_msg: %s to %s\n", filename, DEFAULTQPATH);
+    printf("send_allowchange_msg: %s to %s\n", msg, DEFAULTQPATH);
     return 0;
 }
 


### PR DESCRIPTION
Hi,

When my hosts gets an upgrade, either distribution packages or
in-house applications, I get flooded with `Integrity file changed`
alerts for files and software I upgraded.

Actually, I do not want those alerts, whose lower the signal/noise
ratio. Morever, I tend to just not read these kind of alerts since I
feel most of them are false-positive.

At the moment, OSSEC miss a feature to allow a file to change prior to
the actual update.

I thought of the following requierements:
- we must be able to tell OSSEC that a particular file could change
- we must be able to allow changes for specific agents
- we must be able to set an upper time-limit until the file is allowed to change
- if the file changes after the time limit, we must get an alert
- if the file changes twice during the time limit, we must get an alert ...
- ... unless it have been allowed to change a second time, in which case we don't want an alert
- the agent should be able to tell the monitor which files could change
- we must get an alert if a changement have not been allowed
- actually, we always want an alert whenever one file changes
- we want different alerts levels depending on whether it have been allowed or not

Based on these requierements, I extended `syscheckd` to accept a
`-u <timestamp>`. Called with this switch, `syscheckd` won't start
in daemon, but will read paths from stdin. Those path will be sent to
the monitor, together with the timestamp.

On the monitor (whatever host is running `analysisd` actually), we
watch for those message and produce `allowchanges` token in an
agent-specific queue.  This token contains

  1) a flag to know whether the token is still valid
  2) a timestamp until which it is not valid anymore
  3) the filepath allowed to change.

Now everytime `analysisd` is about to
generated an alert for an integrity change, it try to consume one
token for the file. If a token have been found, we set the decoder to
`syscheck-allowchange`, and users can write their rules according to their needs.
Otherwise, the old behaviour still apply.

As a security consideration, we could argue that this mechanism allow
an attacker to silentely changes binary on the agents if she allows
the changes before being evil.  In fact, the monitor already trust
`syscheckd` for the file integrity, so an attacker with root access
could simply just turn it off.

What do you think about it ?
