### PR TITLE
Allow for longer entries in the system.information column

### DIFF
--- a/src/os_dbd/mysql.schema
+++ b/src/os_dbd/mysql.schema
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS  server
     last_contact    INT         UNSIGNED NOT NULL,
     version         VARCHAR(32)          NOT NULL,
     hostname        VARCHAR(64)          NOT NULL   UNIQUE,
-    information     VARCHAR(128)         NOT NULL,
+    information     TEXT                 NOT NULL,
     PRIMARY KEY  (id)
     );
 

--- a/src/os_dbd/postgresql.schema
+++ b/src/os_dbd/postgresql.schema
@@ -41,7 +41,7 @@ CREATE TABLE server
     last_contact    INT8                 NOT NULL,
     version         VARCHAR(32)          NOT NULL,
     hostname        VARCHAR(64)          NOT NULL   UNIQUE,
-    information     VARCHAR(128)         NOT NULL,
+    information     TEXT                 NOT NULL,
     PRIMARY KEY  (id)
     );
 


### PR DESCRIPTION
Switch from VARCHAR(128) to TEXT to allow for longer entries in the
information column.  On server registration, this column is typically
loaded with the output of ```uname -a```.  That's frequently longer than
128 characters.  For instance on the FreeBSD servers I manage, it's
typically in excess of 180 characters:

```
ox-dell39:~:% uname -a | wc
       1      15     185
```

Since the length of the data being written to that column is checked,
this results in a failed SQL query at which the ossec-dbd process quits.

Tested with postgresql; equivalent change applied to mysql.schema