### PR TITLE
Bugfix for agents failing to bind to a specific local IP address and the server is specified by hostname.

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -237,7 +237,7 @@ int OS_getsocketsize(int ossock)
 int OS_Connect(char *_port, unsigned int protocol, const char *_ip)
 {
     int ossock = 0, s;
-    struct addrinfo hints, *result, *rp, local_ai;
+    struct addrinfo hints, *result, *rp, *local_ai;
     char tempaddr[INET6_ADDRSTRLEN];
 
     if ((_ip == NULL)||(_ip[0] == '\0')) {
@@ -245,7 +245,6 @@ int OS_Connect(char *_port, unsigned int protocol, const char *_ip)
         return(OS_INVALID);
     }
 
-    memset(&local_ai, 0, sizeof(struct addrinfo));
     if (agt) {
         if (agt->lip) {
             memset(&hints, 0, sizeof(struct addrinfo));
@@ -255,14 +254,14 @@ int OS_Connect(char *_port, unsigned int protocol, const char *_ip)
                 verbose("getaddrinfo: %s", gai_strerror(s));
             }
             else {
-                memcpy(&local_ai, result, sizeof(struct addrinfo));
-                freeaddrinfo(result);
+                local_ai = result;
             }
         }
     }
 
     memset(&hints, 0, sizeof(struct addrinfo));
-    hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
+    /* Allow IPv4 or IPv6 if local_ip isn't specified */
+    hints.ai_family = agt->lip ? local_ai->ai_family : AF_UNSPEC;
     hints.ai_protocol = protocol;
     if (protocol == IPPROTO_TCP) {
         hints.ai_socktype = SOCK_STREAM;
@@ -292,7 +291,7 @@ int OS_Connect(char *_port, unsigned int protocol, const char *_ip)
 
         if (agt) {
             if (agt->lip) {
-                if (bind(ossock, local_ai.ai_addr, local_ai.ai_addrlen)) {
+                if (bind(ossock, local_ai->ai_addr, local_ai->ai_addrlen)) {
                     verbose("Unable to bind to local address %s.  Ignoring...",
                             agt->lip);
                 }


### PR DESCRIPTION
This fixes two problems when local_ip is specified on an agent and the server is a dual-stack system specified by hostname instead of IP address.

1.  Freeing the addrinfo of the specified local IP, even though it was copied to a separate structure, prevented a successful bind() to the local IP.  We'll just keep the local IP addrinfo instead of freeing it.

2.  If the local IP is specified, we may as well select the matching address family of the server to bypass unnecessary connection attempts that will fail anyway.