### PR TITLE
Windows decoder fix

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1889,7 +1889,8 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   -->
 <decoder name="windows">
   <type>windows</type>
-  <prematch>^\d\d\d\d \w\w\w \d\d \d\d:\d\d:\d\d WinEvtLog: |^WinEvtLog: </prematch>
+  <!--<prematch>^\d\d\d\d \w\w\w \d\d \d\d:\d\d:\d\d WinEvtLog: |^WinEvtLog: </prematch>-->
+  <program_name>^WinEvtLog</program_name>
   <regex offset="after_prematch">^\.+: (\w+)\((\d+)\): (\.+): </regex>
   <regex>(\.+): \.+: (\S+): </regex>
   <order>status, id, extra_data, user, system_name</order>


### PR DESCRIPTION
This needs extensive testing, and we don't have many Windows logs in the testing framework.

This fixes issue #712, but I'm not positive there isn't any other fallout.