### PR TITLE
Fixed bug at logcollector that inhibited alerts about file reduction

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -481,10 +481,6 @@ void LogCollectorStart()
                     debug1("%s: DEBUG: File size reduced. %s",
                            ARGV0, logff[i].file);
 
-
-                    /* Fix size so we don't alert more than once */
-                    logff[i].size = tmp_stat.st_size;
-
                     /* Get new file */
                     fclose(logff[i].fp);
 
@@ -544,6 +540,13 @@ void LogCollectorStart()
                     continue;
                 }
             }
+
+            /* Update file size */
+#ifdef WIN32
+            logff[i].size = lpFileInformation.nFileSizeHigh + lpFileInformation.nFileSizeLow;
+#else
+            logff[i].size = tmp_stat.st_size;
+#endif
         }
     }
 }

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -46,13 +46,14 @@ void LogCollectorStart()
     time_t curr_time = 0;
     char keepalive[1024];
 
-    /* To check for inode changes */
-    struct stat tmp_stat;
 
 #ifndef WIN32
     int int_error = 0;
     struct timeval fp_timeout;
+    /* To check for inode changes */
+    struct stat tmp_stat;
 #else
+    BY_HANDLE_FILE_INFORMATION lpFileInformation;
 
     /* Check if we are on Windows Vista */
     checkVista();
@@ -412,7 +413,6 @@ void LogCollectorStart()
 			merror("Closing the temporary file %s did not work (%d): %s", logff[i].file, errno, strerror(errno));
 		}
 #else
-                BY_HANDLE_FILE_INFORMATION lpFileInformation;
                 HANDLE h1;
 
                 h1 = CreateFile(logff[i].file, GENERIC_READ,


### PR DESCRIPTION
When OSSEC detects that a file size has been reduced, it updates this size into a local variable, but else it doesn't update it, so Logcollector is able to detect once that the current size of the file is lower than when the file was opened.

This fix makes logcollector update the chached size at each verification, allowing it to be more accurate comparing sizes and to alert if the file was shrunk.