### PR TITLE
Add a rule for users not in sudoers.

### DIFF
--- a/contrib/ossec-testing/tests/sudo.ini
+++ b/contrib/ossec-testing/tests/sudo.ini
@@ -27,3 +27,11 @@ log 1 pass = Jun 25 16:15:45 precise32 sudo:     mike : 3 incorrect password att
 rule = 5404
 alert = 10
 decoder = sudo
+
+[unauthorized user]
+log 1 pass = Apr 13 08:36:31 ix sudo:     ddp2 : user NOT in sudoers ; TTY=ttypZ ; PWD=/home/ddp2 ; USER=root ; COMMAND=/bin/ls
+
+rule = 5405
+alert = 5
+decoder = sudo
+

--- a/etc/rules/syslog_rules.xml
+++ b/etc/rules/syslog_rules.xml
@@ -509,6 +509,13 @@
     <match>3 incorrect password attempts</match>
     <description>Three failed attempts to run sudo</description>
   </rule>
+
+  <rule id="5405" level="5">
+    <if_sid>5400</if_sid>
+    <match>user NOT in sudoers</match>
+    <description>Unauthorized user attempted to use sudo.</description>
+  </rule>
+
 </group> <!-- SYSLOG, SUDO -->
 
 


### PR DESCRIPTION
Based on a suggestion from Cameron Cross on uservoice (pepperidge farms remembers)
https://ossec.uservoice.com/forums/18254-general/suggestions/11498193-add-a-rule-to-detect-when-a-user-is-not-in-the-sud