### PR TITLE
Use 'df -P' instead of 'df -h'

### DIFF
--- a/etc/rules/ossec_rules.xml
+++ b/etc/rules/ossec_rules.xml
@@ -134,7 +134,7 @@
 
   <rule id="531" level="7" ignore="7200">
     <if_sid>530</if_sid>
-    <match>ossec: output: 'df -h': /dev/</match>
+    <match>ossec: output: 'df -P': /dev/</match>
     <regex>100%</regex>
     <description>Partition usage reached 100% (disk space monitor).</description> 
     <group>low_diskspace,</group>

--- a/install.sh
+++ b/install.sh
@@ -330,7 +330,7 @@ SetupLogs()
       echo "" >> $NEWCONFIG
       echo "  <localfile>" >> $NEWCONFIG
       echo "    <log_format>command</log_format>" >> $NEWCONFIG
-      echo "    <command>df -h</command>" >> $NEWCONFIG
+      echo "    <command>df -P</command>" >> $NEWCONFIG
       echo "  </localfile>" >> $NEWCONFIG
       echo "" >> $NEWCONFIG
       echo "  <localfile>" >> $NEWCONFIG


### PR DESCRIPTION
`-P` is supposed to be a stricter format used by scripts. This prevents the output of each device displayed with `df` from being printed on 2 lines
It is incompatible with `-h` on OpenBSD. If this is a popular feature, it can be added back with some scripting shenanigans.