### PR TITLE
add 3 rules for systemd logs. 

### DIFF
--- a/contrib/ossec-testing/tests/systemd.ini
+++ b/contrib/ossec-testing/tests/systemd.ini
@@ -5,3 +5,24 @@ rule = 40701
 alert = 0
 decoder =
 
+[Escape request from different namespace requires a proxy]
+log 1 pass = May  4 17:47:51 collectd systemd-logind[4614]: cgmanager: cgm_enter for controller=systemd, cgroup_path=lxc/collectd/user/1002.user/c1.session, pid=15013 failed: Escape request from different namespace requires a proxy
+
+rule = 40704
+alert = 0
+decoder =
+
+[called from different user namespace]
+log 1 fail = May  4 17:47:51 collectd systemd-logind[4614]: cgmanager: cgm_chown for controller=systemd, cgroup_path=lxc/collectd/user/1002.user/c1.session, uid=1002, gid=1002 failed: chown called from different user namespace
+
+rule = 40705
+alert = 0
+decoder =
+
+[Operation not permitted]
+log 1 fail = May  4 17:47:51 collectd systemd-logind[4614]: Failed to create name=systemd:/lxc/collectd/user/1002.user/c1.session: Operation not permitted
+
+rule = 40706
+alert = 1
+decoder =
+

--- a/contrib/ossec-testing/tests/systemd.ini
+++ b/contrib/ossec-testing/tests/systemd.ini
@@ -6,7 +6,7 @@ alert = 0
 decoder =
 
 [Escape request from different namespace requires a proxy]
-log 1 pass = May  4 17:47:51 collectd systemd-logind[4614]: cgmanager: cgm_enter for controller=systemd, cgroup_path=lxc/collectd/user/1002.user/c1.session, pid=15013 failed: Escape request from different namespace requires a proxy
+log 1 fail = May  4 17:47:51 collectd systemd-logind[4614]: cgmanager: cgm_enter for controller=systemd, cgroup_path=lxc/collectd/user/1002.user/c1.session, pid=15013 failed: Escape request from different namespace requires a proxy
 
 rule = 40704
 alert = 0

--- a/etc/rules/systemd_rules.xml
+++ b/etc/rules/systemd_rules.xml
@@ -23,5 +23,23 @@
     <description>Service has entered a failed state, and likely has not started.</description>
   </rule>
 
+  <rule id="40704" level="0">
+    <if_sid>1002</if_sid> <!-- Not sure why 40700 doesn't work here -->
+    <match>Escape request from different namespace requires a proxy</match>
+    <descripton>No idea.</description> <!-- XXX Need to look this up -->
+  </rule>
+
+  <rule id="40705" level="0"> <!-- Not working at all? -->
+    <if_sid>1002</if_sid>
+    <match>called from different user namespace$</match>
+    <description>No idea</description> <!-- XXX Need to look this up -->
+  </rule>
+
+  <rule id="40706" level="2"> <!-- Not working at all? -->
+    <if_sid>1002</if_sid>
+    <match>Operation not permitted$</match>
+    <description>systemd operation not permitted.</description>
+  </rule>
+
 </group>
 

--- a/etc/rules/systemd_rules.xml
+++ b/etc/rules/systemd_rules.xml
@@ -26,7 +26,7 @@
   <rule id="40704" level="0">
     <if_sid>1002</if_sid> <!-- Not sure why 40700 doesn't work here -->
     <match>Escape request from different namespace requires a proxy</match>
-    <descripton>No idea.</description> <!-- XXX Need to look this up -->
+    <description>No idea.</description> <!-- XXX Need to look this up -->
   </rule>
 
   <rule id="40705" level="0"> <!-- Not working at all? -->


### PR DESCRIPTION
2 of 3 rules have BAD placeholder descriptions until I have a chance to look into them more.

The first works, but with if_sid 1002, which shouldn't be necessary.
The second and third do not work. Unsure as to why, but don't have
time to look into it further just yet.
