### PR TITLE
Netscreen decoder and rule addition

### DIFF
--- a/contrib/ossec-testing/tests/netscreen.ini
+++ b/contrib/ossec-testing/tests/netscreen.ini
@@ -19,3 +19,10 @@ rule = 4507
 alert = 8
 decoder = netscreenfw
 
+[syn flood]
+log 1 pass = Jul  7 05:02:34 ssg5.17.168.192.in-addr.arpa ssg5: NetScreen device_id=ssg5  [Root]system-emergency-00005: SYN flood! From 192.168.18.53:41437 to 192.168.17.251:9612, proto TCP (zone Untrust int  ethernet0/0). Occurred 1 times. (2016-07-07 05:02:32)
+
+rule = 4560
+alert = 3
+decoder = netscreenfw
+

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1272,7 +1272,8 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="netscreenfw-critical">
   <parent>netscreenfw</parent>
   <prematch offset="after_parent">system-critical-\.+ from |</prematch>
-  <prematch>system-alert-\.+ from </prematch>
+  <prematch>system-alert-\.+ from |</prematch>
+  <prematch>system-emergency-\.+ From </prematch>
 
   <regex offset="after_parent">system-(\w+)-(\d+): \.+ </regex>
   <regex>from\.+(\S+)</regex>

--- a/etc/rules/netscreenfw_rules.xml
+++ b/etc/rules/netscreenfw_rules.xml
@@ -110,4 +110,14 @@
     <if_matched_sid>4513</if_matched_sid>
     <description>Multiple Netscreen alert messages.</description>
   </rule>
+
+  <rule id="4560" level="3">
+    <if_sid>4500</if_sid>
+    <match>SYN flood! </match>
+    <description>netscreen detected a SYN flood.</description>
+  </rule>
+
+
+
 </group> <!-- SYSLOG,NETSCREENFW -->
+


### PR DESCRIPTION
Add decoding for system-emergency log events.
Add a simple rule looking for syn floods.
