### PR TITLE
- Format string security fix

### DIFF
--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -174,7 +174,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     snprintf(snd_msg, 127, TO, to[0]);
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
     } else {
         OS_SendTCP(socket, snd_msg);
     }
@@ -183,7 +183,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     snprintf(snd_msg, 127, FROM, from);
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
     } else {
         OS_SendTCP(socket, snd_msg);
     }
@@ -206,7 +206,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
             snprintf(snd_msg, 127, TO, to[i]);
 
             if (sendmail) {
-                fprintf(sendmail, snd_msg);
+                fprintf(sendmail, "%s", snd_msg);
             } else {
                 OS_SendTCP(socket, snd_msg);
             }
@@ -226,7 +226,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
 #endif
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
     } else {
         OS_SendTCP(socket, snd_msg);
     }
@@ -237,7 +237,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
         snprintf(snd_msg, 127, XHEADER, idsname);
 
         if (sendmail) {
-            fprintf(sendmail, snd_msg);
+            fprintf(sendmail, "%s", snd_msg);
         } else {
             OS_SendTCP(socket, snd_msg);
         }
@@ -248,7 +248,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     snprintf(snd_msg, 127, SUBJECT, subject);
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
         fprintf(sendmail, ENDHEADER);
     } else {
         OS_SendTCP(socket, snd_msg);
@@ -259,7 +259,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     fseek(fp, 0, SEEK_SET);
     while (fgets(buffer, 2048, fp) != NULL) {
         if (sendmail) {
-            fprintf(sendmail, buffer);
+            fprintf(sendmail, "%s", buffer);
         } else {
             OS_SendTCP(socket, buffer);
         }

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -200,7 +200,7 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg)
     snprintf(snd_msg, 127, FROM, mail->from);
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
     } else {
         OS_SendTCP(socket, snd_msg);
     }
@@ -223,7 +223,7 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg)
 #endif
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
     } else {
         OS_SendTCP(socket, snd_msg);
     }
@@ -233,9 +233,9 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg)
     snprintf(snd_msg, 127, SUBJECT, sms_msg->subject);
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
         fprintf(sendmail, ENDHEADER);
-        fprintf(sendmail, sms_msg->body);
+        fprintf(sendmail, "%s", sms_msg->body);
 
         if (pclose(sendmail) == -1) {
             merror(WAITPID_ERROR, ARGV0, errno, strerror(errno));
@@ -456,7 +456,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     snprintf(snd_msg, 127, TO, mail->to[0]);
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
     } else {
         OS_SendTCP(socket, snd_msg);
     }
@@ -465,7 +465,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     snprintf(snd_msg, 127, FROM, mail->from);
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
     } else {
         OS_SendTCP(socket, snd_msg);
     }
@@ -475,7 +475,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         memset(snd_msg, '\0', 128);
         snprintf(snd_msg, 127, REPLYTO, mail->reply_to);
         if (sendmail) {
-            fprintf(sendmail, snd_msg);
+            fprintf(sendmail, "%s", snd_msg);
         } else {
             OS_SendTCP(socket, snd_msg);
         }
@@ -493,7 +493,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
             snprintf(snd_msg, 127, TO, mail->to[i]);
 
             if (sendmail) {
-                fprintf(sendmail, snd_msg);
+                fprintf(sendmail, "%s", snd_msg);
             } else {
                 OS_SendTCP(socket, snd_msg);
             }
@@ -515,7 +515,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
             snprintf(snd_msg, 127, TO, mail->gran_to[i]);
 
             if (sendmail) {
-                fprintf(sendmail, snd_msg);
+                fprintf(sendmail, "%s", snd_msg);
             } else {
                 OS_SendTCP(socket, snd_msg);
             }
@@ -536,7 +536,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
 #endif
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
     } else {
         OS_SendTCP(socket, snd_msg);
     }
@@ -547,7 +547,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         snprintf(snd_msg, 127, XHEADER, mail->idsname);
 
         if (sendmail) {
-            fprintf(sendmail, snd_msg);
+            fprintf(sendmail, "%s", snd_msg);
         } else {
             OS_SendTCP(socket, snd_msg);
         }
@@ -568,7 +568,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     }
 
     if (sendmail) {
-        fprintf(sendmail, snd_msg);
+        fprintf(sendmail, "%s", snd_msg);
         fprintf(sendmail, ENDHEADER);
     } else {
         OS_SendTCP(socket, snd_msg);
@@ -580,7 +580,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
     /* Send multiple emails together if we have to */
     do {
         if (sendmail) {
-            fprintf(sendmail, mailmsg->mail->body);
+            fprintf(sendmail, "%s", mailmsg->mail->body);
         } else {
             OS_SendTCP(socket, mailmsg->mail->body);
         }


### PR DESCRIPTION
Signed-off-by: Scott R. Shinn <scott@atomicorp.com>

Fix for these:
os_maild/sendcustomemail.c:262:31: error: format not a string literal and no format arguments [-Werror=format-security]

This could use some testing to ensure the sendmail functionality is still working correctly