### PR TITLE
Problem: we would like to use czmq v3 + encryption and curve authentication

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -257,7 +257,11 @@ int main_analysisd(int argc, char **argv)
 #ifdef ZEROMQ_OUTPUT_ENABLED
     /* Start zeromq */
     if (Config.zeromq_output) {
+#if CZMQ_VERSION_MAJOR == 2 
         zeromq_output_start(Config.zeromq_output_uri);
+#elif CZMQ_VERSION_MAJOR >= 3
+        zeromq_output_start(Config.zeromq_output_uri, Config.zeromq_output_client_cert, Config.zeromq_output_server_cert);
+#endif
     }
 #endif
 

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -32,6 +32,8 @@ int GlobalConf(const char *cfgfile)
     Config.prelude = 0;
     Config.zeromq_output = 0;
     Config.zeromq_output_uri = NULL;
+	Config.zeromq_output_server_cert = NULL;
+	Config.zeromq_output_client_cert = NULL;
     Config.jsonout_output = 0;
     Config.memorysize = 1024;
     Config.mailnotify = -1;

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -32,8 +32,8 @@ int GlobalConf(const char *cfgfile)
     Config.prelude = 0;
     Config.zeromq_output = 0;
     Config.zeromq_output_uri = NULL;
-	Config.zeromq_output_server_cert = NULL;
-	Config.zeromq_output_client_cert = NULL;
+    Config.zeromq_output_server_cert = NULL;
+    Config.zeromq_output_client_cert = NULL;
     Config.jsonout_output = 0;
     Config.memorysize = 1024;
     Config.mailnotify = -1;

--- a/src/analysisd/output/zeromq.c
+++ b/src/analysisd/output/zeromq.c
@@ -13,7 +13,6 @@
 
 #include "shared.h"
 #include "rules.h"
-#include "czmq.h"
 #include "format/to_json.h"
 
 

--- a/src/analysisd/output/zeromq.c
+++ b/src/analysisd/output/zeromq.c
@@ -18,10 +18,15 @@
 
 
 /* Global variables */
+#if CZMQ_VERSION_MAJOR == 2
 static zctx_t *zeromq_context;
 static void *zeromq_pubsocket;
+#elif CZMQ_VERSION_MAJOR >= 3
+zsock_t *zeromq_pubsocket;
+zactor_t *auth;
+#endif
 
-
+#if CZMQ_VERSION_MAJOR == 2
 void zeromq_output_start(const char *uri)
 {
     int rc;
@@ -47,13 +52,64 @@ void zeromq_output_start(const char *uri)
         return;
     }
 }
+#elif CZMQ_VERSION_MAJOR >= 3
+void zeromq_output_start(const char *uri, const char *client_cert_path, const char *server_cert_path)
+{
+    int rc;
 
+    debug1("%s: DEBUG: New ZeroMQ Socket: ZMQ_PUB", ARGV0);
+    zeromq_pubsocket = zsock_new(ZMQ_PUB);
+    if (zeromq_pubsocket == NULL) {
+        merror("%s: Unable to initialize ZeroMQ Socket", ARGV0);
+        return;
+    }
+
+    if (zsys_has_curve()) {
+        if (client_cert_path && server_cert_path) {
+            debug1("%s: DEBUG: Initiating CURVE for ZeroMQ Socket", ARGV0);
+            auth = zactor_new(zauth, NULL);
+            if (!auth) {
+                merror("%s: Unable to start auth for ZeroMQ Sock", ARGV0);
+            }
+            zstr_sendx(auth, "CURVE", client_cert_path, NULL);
+            zsock_wait(auth);
+
+            zcert_t *server_cert = zcert_load(server_cert_path);
+            if (!server_cert) {
+                merror("%s: Unable to load server certificate: %s.", ARGV0, server_cert_path);
+            }
+
+            zcert_apply(server_cert, zeromq_pubsocket);
+            zsock_set_curve_server(zeromq_pubsocket, 1);
+
+            zcert_destroy(&server_cert);
+        }
+    }
+
+    debug1("%s: DEBUG: Listening on ZeroMQ Socket: %s", ARGV0, uri);
+    rc = zsock_bind(zeromq_pubsocket, "%s", uri);
+    if (rc) {
+        merror("%s: Unable to bind the ZeroMQ Socket: %s.", ARGV0, uri);
+        return;
+    }
+}
+#endif
+
+#if CZMQ_VERSION_MAJOR == 2
 void zeromq_output_end()
 {
     zsocket_destroy(zeromq_context, zeromq_pubsocket);
     zctx_destroy(&zeromq_context);
 }
