### PR TITLE
Add a rule to quiet 1002 from alerting on failed useradds.

### DIFF
--- a/contrib/ossec-testing/tests/syslog.ini
+++ b/contrib/ossec-testing/tests/syslog.ini
@@ -33,3 +33,11 @@ log 1 fail = 2015 2015 Nov 13 13:40:01 ether rsyslogd-2177: imuxsock begins to d
 rule = 2945
 alert = 4
 decoder =
+
+[useradd failed]
+log 1 pass = May  4 18:21:10 collectd useradd[15178]: failed adding user 'ansible', data deleted
+
+rule = 5905
+alert = 0
+decoder =
+

--- a/contrib/ossec-testing/tests/syslog.ini
+++ b/contrib/ossec-testing/tests/syslog.ini
@@ -35,7 +35,7 @@ alert = 4
 decoder =
 
 [useradd failed]
-log 1 pass = May  4 18:21:10 collectd useradd[15178]: failed adding user 'ansible', data deleted
+log 1 fail = May  4 18:21:10 collectd useradd[15178]: failed adding user 'ansible', data deleted
 
 rule = 5905
 alert = 0

--- a/etc/rules/syslog_rules.xml
+++ b/etc/rules/syslog_rules.xml
@@ -474,6 +474,13 @@
     <match>^changed user</match>
     <description>Information from the user was changed</description>
   </rule>
+
+  <rule id="5905" level="0">
+    <program_name>useradd</program_name>
+    <match>failed adding user </match>
+    <description>useradd failed.</description>
+  </rule>
+
 </group> <!-- SYSLOG,ADDUSER -->
 
 


### PR DESCRIPTION
Are useradd failures something we'd care about seeing? I have it set to level 0 at the moment, but it wouldn't be hard to convince me it should be higher.