### PR TITLE
Let's not write a zero'ed local_decoder.xml. 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -476,7 +476,6 @@ endif
 	install -d -m 0750 -o ${OSSEC_USER_REM} -g ${OSSEC_GROUP} ${PREFIX}/queue/rids
 
 	install -m 0640 -o root -g ${OSSEC_GROUP} ../etc/decoder.xml ${PREFIX}/etc/
-	install -m 0640 -o root -g ${OSSEC_GROUP} /dev/null ${PREFIX}/etc/local_decoder.xml
 
 	rm -f ${PREFIX}/etc/shared/merged.mg
 


### PR DESCRIPTION
Overwriting what's there is bad.

Noticed during an upgrade to the latest 2.9 beta release.