### PR TITLE
Fixed segmentation fault at logcollector

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -401,13 +401,14 @@ void LogCollectorStart()
 			merror(FOPEN_ERROR, ARGV0, logff[i].file, errno, strerror(errno));
 		}
 
-                if ((fstat(fileno(tf), &tmp_stat)) == -1) {
+                else if ((fstat(fileno(tf), &tmp_stat)) == -1) {
                     fclose(logff[i].fp);
+                    fclose(tf);
                     logff[i].fp = NULL;
 
                     merror(FSTAT_ERROR, ARGV0, logff[i].file, errno, strerror(errno));
                 }
-		if(fclose(tf) == EOF) {
+		else if(fclose(tf) == EOF) {
 			merror("Closing the temporary file %s did not work (%d): %s", logff[i].file, errno, strerror(errno));
 		}
 #else


### PR DESCRIPTION
This should solve the issue https://github.com/ossec/ossec-hids/issues/829.

When Logcollector can't open a temporary file pointer (because it receives a null pointer) it shows an error but tries to get the file descriptor from that null pointer. This causes the segmentation fault.

I added some `else` statements in order to avoid to read this pointer after showing the error.