### PR TITLE
Match the arguments passed from WinExecdRun().

### DIFF
--- a/active-response/win/route-null.cmd
+++ b/active-response/win/route-null.cmd
@@ -9,9 +9,10 @@ FOR /F "TOKENS=1-3 DELIMS=:" %%A IN ("%TIME%") DO SET TIM=%%A:%%B:%%C
 :: Check for required arguments
 IF /I "%1"=="" GOTO ERROR
 IF /I "%2"=="" GOTO ERROR
+IF /I "%3"=="" GOTO ERROR
 
 :: Check for a valid IP
-ECHO "%2" | %WINDIR%\system32\findstr.exe /R "\." >nul || GOTO ipv6
+ECHO "%3" | %WINDIR%\system32\findstr.exe /R "\." >nul || GOTO ipv6
 
 set prefixlength=32
 set gateway=0.0.0.0
@@ -28,20 +29,20 @@ IF /I "%1"=="delete" GOTO DEL
 
 :ERROR
 ECHO Invalid argument(s).
-ECHO Usage: route-null.cmd ^(ADD^|DELETE^) IP Address
-ECHO Example: route-null.cmd ADD 1.2.3.4
+ECHO Usage: route-null.cmd ^(ADD^|DELETE^) user IP_Address
+ECHO Example: route-null.cmd ADD - 1.2.3.4
 EXIT /B 1
 
 :: Adding IP to be null-routed.
 
 :ADD
-%WINDIR%\system32\route.exe ADD %2/%prefixlength% %gateway%
+%WINDIR%\system32\route.exe ADD %3/%prefixlength% %gateway%
 :: Log it
-ECHO %DAT%%TIM% %~dp0%0 %1 - %2 >> "%OSSECPATH%active-response\active-responses.log"
+ECHO %DAT%%TIM% %~dp0%0 %1 %2 %3 >> "%OSSECPATH%active-response\active-responses.log"
 GOTO EXIT
 
 :DEL
-%WINDIR%\system32\route.exe DELETE %2/%prefixlength%
-ECHO %DAT%%TIM% %~dp0%0 %1 - %2 >> "%OSSECPATH%active-response\active-responses.log"
+%WINDIR%\system32\route.exe DELETE %3/%prefixlength%
+ECHO %DAT%%TIM% %~dp0%0 %1 %2 %3 >> "%OSSECPATH%active-response\active-responses.log"
 
 :EXIT /B 0:


### PR DESCRIPTION
Reference the ossec-list discussion:
  https://groups.google.com/forum/#!topic/ossec-list/bTAbuvSZKGo

Active Response in Windows was not working.  Apparently route-null.cmd was changed in commit 168cb2f to look for only two arguments instead of three resulting in the IP address, which is the third arg, being ignored.  This restores the mandatory arg count to three.