### PR TITLE
- GeoIP support in Alerts

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ OSSEC_USER_REM?=ossecr
 
 USE_PRELUDE?=no
 USE_ZEROMQ?=no
-USE_GEOIP?=no
+USE_GEOIP?=yes
 USE_INOTIFY=no
 
 ifneq (${TARGET},winagent)

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,7 @@ OSSEC_USER_REM?=ossecr
 
 USE_PRELUDE?=no
 USE_ZEROMQ?=no
-USE_GEOIP?=yes
+USE_GEOIP?=no
 USE_INOTIFY=no
 
 ifneq (${TARGET},winagent)

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -82,6 +82,17 @@ void OS_Store(const Eventinfo *lf)
 
 void OS_LogOutput(Eventinfo *lf)
 {
+#ifdef LIBGEOIP_ENABLED
+    if (Config.geoipdb_file) {
+        if (lf->srcip) {
+                lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
+        }
+        if (lf->dstip) {
+                lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
+        }
+    }
+#endif
+
     printf(
         "** Alert %ld.%ld:%s - %s\n"
         "%d %s %02d %s %s%s%s\nRule: %d (level %d) -> '%s'"
@@ -104,8 +115,14 @@ void OS_LogOutput(Eventinfo *lf)
         lf->srcip == NULL ? "" : "\nSrc IP: ",
         lf->srcip == NULL ? "" : lf->srcip,
 
-        lf->srcgeoip == NULL?"":" / ",
-        lf->srcgeoip == NULL?"":lf->srcgeoip,
+#ifdef LIBGEOIP_ENABLED
+        lf->srcgeoip == NULL ? "" : "\nSrc Location: ",
+        lf->srcgeoip == NULL ? "" : lf->srcgeoip,
+#else
+        "",
+        "",
+#endif
+
 
 
         lf->srcport == NULL ? "" : "\nSrc Port: ",
@@ -114,8 +131,14 @@ void OS_LogOutput(Eventinfo *lf)
         lf->dstip == NULL ? "" : "\nDst IP: ",
         lf->dstip == NULL ? "" : lf->dstip,
 
-        lf->dstgeoip == NULL?"":" / ",
-        lf->dstgeoip == NULL?"":lf->dstgeoip,
+#ifdef LIBGEOIP_ENABLED
+        lf->dstgeoip == NULL ? "" : "\nDst Location: ",
+        lf->dstgeoip == NULL ? "" : lf->dstgeoip,
+#else
+        "",
+        "",
+#endif
+
 
 
         lf->dstport == NULL ? "" : "\nDst Port: ",
@@ -144,6 +167,17 @@ void OS_LogOutput(Eventinfo *lf)
 
 void OS_Log(Eventinfo *lf)
 {
+#ifdef LIBGEOIP_ENABLED
+    if (Config.geoipdb_file) {
+        if (lf->srcip) {
+                lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
+        }
+        if (lf->dstip) {
+                lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
+        }
+    }
+#endif
+
     /* Writing to the alert log file */
     fprintf(_aflog,
             "** Alert %ld.%ld:%s - %s\n"
@@ -167,8 +201,13 @@ void OS_Log(Eventinfo *lf)
             lf->srcip == NULL ? "" : "\nSrc IP: ",
             lf->srcip == NULL ? "" : lf->srcip,
 
-            lf->srcgeoip == NULL?"":" / ",
-            lf->srcgeoip == NULL?"":lf->srcgeoip,
+#ifdef LIBGEOIP_ENABLED
+            lf->srcgeoip == NULL ? "" : "\nSrc Location: ",
+            lf->srcgeoip == NULL ? "" : lf->srcgeoip,
+#else
+            "",
+            "",
+#endif
 
 
             lf->srcport == NULL ? "" : "\nSrc Port: ",
@@ -177,8 +216,14 @@ void OS_Log(Eventinfo *lf)
             lf->dstip == NULL ? "" : "\nDst IP: ",
             lf->dstip == NULL ? "" : lf->dstip,
 
-            lf->dstgeoip == NULL?"":" / ",
-            lf->dstgeoip == NULL?"":lf->dstgeoip,
+#ifdef LIBGEOIP_ENABLED
+            lf->dstgeoip == NULL ? "" : "\nDst Location: ",
+            lf->dstgeoip == NULL ? "" : lf->dstgeoip,
+#else
+            "",
+            "",
+#endif
+
 
 
             lf->dstport == NULL ? "" : "\nDst Port: ",

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -132,6 +132,8 @@ int main_analysisd(int argc, char **argv)
     hourly_syscheck = 0;
     hourly_firewall = 0;
 
+    geoipdb = NULL;
+
     while ((c = getopt(argc, argv, "Vtdhfu:g:D:c:")) != -1) {
         switch (c) {
             case 'V':
@@ -220,6 +222,17 @@ int main_analysisd(int argc, char **argv)
     }
 
     debug1(READ_CONFIG, ARGV0);
+
+
+    /* Opening GeoIP DB */
+    if(Config.geoipdb_file) {
+        geoipdb = GeoIP_open(Config.geoipdb_file, GEOIP_INDEX_CACHE);
+        if (geoipdb == NULL)
+        {
+            merror("%s: Unable to open GeoIP database from: %s (disabling GeoIP).", ARGV0, Config.geoipdb_file);
+        }
+    }
+
 
     /* Fix Config.ar */
     Config.ar = ar_flag;
@@ -1213,6 +1226,31 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
                 return (NULL);
             }
         }
+
+        /* Adding checks for geoip. */
+        if(rule->srcgeoip) {
+            if(lf->srcgeoip) {
+                if(!OSMatch_Execute(lf->srcgeoip,
+                            strlen(lf->srcgeoip),
+                            rule->srcgeoip))
+                    return(NULL);
+            } else {
+                return(NULL);
+            }
+        }
+
+
+        if(rule->dstgeoip) {
+            if(lf->dstgeoip) {
+                if(!OSMatch_Execute(lf->dstgeoip,
+                            strlen(lf->dstgeoip),
+                            rule->dstgeoip))
+                    return(NULL);
+            } else {
+                return(NULL);
+            }
+        }
+
 
         /* Check if any rule related to the size exist */
         if (rule->maxsize) {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -132,7 +132,10 @@ int main_analysisd(int argc, char **argv)
     hourly_syscheck = 0;
     hourly_firewall = 0;
 
+#ifdef LIBGEOIP_ENABLED
     geoipdb = NULL;
+#endif
+
 
     while ((c = getopt(argc, argv, "Vtdhfu:g:D:c:")) != -1) {
         switch (c) {
@@ -224,6 +227,7 @@ int main_analysisd(int argc, char **argv)
     debug1(READ_CONFIG, ARGV0);
 
 
+#ifdef LIBGEOIP_ENABLED
     /* Opening GeoIP DB */
     if(Config.geoipdb_file) {
         geoipdb = GeoIP_open(Config.geoipdb_file, GEOIP_INDEX_CACHE);
@@ -232,6 +236,8 @@ int main_analysisd(int argc, char **argv)
             merror("%s: Unable to open GeoIP database from: %s (disabling GeoIP).", ARGV0, Config.geoipdb_file);
         }
     }
+#endif
+
 
 
     /* Fix Config.ar */

--- a/src/analysisd/config.h
+++ b/src/analysisd/config.h
@@ -12,9 +12,11 @@
 
 #include "config/config.h"
 #include "config/global-config.h"
+#include "GeoIP.h"
 
 extern long int __crt_ftell; /* Global ftell pointer */
 extern _Config Config;       /* Global Config structure */
+GeoIP *geoipdb;
 
 int GlobalConf(const char *cfgfile);
 

--- a/src/analysisd/config.h
+++ b/src/analysisd/config.h
@@ -19,7 +19,10 @@
 
 extern long int __crt_ftell; /* Global ftell pointer */
 extern _Config Config;       /* Global Config structure */
+
+#ifdef LIBGEOIP_ENABLED
 GeoIP *geoipdb;
+#endif
 
 int GlobalConf(const char *cfgfile);
 

--- a/src/analysisd/config.h
+++ b/src/analysisd/config.h
@@ -12,7 +12,10 @@
 
 #include "config/config.h"
 #include "config/global-config.h"
+#ifdef LIBGEOIP_ENABLED
 #include "GeoIP.h"
+#endif
+
 
 extern long int __crt_ftell; /* Global ftell pointer */
 extern _Config Config;       /* Global Config structure */

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -260,6 +260,9 @@ void *SrcIP_FP(Eventinfo *lf, char *field)
 #endif
 
     lf->srcip = field;
+    if(!lf->srcgeoip) { 
+        lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
+    }
     return (NULL);
 }
 
@@ -272,6 +275,9 @@ void *DstIP_FP(Eventinfo *lf, char *field)
 #endif
 
     lf->dstip = field;
+    if(!lf->dstgeoip) { 
+        lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
+    }
     return (NULL);
 }
 

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -260,10 +260,15 @@ void *SrcIP_FP(Eventinfo *lf, char *field)
 #endif
 
     lf->srcip = field;
+
+#ifdef LIBGEOIP_ENABLED
+
     if(!lf->srcgeoip) { 
         lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
     }
     return (NULL);
+#endif
+
 }
 
 void *DstIP_FP(Eventinfo *lf, char *field)
@@ -275,10 +280,14 @@ void *DstIP_FP(Eventinfo *lf, char *field)
 #endif
 
     lf->dstip = field;
+#ifdef LIBGEOIP_ENABLED
+
     if(!lf->dstgeoip) { 
         lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
     }
     return (NULL);
+#endif
+
 }
 
 void *SrcPort_FP(Eventinfo *lf, char *field)

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -56,6 +56,7 @@ void OS_CreateOSDecoderList(void);
 int OS_AddOSDecoder(OSDecoderInfo *pi);
 OSDecoderNode *OS_GetFirstOSDecoder(const char *pname);
 int getDecoderfromlist(const char *name);
+char *GetGeoInfobyIP(char *ip_addr);
 int SetDecodeXML(void);
 void HostinfoInit(void);
 void SyscheckInit(void);

--- a/src/analysisd/decoders/geoip.c
+++ b/src/analysisd/decoders/geoip.c
@@ -13,6 +13,9 @@
 
 /* GeoIP - Every IP address will have its geolocation added to it */
 
+#ifdef LIBGEOIP_ENABLED
+
+
 #include "config.h"
 #include "os_regex/os_regex.h"
 #include "eventinfo.h"
@@ -81,3 +84,6 @@ char *GetGeoInfobyIP(char *ip_addr)
     return(geodata);
  
 }
