### PR TITLE
Syscheck boot

### DIFF
--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -11,7 +11,7 @@
     
     <!-- Directories to check  (perform all possible verifications) -->
     <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
-    <directories check_all="yes">/bin,/sbin</directories>
+    <directories check_all="yes">/bin,/sbin,/boot</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -82,7 +82,7 @@
     
     <!-- Directories to check  (perform all possible verifications) -->
     <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
-    <directories check_all="yes">/bin,/sbin</directories>
+    <directories check_all="yes">/bin,/sbin,/boot</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -81,7 +81,7 @@
     
     <!-- Directories to check  (perform all possible verifications) -->
     <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
-    <directories check_all="yes">/bin,/sbin</directories>
+    <directories check_all="yes">/bin,/sbin,/boot</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -40,7 +40,7 @@
     
     <!-- Directories to check  (perform all possible verifications) -->
     <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
-    <directories check_all="yes">/bin,/sbin</directories>
+    <directories check_all="yes">/bin,/sbin,/boot</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>

--- a/etc/templates/config/syscheck.template
+++ b/etc/templates/config/syscheck.template
@@ -4,7 +4,7 @@
     
     <!-- Directories to check  (perform all possible verifications) -->
     <directories check_all="yes">/etc,/usr/bin,/usr/sbin</directories>
-    <directories check_all="yes">/bin,/sbin</directories>
+    <directories check_all="yes">/bin,/sbin,/boot</directories>
 
     <!-- Files/directories to ignore -->
     <ignore>/etc/mtab</ignore>


### PR DESCRIPTION
Add /boot to default syscheck directories. I don't think this should have any ill effects on non-linux systems.
This solves issue #675 