### PR TITLE
Dichotomic search to add agents with authd

### DIFF
--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -24,7 +24,7 @@ char *OS_AddNewAgent(const char *name, const char *ip, const char *id)
     char *muname;
     char *finals;
 
-    char nid[9];
+    char nid[9] = { '\0' }, nid_p[9] = { '\0' };
 
     srandom_init();
 
@@ -37,17 +37,32 @@ char *OS_AddNewAgent(const char *name, const char *ip, const char *id)
 
     free(muname);
 
-    nid[8] = '\0';
     if (id == NULL) {
-        int i = 1024;
-        snprintf(nid, 6, "%d", i);
-        while (IDExist(nid)) {
-            i++;
-            snprintf(nid, 6, "%d", i);
-            if (i >= (MAX_AGENTS + 1024)) {
-                return (NULL);
-            }
+        int i = AUTHD_FIRST_ID;
+        int j = MAX_AGENTS + AUTHD_FIRST_ID;
+        int m = (i + j) / 2;
+
+        snprintf(nid, 8, "%d", m);
+        snprintf(nid_p, 8, "%d", m - 1);
+
+        /* Dichotomic search */
+
+        while (1) {
+            if (IDExist(nid)) {
+                if (m == i)
+                    return NULL;
+
+                i = m;
+            } else if (!IDExist(nid_p) && m > i )
+                j = m;
+            else
+                break;
+
+            m = (i + j) / 2;
+            snprintf(nid, 8, "%d", m);
+            snprintf(nid_p, 8, "%d", m - 1);
         }
+
         id = nid;
     }
 
@@ -407,4 +422,3 @@ int print_agents(int print_status, int active_only, int csv_output)
 
     return (0);
 }
-

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -58,6 +58,11 @@ http://www.ossec.net/main/license/\n"
 #define MAX_AGENTS  256
 #endif
 
+/* First ID assigned by authd */
+#ifndef AUTHD_FIRST_ID
+#define AUTHD_FIRST_ID  1024
+#endif
+
 /* Notify the manager */
 #define NOTIFY_TIME     600 /* ... every 600 seconds (10 minutes) */
 


### PR DESCRIPTION
This patch solves the issue https://github.com/ossec/ossec-hids/issues/873, speeding up the agent ID assignation at `ossec-authd` by using dichotomic search.

Currently, when assigning a new ID, OSSEC tries to use 1, 2, etc, until it finds the first empty ID. For each attempt, it opens the keys file and goes through it. So, the algorithmic efficiency is O(n^2).

Since the assigned IDs are always correlative, this implementation guesses the first free ID by splitting the entire list of possible values and testing only the central number. This way it achieves a linear-logarithmic efficiency, O(n log n).