+
+#endif
+

--- a/src/analysisd/decoders/geoip.c
+++ b/src/analysisd/decoders/geoip.c
@@ -1,0 +1,83 @@
+/* @(#) $Id: ./src/analysisd/decoders/geoip.c, 2014/03/08 dcid Exp $
+ */
+
+/* Copyright (C) 2014 Daniel Cid
+ * All right reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+
+/* GeoIP - Every IP address will have its geolocation added to it */
+
+#include "config.h"
+#include "os_regex/os_regex.h"
+#include "eventinfo.h"
+#include "alerts/alerts.h"
+#include "decoder.h"
+#include "GeoIP.h"
+#include "GeoIPCity.h"
+
+
+char *GetGeoInfobyIP(char *ip_addr)
+{
+    GeoIPRecord *geoiprecord;
+    char *geodata = NULL;
+    char geobuffer[256 +1];
+
+    if(!geoipdb)
+    {
+        return(NULL);
+    }
+
+    if(!ip_addr)
+    {
+        return(NULL);
+    }
+
+    geoiprecord = GeoIP_record_by_name(geoipdb, (const char *)ip_addr);
+    if(geoiprecord == NULL)
+    {
+        return(NULL);
+    }
+    
+    if(geoiprecord->country_code == NULL || geoiprecord->country_code == NULL)
+    {
+        GeoIPRecord_delete(geoiprecord);
+        return(NULL);
+    }
+
+    if(geoiprecord->country_code[0] == NULL || strlen(geoiprecord->country_code) < 2)
+    {
+        GeoIPRecord_delete(geoiprecord);
+        return(NULL);
+    }
+   
+
+    if(geoiprecord->region != NULL && geoiprecord->region[0] != NULL)
+    {
+        char *regionname = NULL;
+        regionname = GeoIP_region_name_by_code(geoiprecord->country_code, geoiprecord->region);
+        if(regionname != NULL)
+        {
+            snprintf(geobuffer, 255, "%s / %s", geoiprecord->country_code, regionname);
+            geobuffer[255] = '\0';
+            geodata = strdup(geobuffer);
+        }
+        else
+        {
+            geodata = strdup(geoiprecord->country_code);
+        }
+    }
+    else
+    {
+        geodata = strdup(geoiprecord->country_code);
+    }
+
+    GeoIPRecord_delete(geoiprecord);
+    return(geodata);
+ 
+}

