### PR TITLE
Ignore OpenBSD's Random seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ src/external/zlib-1.2.8/zlib.pc
 src/isbigendian.c
 src/analysisd/compiled_rules/compiled_rules.h
 etc/ossec.mc
-
+src/Config.OS
+src/external/zlib-1.2.8/ztest*
 
 # Compiled programs
 src/agent-auth

--- a/contrib/ossec-testing/tests/sshd.ini
+++ b/contrib/ossec-testing/tests/sshd.ini
@@ -87,6 +87,7 @@ decoder = sshd
 
 [ssh no matching key exchange]
 log 1 pass = Sep 16 05:46:56 junction sshd[1961]: fatal: Unable to negotiate with 108.229.36.174: no matching key exchange method found. Their offer: diffie-hellman-group1-sha1,diffie-hellman-group-exchange-sha1 [preauth]
+log 2 pass = Apr 18 21:27:08 web2 sshd[23484]: fatal: Unable to negotiate a key exchange method [preauth]
 
 rule = 5752
 alert = 2

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -18,6 +18,7 @@
     <ignore>/etc/hosts.deny</ignore>
     <ignore>/etc/mail/statistics</ignore>
     <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
     <ignore>/etc/adjtime</ignore>
     <ignore>/etc/httpd/logs</ignore>
 

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -89,6 +89,7 @@
     <ignore>/etc/hosts.deny</ignore>
     <ignore>/etc/mail/statistics</ignore>
     <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
     <ignore>/etc/adjtime</ignore>
     <ignore>/etc/httpd/logs</ignore>
 

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -88,6 +88,7 @@
     <ignore>/etc/hosts.deny</ignore>
     <ignore>/etc/mail/statistics</ignore>
     <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
     <ignore>/etc/adjtime</ignore>
     <ignore>/etc/httpd/logs</ignore>
 

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -47,6 +47,7 @@
     <ignore>/etc/hosts.deny</ignore>
     <ignore>/etc/mail/statistics</ignore>
     <ignore>/etc/random-seed</ignore>
+    <ignore>/etc/random.seed</ignore>
     <ignore>/etc/adjtime</ignore>
     <ignore>/etc/httpd/logs</ignore>
 

--- a/etc/rules/sshd_rules.xml
+++ b/etc/rules/sshd_rules.xml
@@ -345,7 +345,7 @@
   <rule id="5750" level="0">
     <decoded_as>sshd</decoded_as>
     <if_sid>5700</if_sid>
-    <match>Unable to negotiate with </match>
+    <match>Unable to negotiate with |Unable to negotiate a key</match>
     <description>sshd could not negotiate with client.</description>
   </rule>
 
@@ -358,7 +358,7 @@
 
   <rule id="5752" level="2">
     <if_sid>5750</if_sid>
-    <match>no matching key exchange method found.</match>
+    <match>no matching key exchange method found.|Unable to negotiate a key exchange method</match>
     <description>Client did not offer an acceptable key exchange method.</description>
   </rule>
 


### PR DESCRIPTION
OpenBSD used random.seed instead of the random-seed we already ignore, so ignore theirs too.

This PR pulls in stuff from some previous PRs because I lacked coffee one day.