### PR TITLE
Fix different representation of permisions display.

### DIFF
--- a/contrib/debian-packages/ossec-hids/debian/patches/01_makefile.patch
+++ b/contrib/debian-packages/ossec-hids/debian/patches/01_makefile.patch
@@ -8,7 +8,7 @@ Index: ossec-hids-2.8.2/Makefile
 +# 06/15/2015
 +#
 +
-+DESTDIR=/
++DESTDIR?=/
 +DIR=$(DESTDIR)/var/ossec/
 +OSSEC_INIT=$(DIR)/etc/ossec-init.conf
 +
@@ -72,6 +72,6 @@ Index: ossec-hids-2.8.2/Makefile
 +	cp -p active-response/firewalls/*.sh $(DIR)/active-response/bin/
 +	cp -p src/init/ossec-hids-debian.init $(DIR)/etc/init.d/ossec
 +	echo "DIRECTORY=\"/var/ossec\"" > $(OSSEC_INIT)
-+	echo "VERSION=\"v2.8.2\"" >> $(OSSEC_INIT)
++	echo "VERSION=\"$(cat src/VERSION)" >> $(OSSEC_INIT)
 +	echo "DATE=\"`date`\"" >> $(OSSEC_INIT)
 +	echo "TYPE=\"server\"" >> $(OSSEC_INIT)

--- a/src/Makefile
+++ b/src/Makefile
@@ -294,7 +294,7 @@ endif # USE_OPENSSL
 
 ifneq (,$(filter ${USE_OPENSSL},yes y Y 1))
 	DEFINES+=-DLIBOPENSSL_ENABLED
-	ifneq (${OPENSSL_LIBS},)
+	ifeq (${OPENSSL_LIBS},)
 		OSSEC_LDFLAGS+=-lssl -lcrypto
 	else
 		OSSEC_LDFLAGS+=${OPENSSL_LIBS}

--- a/src/agentlessd/scripts/ssh_integrity_check_linux
+++ b/src/agentlessd/scripts/ssh_integrity_check_linux
@@ -25,7 +25,7 @@ source $sshsrc
 source $susrc
 
 set timeout 600
-send "echo \"INFO: Starting.\"; for i in `find $args 2>/dev/null`;do tail \$i >/dev/null 2>&1 && md5=`md5sum \$i | cut -d \" \" -f 1` && sha1=`sha1sum \$i | cut -d \" \" -f 1` && echo FWD: `stat --printf \"%s:%a:%u:%g\" \$i`:\$md5:\$sha1 \$i; done; exit\r"
+send "unset HISTFILE echo \"INFO: Starting.\"; for i in `find $args 2>/dev/null`;do tail \$i >/dev/null 2>&1 && md5=`md5sum \$i | cut -d \" \" -f 1` && sha1=`sha1sum \$i | cut -d \" \" -f 1` && echo FWD: `stat --printf \"%s:%a:%u:%g\" \$i`:\$md5:\$sha1 \$i; done; exit\r"
 send "exit\r"
 
 expect {

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -452,48 +452,14 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
             if (oldperm == newperm) {
                 sdb.perm[0] = '\0';
             } else if (oldperm > 0 && newperm > 0) {
+		char opstr[10];
+		char npstr[10];
+
+		strncpy(opstr, agent_file_perm(c_oldperm), sizeof(opstr));
+		strncpy(npstr, agent_file_perm(c_newperm), sizeof(npstr));
 
                 snprintf(sdb.perm, OS_FLSIZE, "Permissions changed from "
-                         "'%c%c%c%c%c%c%c%c%c' "
-                         "to '%c%c%c%c%c%c%c%c%c'\n",
-                         (oldperm & S_IRUSR) ? 'r' : '-',
-                         (oldperm & S_IWUSR) ? 'w' : '-',
-
-                         (oldperm & S_ISUID) ? 's' :
-                         (oldperm & S_IXUSR) ? 'x' : '-',
-
-                         (oldperm & S_IRGRP) ? 'r' : '-',
-                         (oldperm & S_IWGRP) ? 'w' : '-',
-
-                         (oldperm & S_ISGID) ? 's' :
-                         (oldperm & S_IXGRP) ? 'x' : '-',
-
-                         (oldperm & S_IROTH) ? 'r' : '-',
-                         (oldperm & S_IWOTH) ? 'w' : '-',
-
-                         (oldperm & S_ISVTX) ? 't' :
-                         (oldperm & S_IXOTH) ? 'x' : '-',
-
-
-
-                         (newperm & S_IRUSR) ? 'r' : '-',
-                         (newperm & S_IWUSR) ? 'w' : '-',
-
-                         (newperm & S_ISUID) ? 's' :
-                         (newperm & S_IXUSR) ? 'x' : '-',
-
-
-                         (newperm & S_IRGRP) ? 'r' : '-',
-                         (newperm & S_IWGRP) ? 'w' : '-',
-
-                         (newperm & S_ISGID) ? 's' :
-                         (newperm & S_IXGRP) ? 'x' : '-',
-
-                         (newperm & S_IROTH) ? 'r' : '-',
-                         (newperm & S_IWOTH) ? 'w' : '-',
-
-                         (newperm & S_ISVTX) ? 't' :
-                         (newperm & S_IXOTH) ? 'x' : '-');
+                         "'%9.9s' to '%9.9s'\n", opstr, npstr);
 
                 lf->perm_before = oldperm;
                 lf->perm_after = newperm;

--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -58,6 +58,12 @@ agent_info *get_agent_info(const char *agent_name, const char *agent_ip) __attri
  */
 int connect_to_remoted(void);
 