--- a/src/analysisd/decoders/plugins/ossecalert_decoder.c
+++ b/src/analysisd/decoders/plugins/ossecalert_decoder.c
@@ -160,12 +160,10 @@ void *OSSECAlert_Decoder_Exec(Eventinfo *lf)
         if(strncmp(oa_val, "srcip: ", 7) == 0)
         {
             os_strdup(oa_val + 7, lf->srcip);
-            #ifdef GEOIP
             if(!lf->srcgeoip && lf->srcip)
             {
                 lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
             }
-            #endif
         }
         if(strncmp(oa_val, "user: ", 6) == 0)
         {

--- a/src/analysisd/decoders/plugins/ossecalert_decoder.c
+++ b/src/analysisd/decoders/plugins/ossecalert_decoder.c
@@ -160,10 +160,6 @@ void *OSSECAlert_Decoder_Exec(Eventinfo *lf)
         if(strncmp(oa_val, "srcip: ", 7) == 0)
         {
             os_strdup(oa_val + 7, lf->srcip);
-            if(!lf->srcgeoip && lf->srcip)
-            {
-                lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
-            }
         }
         if(strncmp(oa_val, "user: ", 6) == 0)
         {

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -439,7 +439,9 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->location = NULL;
 
     lf->srcip = NULL;
+    lf->srcgeoip = NULL;
     lf->dstip = NULL;
+    lf->dstgeoip = NULL;
     lf->srcport = NULL;
     lf->dstport = NULL;
     lf->protocol = NULL;
@@ -500,9 +502,21 @@ void Free_Eventinfo(Eventinfo *lf)
     if (lf->srcip) {
         free(lf->srcip);
     }
+
+    if(lf->srcgeoip) {
+        free(lf->srcgeoip);
+        lf->srcgeoip = NULL;
+    }
+
     if (lf->dstip) {
         free(lf->dstip);
     }
+
+    if(lf->dstgeoip) {
+        free(lf->dstgeoip);
+        lf->dstgeoip = NULL;
+    }
+
     if (lf->srcport) {
         free(lf->srcport);
     }

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -24,7 +24,9 @@ typedef struct _Eventinfo {
 
     /* Extracted from the decoders */
     char *srcip;
+    char *srcgeoip;
     char *dstip;
+    char *dstgeoip;
     char *srcport;
     char *dstport;
     char *protocol;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -47,6 +47,9 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->srcip) {
         cJSON_AddStringToObject(root, "srcip", lf->srcip);
     }
+    if (lf->srcgeoip) {
+        cJSON_AddStringToObject(root, "srcgeoip", lf->srcgeoip);
+    }
     if (lf->srcport) {
         cJSON_AddStringToObject(root, "srcport", lf->srcport);
     }
@@ -55,6 +58,9 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     }
     if (lf->dstip) {
         cJSON_AddStringToObject(root, "dstip", lf->dstip);
+    }
+    if (lf->dstgeoip) {
+        cJSON_AddStringToObject(root, "dstip", lf->dstgeoip);
     }
     if (lf->dstport) {
         cJSON_AddStringToObject(root, "dstport", lf->dstport);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -67,8 +67,10 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_check_if_ignored = "check_if_ignored";
 
     const char *xml_srcip = "srcip";
+    const char *xml_srcgeoip = "srcgeoip";
     const char *xml_srcport = "srcport";
     const char *xml_dstip = "dstip";
+    const char *xml_dstgeoip = "dstgeoip";
     const char *xml_dstport = "dstport";
     const char *xml_user = "user";
     const char *xml_url = "url";
@@ -109,6 +111,8 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_dodiff = "check_diff";
 
     const char *xml_different_url = "different_url";
+    const char *xml_different_srcip = "different_srcip";
+    const char *xml_different_geoip = "different_geoip";
 
     const char *xml_notsame_source_ip = "not_same_source_ip";
     const char *xml_notsame_user = "not_same_user";
@@ -315,6 +319,9 @@ int Rules_OP_ReadRules(const char *rulefile)
                 char *id = NULL;
                 char *srcport = NULL;
                 char *dstport = NULL;
+                char *srcgeoip = NULL;
+                char *dstgeoip = NULL;
+
                 char *status = NULL;
                 char *hostname = NULL;
                 char *extra_data = NULL;
@@ -508,6 +515,20 @@ int Rules_OP_ReadRules(const char *rulefile)
                         if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                         }
+                    } else if(strcasecmp(rule_opt[k]->element,xml_srcgeoip)==0) {
+                        srcgeoip =
+                            loadmemory(srcgeoip,
+                                    rule_opt[k]->content);
+
+                        if(!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
+                            config_ruleinfo->alert_opts |= DO_EXTRAINFO;
+                    } else if(strcasecmp(rule_opt[k]->element,xml_dstgeoip)==0) {
+                        dstgeoip =
+                            loadmemory(dstgeoip,
+                                    rule_opt[k]->content);
+
+                        if(!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
+                            config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                     } else if (strcasecmp(rule_opt[k]->element, xml_id) == 0) {
                         id =
                             loadmemory(id,
@@ -797,6 +818,18 @@ int Rules_OP_ReadRules(const char *rulefile)
                         if (!(config_ruleinfo->alert_opts & SAME_EXTRAINFO)) {
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                         }
+                    } else if(strcmp(rule_opt[k]->element,
+                                   xml_different_srcip) == 0) {
+                        config_ruleinfo->context_opts|= DIFFERENT_SRCIP;
+
+                        if(!(config_ruleinfo->alert_opts & SAME_EXTRAINFO))
+                            config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
+                    } else if(strcmp(rule_opt[k]->element,
+                                   xml_different_geoip) == 0) {
+                        config_ruleinfo->context_opts|= DIFFERENT_GEOIP;
+
+                        if(!(config_ruleinfo->alert_opts & SAME_EXTRAINFO))
+                            config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     } else if (strcmp(rule_opt[k]->element, xml_notsame_id) == 0) {
                         config_ruleinfo->context_opts &= NOT_SAME_ID;
                     } else if (strcasecmp(rule_opt[k]->element,
@@ -1075,6 +1108,32 @@ int Rules_OP_ReadRules(const char *rulefile)
                     free(user);
                     user = NULL;
                 }
+
+                /* Adding in srcgeoip */
+                if(srcgeoip) {
+                    os_calloc(1, sizeof(OSMatch), config_ruleinfo->srcgeoip);
+                    if(!OSMatch_Compile(srcgeoip, config_ruleinfo->srcgeoip, 0)) {
+                        merror(REGEX_COMPILE, ARGV0, srcgeoip,
+                                              config_ruleinfo->srcgeoip->error);
+                        return(-1);
+                    }
+                    free(srcgeoip);
+                    srcgeoip = NULL;
+                }
+
+
+                /* Adding in dstgeoip */
+                if(dstgeoip) {
+                    os_calloc(1, sizeof(OSMatch), config_ruleinfo->dstgeoip);
+                    if(!OSMatch_Compile(dstgeoip, config_ruleinfo->dstgeoip, 0)) {
+                        merror(REGEX_COMPILE, ARGV0, dstgeoip,
+                                              config_ruleinfo->dstgeoip->error);
+                        return(-1);
+                    }
+                    free(dstgeoip);
+                    dstgeoip = NULL;
+                }
+
 
                 /* Add in URL */
                 if (url) {

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -24,6 +24,8 @@
 #define SAME_ID         0x004 /* 4   */
 #define SAME_LOCATION   0x008 /* 8   */
 #define DIFFERENT_URL   0x010 /* */
+#define DIFFERENT_SRCIP 0x200 
+#define DIFFERENT_GEOIP 0x400 
 #define SAME_SRCPORT    0x020
 #define SAME_DSTPORT    0x040
 #define SAME_DODIFF     0x100
@@ -130,6 +132,8 @@ typedef struct _RuleInfo {
 
     os_ip **srcip;
     os_ip **dstip;
+    OSMatch *srcgeoip;
+    OSMatch *dstgeoip;
     OSMatch *srcport;
     OSMatch *dstport;
     OSMatch *user;

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -103,6 +103,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
     const char *xml_prelude = "prelude_output";
     const char *xml_prelude_profile = "prelude_profile";
     const char *xml_prelude_log_level = "prelude_log_level";
+    const char *xml_geoipdb_file = "geoipdb";
     const char *xml_zeromq_output = "zeromq_output";
     const char *xml_zeromq_output_uri = "zeromq_uri";
     const char *xml_jsonout_output = "jsonout_output";
@@ -229,6 +230,12 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
             } else {
                 merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
                 return (OS_INVALID);
+            }
+        /* GeoIP */
+        } else if(strcmp(node[i]->element, xml_geoipdb_file) == 0) {
+            if(Config)
+            {
+                Config->geoipdb_file = strdup(node[i]->content);
             }
         } else if (strcmp(node[i]->element, xml_prelude_profile) == 0) {
             if (Config) {

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -32,6 +32,9 @@ typedef struct __Config {
     /* prelude profile name */
     char *prelude_profile;
 
+    /* GeoIP DB */
+    char *geoipdb_file;
+
     /* ZEROMQ Export */
     u_int8_t zeromq_output;
     char *zeromq_output_uri;

--- a/src/headers/read-alert.h
+++ b/src/headers/read-alert.h
@@ -35,10 +35,8 @@ typedef struct _alert_data {
     char *old_sha1;
     char *new_sha1;
     char **log;
-#ifdef LIBGEOIP_ENABLED
     char *srcgeoip;
     char *dstgeoip;
-#endif
 } alert_data;
 
 alert_data *GetAlertData(int flag, FILE *fp) __attribute__((nonnull));

--- a/src/headers/read-alert.h
+++ b/src/headers/read-alert.h
@@ -36,8 +36,8 @@ typedef struct _alert_data {
     char *new_sha1;
     char **log;
 #ifdef LIBGEOIP_ENABLED
-    char *geoipdatasrc;
-    char *geoipdatadst;
+    char *srcgeoip;
+    char *dstgeoip;
 #endif
 } alert_data;
 

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -20,6 +20,8 @@
 #define SAME_ID         0x004 /* 4   */
 #define SAME_LOCATION   0x008 /* 8   */
 #define DIFFERENT_URL   0x010
+#define DIFFERENT_SRCIP 0x200
+#define DIFFERENT_GEOIP 0x400 
 #define SAME_SRCPORT    0x020
 #define SAME_DSTPORT    0x040
 #define SAME_DODIFF     0x100

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -104,8 +104,8 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         field_add_string(syslog_msg, OS_SIZE_2048, " classification: %s;", al_data->group );
         field_add_string(syslog_msg, OS_SIZE_2048, " srcip: %s;", al_data->srcip );
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " srccity: %s;", al_data->geoipdatasrc );
-        field_add_string(syslog_msg, OS_SIZE_2048, " dstcity: %s;", al_data->geoipdatadst );
+        field_add_string(syslog_msg, OS_SIZE_2048, " srccity: %s;", al_data->srcgeoip );
+        field_add_string(syslog_msg, OS_SIZE_2048, " dstcity: %s;", al_data->dstgeoip );
 #endif
         field_add_string(syslog_msg, OS_SIZE_2048, " dstip: %s;", al_data->dstip );
         field_add_string(syslog_msg, OS_SIZE_2048, " user: %s;", al_data->user );
@@ -136,8 +136,8 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         field_add_string(syslog_msg, OS_SIZE_2048, " suser=%s", al_data->user );
         field_add_string(syslog_msg, OS_SIZE_2048, " dst=%s", al_data->dstip );
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs3Label=SrcCity cs3=%s", al_data->geoipdatasrc );
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=DstCity cs4=%s", al_data->geoipdatadst );
+        field_add_string(syslog_msg, OS_SIZE_2048, " cs3Label=SrcCity cs3=%s", al_data->srcgeoip );
+        field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=DstCity cs4=%s", al_data->dstgeoip );
 #endif
         field_add_string(syslog_msg, OS_SIZE_2048, " suser=%s", al_data->user );
         field_add_string(syslog_msg, OS_SIZE_2048, " dst=%s", al_data->dstip );
@@ -205,11 +205,11 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
             cJSON_AddStringToObject(root,   "sha1_new",   al_data->new_sha1);
         }
 #ifdef LIBGEOIP_ENABLED
-        if (al_data->geoipdatasrc) {
-            cJSON_AddStringToObject(root, "src_city", al_data->geoipdatasrc);
+        if (al_data->srcgeoip) {
+            cJSON_AddStringToObject(root, "src_city", al_data->srcgeoip);
         }
-        if (al_data->geoipdatadst) {
-            cJSON_AddStringToObject(root, "dst_city", al_data->geoipdatadst);
+        if (al_data->dstgeoip) {
+            cJSON_AddStringToObject(root, "dst_city", al_data->dstgeoip);
         }
 #endif
 
@@ -249,8 +249,8 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         }
 
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " src_city=\"%s\",", al_data->geoipdatasrc );
-        field_add_string(syslog_msg, OS_SIZE_2048, " dst_city=\"%s\",", al_data->geoipdatadst );
+        field_add_string(syslog_msg, OS_SIZE_2048, " src_city=\"%s\",", al_data->srcgeoip );
+        field_add_string(syslog_msg, OS_SIZE_2048, " dst_city=\"%s\",", al_data->dstgeoip );
 #endif
 
         if ( field_add_string(syslog_msg, OS_SIZE_2048, " dst_ip=\"%s\",", al_data->dstip ) > 0 ) {

--- a/src/os_dbd/alert.c
+++ b/src/os_dbd/alert.c
@@ -88,7 +88,7 @@ static int __DBInsertLocation(const char *location, const DBConfig *db_config)
 int OS_Alert_InsertDB(const alert_data *al_data, DBConfig *db_config)
 {
     int i;
-    unsigned int location_id = 0;
+    unsigned int s_ip = 0, d_ip = 0, location_id = 0;
     unsigned short s_port = 0, d_port = 0;
     int *loc_id;
     char sql_query[OS_SIZE_8192 + 1];
@@ -97,6 +97,26 @@ int OS_Alert_InsertDB(const alert_data *al_data, DBConfig *db_config)
     /* Clear the memory before insert */
     sql_query[0] = '\0';
     sql_query[OS_SIZE_8192] = '\0';
+
+    /* Converting srcip to int */
+    if(al_data->srcip) {
+        struct in_addr net;
+
+        /* Extracting ip address */
+        if(inet_aton(al_data->srcip, &net)) {
+            s_ip = net.s_addr;
+        }
+    }
+
+    /* Converting dstip to int */
+    if(al_data->dstip) {
+        struct in_addr net;
+
+        /* Extracting ip address */
+        if(inet_aton(al_data->dstip, &net)) {
+            d_ip = net.s_addr;
+        }
+    }
 
 
     /* Source Port */
@@ -163,12 +183,12 @@ int OS_Alert_InsertDB(const alert_data *al_data, DBConfig *db_config)
         snprintf(sql_query, OS_SIZE_8192,
                  "INSERT INTO "
                  "alert(server_id,rule_id,level,timestamp,location_id,src_ip,src_port,dst_ip,dst_port,alertid,user,full_log,tld) "
-                 "VALUES ('%u', '%u','%u','%u', '%u', '%s', '%u', '%s', '%u', '%s', '%s', '%s','%.2s')",
+                 "VALUES ('%u', '%u','%u','%u', '%u', '%lu', '%u', '%lu', '%u', '%s', '%s', '%s','%.2s')",
                  db_config->server_id, al_data->rule,
                  al_data->level,
                  (unsigned int)time(0), *loc_id,
-                 al_data->srcip, (unsigned short)s_port,
-                 al_data->dstip, (unsigned short)d_port,
+                 (unsigned long)ntohl(s_ip), (unsigned short)s_port,
+                 (unsigned long)ntohl(d_ip), (unsigned short)d_port,
                  al_data->alertid,
                  al_data->user, fulllog, al_data->srcgeoip);
 	break;

--- a/src/os_dbd/alert.c
+++ b/src/os_dbd/alert.c
@@ -162,15 +162,15 @@ int OS_Alert_InsertDB(const alert_data *al_data, DBConfig *db_config)
       case MYSQLDB:
         snprintf(sql_query, OS_SIZE_8192,
                  "INSERT INTO "
-                 "alert(server_id,rule_id,level,timestamp,location_id,src_ip,src_port,dst_ip,dst_port,alertid,user,full_log) "
-                 "VALUES ('%u', '%u','%u','%u', '%u', '%s', '%u', '%s', '%u', '%s', '%s', '%s')",
+                 "alert(server_id,rule_id,level,timestamp,location_id,src_ip,src_port,dst_ip,dst_port,alertid,user,full_log,tld) "
+                 "VALUES ('%u', '%u','%u','%u', '%u', '%s', '%u', '%s', '%u', '%s', '%s', '%s','%.2s')",
                  db_config->server_id, al_data->rule,
                  al_data->level,
                  (unsigned int)time(0), *loc_id,
                  al_data->srcip, (unsigned short)s_port,
                  al_data->dstip, (unsigned short)d_port,
                  al_data->alertid,
-                 al_data->user, fulllog);
+                 al_data->user, fulllog, al_data->srcgeoip);
 	break;
 
       case POSTGDB:

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -163,13 +163,13 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p,
 #ifdef LIBGEOIP_ENABLED
     /* Get GeoIP information */
     if (Mail->geoip) {
-        if (al_data->geoipdatasrc) {
-            snprintf(geoip_msg_src, OS_SIZE_1024, "Src Location: %s\r\n", al_data->geoipdatasrc);
+        if (al_data->srcgeoip) {
+            snprintf(geoip_msg_src, OS_SIZE_1024, "Src Location: %s\r\n", al_data->srcgeoip);
         } else {
             geoip_msg_src[0] = '\0';
         }
-        if (al_data->geoipdatadst) {
-            snprintf(geoip_msg_dst, OS_SIZE_1024, "Dst Location: %s\r\n", al_data->geoipdatadst);
+        if (al_data->dstgeoip) {
+            snprintf(geoip_msg_dst, OS_SIZE_1024, "Dst Location: %s\r\n", al_data->dstgeoip);
         } else {
             geoip_msg_dst[0] = '\0';
         }

--- a/src/shared/read-alert.c
+++ b/src/shared/read-alert.c
@@ -116,13 +116,13 @@ void FreeAlertData(alert_data *al_data)
         al_data->log = NULL;
     }
 #ifdef LIBGEOIP_ENABLED
-    if (al_data->geoipdatasrc) {
-        free(al_data->geoipdatasrc);
-        al_data->geoipdatasrc = NULL;
+    if (al_data->srcgeoip) {
+        free(al_data->srcgeoip);
+        al_data->srcgeoip = NULL;
     }
-    if (al_data->geoipdatadst) {
-        free(al_data->geoipdatadst);
-        al_data->geoipdatadst = NULL;
+    if (al_data->dstgeoip) {
+        free(al_data->dstgeoip);
+        al_data->dstgeoip = NULL;
     }
 #endif
     free(al_data);
@@ -151,8 +151,8 @@ alert_data *GetAlertData(int flag, FILE *fp)
     char *new_sha1 = NULL;
     char **log = NULL;
 #ifdef LIBGEOIP_ENABLED
-    char *geoipdatasrc = NULL;
-    char *geoipdatadst = NULL;
+    char *srcgeoip = NULL;
+    char *dstgeoip = NULL;
 #endif
     int level = 0, rule = 0, srcport = 0, dstport = 0;
 
@@ -181,8 +181,8 @@ alert_data *GetAlertData(int flag, FILE *fp)
                 al_data->date = date;
                 al_data->filename = filename;
 #ifdef LIBGEOIP_ENABLED
-                al_data->geoipdatasrc = geoipdatasrc;
-                al_data->geoipdatadst = geoipdatadst;
+                al_data->srcgeoip  = srcgeoip ;
+                al_data->dstgeoip = dstgeoip;
 #endif
                 al_data->old_md5 = old_md5;
                 al_data->new_md5 = new_md5;
@@ -333,8 +333,8 @@ alert_data *GetAlertData(int flag, FILE *fp)
             else if (strncmp(GEOIP_BEGIN_SRC, str, GEOIP_BEGIN_SRC_SZ) == 0) {
                 os_clearnl(str, p);
                 p = str + GEOIP_BEGIN_SRC_SZ;
-                free(geoipdatasrc);
-                os_strdup(p, geoipdatasrc);
+                free(srcgeoip);
+                os_strdup(p, srcgeoip);
             }
 #endif
             /* srcport */
@@ -357,8 +357,8 @@ alert_data *GetAlertData(int flag, FILE *fp)
             else if (strncmp(GEOIP_BEGIN_DST, str, GEOIP_BEGIN_DST_SZ) == 0) {
                 os_clearnl(str, p);
                 p = str + GEOIP_BEGIN_DST_SZ;
-                free(geoipdatadst);
-                os_strdup(p, geoipdatadst);
+                free(dstgeoip);
+                os_strdup(p, dstgeoip);
             }
 #endif
             /* dstport */
@@ -450,13 +450,13 @@ l_error:
             srcip = NULL;
         }
 #ifdef LIBGEOIP_ENABLED
-        if (geoipdatasrc) {
-            free(geoipdatasrc);
-            geoipdatasrc = NULL;
+        if (srcgeoip) {
+            free(srcgeoip);
+            srcgeoip = NULL;
         }
-        if (geoipdatadst) {
-            free(geoipdatadst);
-            geoipdatadst = NULL;
+        if (dstgeoip) {
+            free(dstgeoip);
+            dstgeoip = NULL;
         }
 #endif
         if (user) {
@@ -535,8 +535,8 @@ l_error:
     free(new_sha1);
     free(filename);
 #ifdef LIBGEOIP_ENABLED
-    free(geoipdatasrc);
-    free(geoipdatadst);
+    free(srcgeoip);
+    free(dstgeoip);
 #endif
 
     /* We need to clean end of file before returning */


### PR DESCRIPTION
Signed-off-by: Scott R. Shinn <scott@atomicorp.com>

This is a re-visit of dcids GeoIP patch, it adds the Geo Location of the IP address to the Alert and JSON output. It requires the GeoIP-devel package to build, and the GeoLiteCity.dat (included in GeoIP-GeoLite-data-extra package, or can be manually downloaded).

<global>
   <geoipdb>/usr/share/GeoIP/GeoLiteCity.dat</geoipdb>
</global>