### PR TITLE
Fixed memory error on CDB lists management

### DIFF
--- a/src/analysisd/lists_list.c
+++ b/src/analysisd/lists_list.c
@@ -151,7 +151,7 @@ static int OS_DBSearchKeyValue(ListRule *lrule, char *key)
         if (cdb_find(&lrule->db->cdb, key, strlen(key)) > 0 ) {
             vpos = cdb_datapos(&lrule->db->cdb);
             vlen = cdb_datalen(&lrule->db->cdb);
-            val = (char *) malloc(vlen);
+            val = (char *) calloc(vlen + 1, sizeof(char));
             cdb_read(&lrule->db->cdb, val, vlen, vpos);
             result = OSMatch_Execute(val, vlen, lrule->matcher);
             free(val);
@@ -294,4 +294,3 @@ int OS_DBSearch(ListRule *lrule, char *key)
             return 0;
     }
 }
-


### PR DESCRIPTION
When `cdb_read()` gets less bytes than `vlen`, there is no end-of-string and `OS_MatchExecute()` deals with uninitialized memory. Valgrind warns about this, and sometimes analysisd produces a segmentation fault when tries to match with a rule that references a CDB list with value checking.

This should fix this problem.