+/* Return the unix permission string based on the syscheck db perm string
+ * agentless logs octal permissions, local syscheck decimal st_mode
+ * Returns a pointer to a local static array
+ */
+char *agent_file_perm(char *perm);
+
 /* Sends a message to an agent
  * Returns -1 on error
  */

--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -58,11 +58,13 @@ agent_info *get_agent_info(const char *agent_name, const char *agent_ip) __attri
  */
 int connect_to_remoted(void);
 
+#ifndef WIN32
 /* Return the unix permission string based on the syscheck db perm string
  * agentless logs octal permissions, local syscheck decimal st_mode
  * Returns a pointer to a local static array
  */
 char *agent_file_perm(char *perm);
+#endif
 
 /* Sends a message to an agent
  * Returns -1 on error

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -863,6 +863,28 @@ int connect_to_remoted()
     return (arq);
 }
 
+char *agent_file_perm(char *perm) 
+{
+	/* rwxrwxrwx0 -> 10 */
+	static char permissions[10];
+	mode_t mode = 0;
+
+	/* octal or decimal */
+	mode = (mode_t) strtoul(perm, 0, strlen(perm) == 3 ? 8 : 10);
+
+	permissions[0] = (mode & S_IRUSR) ? 'r' : '-';
+	permissions[1] = (mode & S_IWUSR) ? 'w' : '-';
+	permissions[2] = (mode & S_ISUID) ? 's' : (mode & S_IXUSR) ? 'x' : '-';
+	permissions[3] = (mode & S_IRGRP) ? 'r' : '-';
+	permissions[4] = (mode & S_IWGRP) ? 'w' : '-';
+	permissions[5] = (mode & S_ISGID) ? 's' : (mode & S_IXGRP) ? 'x' : '-';
+	permissions[6] = (mode & S_IROTH) ? 'r' : '-';
+	permissions[7] = (mode & S_IWOTH) ? 'w' : '-';
+	permissions[8] = (mode & S_ISVTX) ? 't' : (mode & S_IXOTH) ? 'x' : '-';
+
+	return &permissions[0];
+}
+
 #endif /* !WIN32 */
 
 /* Internal funtion. Extract last time of scan from rootcheck/syscheck. */
@@ -1228,27 +1250,5 @@ char **get_agents(int flag)
 
     closedir(dp);
     return (f_files);