+#elif CZMQ_VERSION_MAJOR >= 3
+void zeromq_output_end()
+{
+    zsock_destroy(&zeromq_pubsocket);
+    zactor_destroy(&auth);
+}
+#endif
 
+#if CZMQ_VERSION_MAJOR == 2
 void zeromq_output_event(const Eventinfo *lf)
 {
     char *json_alert = Eventinfo_to_jsonstr(lf);
@@ -64,6 +120,17 @@ void zeromq_output_event(const Eventinfo *lf)
     zmsg_send(&msg, zeromq_pubsocket);
     free(json_alert);
 }
+#elif ZMQ_VERSION_MAJOR >= 3
+void zeromq_output_event(const Eventinfo *lf)
+{
+    char *json_alert = Eventinfo_to_jsonstr(lf);
 
+    zmsg_t *msg = zmsg_new();
+    zmsg_addstr(msg, "ossec.alerts");
+    zmsg_addstr(msg, json_alert);
+    zmsg_send(&msg, zeromq_pubsocket);
+    free(json_alert);
+}
 #endif
 
+#endif

--- a/src/analysisd/output/zeromq.h
+++ b/src/analysisd/output/zeromq.h
@@ -13,11 +13,12 @@
 #define _ZEROMQ_H_
 
 #include "eventinfo.h"
+#include <czmq.h>
 
 void zeromq_output_event(const Eventinfo *lf);
 #if CZMQ_VERSION_MAJOR == 2
 void zeromq_output_start(const char *uri);
-#elif CZMQ_VERSION_MAJOR == 3
+#elif CZMQ_VERSION_MAJOR >= 3
 void zeromq_output_start(const char *uri, const char *client_cert_path, const char *server_cert_path);
 #endif
 void zeromq_output_end(void);

--- a/src/analysisd/output/zeromq.h
+++ b/src/analysisd/output/zeromq.h
@@ -15,7 +15,11 @@
 #include "eventinfo.h"
 
 void zeromq_output_event(const Eventinfo *lf);
+#if CZMQ_VERSION_MAJOR == 2
 void zeromq_output_start(const char *uri);
+#elif CZMQ_VERSION_MAJOR == 3
+void zeromq_output_start(const char *uri, const char *client_cert_path, const char *server_cert_path);
+#endif
 void zeromq_output_end(void);
 
 

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -105,6 +105,8 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
     const char *xml_prelude_log_level = "prelude_log_level";
     const char *xml_zeromq_output = "zeromq_output";
     const char *xml_zeromq_output_uri = "zeromq_uri";
+    const char *xml_zeromq_output_server_cert = "zeromq_server_cert";
+    const char *xml_zeromq_output_client_cert = "zeromq_client_cert";
     const char *xml_jsonout_output = "jsonout_output";
     const char *xml_stats = "stats";
     const char *xml_memorysize = "memory_size";
@@ -261,6 +263,14 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
         } else if (strcmp(node[i]->element, xml_zeromq_output_uri) == 0) {
             if (Config) {
                 Config->zeromq_output_uri = strdup(node[i]->content);
+            }
+        } else if (strcmp(node[i]->element, xml_zeromq_output_server_cert) == 0) {
+            if (Config) {
+                Config->zeromq_output_server_cert = strdup(node[i]->content);
+            }
+        } else if (strcmp(node[i]->element, xml_zeromq_output_client_cert) == 0) {
+            if (Config) {
+                Config->zeromq_output_client_cert = strdup(node[i]->content);
             }
         }
         /* jsonout output */

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -35,6 +35,8 @@ typedef struct __Config {
     /* ZEROMQ Export */
     u_int8_t zeromq_output;
     char *zeromq_output_uri;
+    char *zeromq_output_server_cert;
+    char *zeromq_output_client_cert;
 
     /* JSONOUT Export */
     u_int8_t jsonout_output;


### PR DESCRIPTION
Solution: add support for CZMQ v3.  This helps move ossec off of deprecated CZMQ v2 APIs but maintains support for building against CZMQ v2. Additionally, if cert  paths are defined in the config then the publish socket will be configured as a CURVE server - and will use certificate authentication for clients + encrypt all traffic.

These changes will work with the upcoming improved ZeroMQ support in [rsyslog 8.19](https://github.com/rsyslog/rsyslog/pull/1032) - allowing the ossec analyzer to send encrypted messages over zeromq directly to rsyslog.