-}
-
-char *agent_file_perm(char *perm) 
-{
-	/* rwxrwxrwx0 -> 10 */
-	static char permissions[10];
-	mode_t mode = 0;
-
-	/* octal or decimal */
-	mode = (mode_t) strtoul(perm, 0, strlen(perm) == 3 ? 8 : 10);
-
-	permissions[0] = (mode & S_IRUSR) ? 'r' : '-';
-	permissions[1] = (mode & S_IWUSR) ? 'w' : '-';
-	permissions[2] = (mode & S_ISUID) ? 's' : (mode & S_IXUSR) ? 'x' : '-';
-	permissions[3] = (mode & S_IRGRP) ? 'r' : '-';
-	permissions[4] = (mode & S_IWGRP) ? 'w' : '-';
-	permissions[5] = (mode & S_ISGID) ? 's' : (mode & S_IXGRP) ? 'x' : '-';
-	permissions[6] = (mode & S_IROTH) ? 'r' : '-';
-	permissions[7] = (mode & S_IWOTH) ? 'w' : '-';
-	permissions[8] = (mode & S_ISVTX) ? 't' : (mode & S_IXOTH) ? 'x' : '-';
-
-	return &permissions[0];
 }
 

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -59,7 +59,6 @@ static int _do_print_attrs_syscheck(const char *prev_attrs, const char *attrs, _
     const char *p_size, *size;
     char *p_perm, *p_uid, *p_gid, *p_md5, *p_sha1;
     char *perm, *uid, *gid, *md5, *sha1;
-    int perm_int;
     char perm_str[36];
 
 
@@ -123,25 +122,7 @@ static int _do_print_attrs_syscheck(const char *prev_attrs, const char *attrs, _
     }
 
     perm_str[35] = '\0';
-    perm_int = atoi(perm);
-    snprintf(perm_str, 35,
-             "%c%c%c%c%c%c%c%c%c",
-             (perm_int & S_IRUSR) ? 'r' : '-',
-             (perm_int & S_IWUSR) ? 'w' : '-',
-
-             (perm_int & S_ISUID) ? 's' :
-             (perm_int & S_IXUSR) ? 'x' : '-',
-
-             (perm_int & S_IRGRP) ? 'r' : '-',
-             (perm_int & S_IWGRP) ? 'w' : '-',
-
-             (perm_int & S_ISGID) ? 's' :
-             (perm_int & S_IXGRP) ? 'x' : '-',
-
-             (perm_int & S_IROTH) ? 'r' : '-',
-             (perm_int & S_IWOTH) ? 'w' : '-',
-             (perm_int & S_ISVTX) ? 't' :
-             (perm_int & S_IXOTH) ? 'x' : '-');
+    snprintf(perm_str, 35, "%9.9s", agent_file_perm(perm));
 
     printf("Integrity checking values:\n");
     printf("   Size:%s%s\n", (strcmp(size, p_size) == 0) ? " " : " >", size);
@@ -1248,3 +1229,26 @@ char **get_agents(int flag)
     closedir(dp);
     return (f_files);
 }
+
+char *agent_file_perm(char *perm) 
+{
+	/* rwxrwxrwx0 -> 10 */
+	static char permissions[10];
+	mode_t mode = 0;
+
+	/* octal or decimal */
+	mode = (mode_t) strtoul(perm, 0, strlen(perm) == 3 ? 8 : 10);
+
+	permissions[0] = (mode & S_IRUSR) ? 'r' : '-';
+	permissions[1] = (mode & S_IWUSR) ? 'w' : '-';
+	permissions[2] = (mode & S_ISUID) ? 's' : (mode & S_IXUSR) ? 'x' : '-';
+	permissions[3] = (mode & S_IRGRP) ? 'r' : '-';
+	permissions[4] = (mode & S_IWGRP) ? 'w' : '-';
+	permissions[5] = (mode & S_ISGID) ? 's' : (mode & S_IXGRP) ? 'x' : '-';
+	permissions[6] = (mode & S_IROTH) ? 'r' : '-';
+	permissions[7] = (mode & S_IWOTH) ? 'w' : '-';
+	permissions[8] = (mode & S_ISVTX) ? 't' : (mode & S_IXOTH) ? 'x' : '-';
+
+	return &permissions[0];
+}
+


### PR DESCRIPTION
Hi,

The agentless file permissions are stored in the 'database' as octal values.
The agentfull file permissions are stored in the 'database' as the decimal st_mode value.

When reporting the agentless changes in permissions, weird representations are shown.

In order not to disturb any existing databases or introduce conversions on both the code and the database, this patch just determines if the permissions in the 'database' are in octal or decimal st_mode repesentation and converts this correctly to a string.

Also included are:

Fix Makefile openssl commandline flag.
Fix fixed version in debian contrib.

And 'unset HISTFILE' before the linux ssh command in the expect script.

Kind regards,
Stephan