### PR TITLE
Add IPv6 capability to contributed PERL scripts.

### DIFF
--- a/contrib/active-list.pl
+++ b/contrib/active-list.pl
@@ -14,6 +14,7 @@
 use strict;
 use warnings;
 use DBI;
+use Regexp::IPv6 qw($IPv6_re);
 
 # -----------------------
 # DB access configuration
@@ -47,6 +48,8 @@ if ($ipAddr =~ m/^(\d\d?\d?)\.(\d\d?\d?)\.(\d\d?\d?)\.(\d\d?\d?)/) {
 		WriteLog("Invalid IP address: $ipAddr\n");
 		exit 1;
 	}
+}
+else if ($ipAddr =~ m/^$IPv6_re/) {
 }
 else {
 	WriteLog("Invalid IP address: $ipAddr\n");

--- a/contrib/ossec2mysql.pl
+++ b/contrib/ossec2mysql.pl
@@ -2,6 +2,7 @@
 use Socket;
 use POSIX 'setsid';
 use strict;
+use Regexp::IPv6 qw($IPv6_re);
 # ---------------------------------------------------------------------------
 # Author: Meir Michanie (meirm@riunx.com)
 # Co-Author: J.A.Senger (jorge@br10.com.br)
@@ -101,7 +102,7 @@ $conf{resolve}=1;
 
 my($OCT) = '(?:25[012345]|2[0-4]\d|1?\d\d?)';
 
-my($IP) = $OCT . '\.' . $OCT . '\.' . $OCT . '\.' . $OCT;
+my($IP) = $OCT . '\.' . $OCT . '\.' . $OCT . '\.' . $OCT . '\|' . $IPv6_re;
 
 my $VERSION="0.4";
 my $sig_class_id=1;
@@ -210,8 +211,8 @@ sub taillog {
 				$dstip=$resolv{$alerthost};
 			}else{
 				if ($conf{'resolve'}){
-					$dstip=`host $alerthost 2>/dev/null | grep 'has address' `;
-					if ($dstip =~m/(\d+\.\d+\.\d+\.\d+)/ ){
+					$dstip=`host $alerthost 2>/dev/null | grep 'has address\|has IPv6 address' `;
+					if ($dstip =~m/($IP)/ ){
 						$dstip=$1;
 					}else{
 						$dstip=$srcip;
@@ -264,7 +265,7 @@ sub taillog {
                 $date=$1;
                 $alerthost=$2;
                 $datasource=$3;
-                if ($datasource=~ m/(\d+\.\d+\.\d+\.\d+)/){
+                if ($datasource=~ m/($IP)/){
                         $alerthost=$1;
                         $datasource="remoted";
                 }
@@ -285,10 +286,10 @@ sub taillog {
 		$level=$2;
 		$description= $3;
 	}elsif ( m/Src IP:/){
-		if ( m/($IP)/){
+		if ( m/Src IP: (\S+)/){
                         $srcip=$1;
                 }else{
-                        $srcip='0.0.0.0';
+                        $srcip='';
                 }
 	}elsif ( m/User: (.*)$/){
                 $user=$1;

--- a/contrib/ossec2mysqld.pl
+++ b/contrib/ossec2mysqld.pl
@@ -2,6 +2,7 @@
 use strict;
 use Socket;
 use POSIX 'setsid';
+use Regexp::IPv6 qw($IPv6_re);
 # ---------------------------------------------------------------------------
 # Author: Meir Michanie (meirm@riunx.com)
 # Co-Author: J.A.Senger (jorge@br10.com.br)
@@ -102,7 +103,7 @@ $conf{resolve}=1;
 
 my($OCT) = '(?:25[012345]|2[0-4]\d|1?\d\d?)';
 
-my($IP) = $OCT . '\.' . $OCT . '\.' . $OCT . '\.' . $OCT;
+my($IP) = $OCT . '\.' . $OCT . '\.' . $OCT . '\.' . $OCT . '\|' . $IPv6_re;
 
 my $VERSION="0.4";
 my $sig_class_id=1;
@@ -238,8 +239,8 @@ sub taillog {
 				$dstip=$resolv{$alerthost};
 			}else{
 				if ($conf{'resolve'}){
-					$dstip=`host $alerthost 2>/dev/null | grep 'has address' `;
-					if ($dstip =~m/(\d+\.\d+\.\d+\.\d+)/ ){
+					$dstip=`host $alerthost 2>/dev/null | grep 'has address\|has IPv6 address' `;
+					if ($dstip =~m/($IP)/ ){
 						$dstip=$1;
 					}else{
 						$dstip=$srcip;
@@ -291,7 +292,7 @@ sub taillog {
 		$date=$1;
 		$alerthost=$2;
 		$datasource=$3;
-		if ($datasource=~ m/(\d+\.\d+\.\d+\.\d+)/){
+		if ($datasource=~ m/($IP)/){
 			$alerthost=$1;
 			$datasource="remoted";
 		}
@@ -311,10 +312,10 @@ sub taillog {
 		$level=$2;
 		$description= $3;
 	}elsif ( m/Src IP:/){
-		if ( m/($IP)/){
+		if ( m/Src IP: (\S+)/){
                         $srcip=$1;
                 }else{
-                        $srcip='0.0.0.0';
+                        $srcip='';
                 }
 	}elsif ( m/User: (.*)$/){
                 $user=$1;

--- a/contrib/ossec2snorby/ossec2snorby.pl
+++ b/contrib/ossec2snorby/ossec2snorby.pl
@@ -3,6 +3,7 @@ use Socket;
 use POSIX 'setsid';
 use strict;
 use ossecmysql;
+use Regexp::IPv6 qw($IPv6_re);
 # ---------------------------------------------------------------------------
 # Author: Meir Michanie (meirm@riunx.com)
 # Co-Author: J.A.Senger (jorge@br10.com.br)
@@ -123,7 +124,7 @@ my $LOG='/var/ossec/logs/alerts/alerts.log';  # we need to tail this file instea
 
 my ($LOGGER)='ossec2snorby';
 my($OCT) = '(?:25[012345]|2[0-4]\d|1?\d\d?)';
-my($IP) = $OCT . '\.' . $OCT . '\.' . $OCT . '\.' . $OCT;
+my($IP) = $OCT . '\.' . $OCT . '\.' . $OCT . '\.' . $OCT . '\|' . $IPv6_re;
 my $dump=0;
 my ($hids_id,$hids,$hids_interface,$last_cid)=(undef, 'localhost', 'ossec',0);
 my ($tempvar,$VERBOSE)=(0,0); 
@@ -251,7 +252,7 @@ sub taillog {
                 $dstip=$resolv{$alerthost};
             }else{
                 if ($conf{'resolve'}){
-                    if ($alerthost =~m/(\d+\.\d+\.\d+\.\d+)/ ){
+                    if ($alerthost =~m/($IP)/ ){
                         $dstip=$1;
                     }else{
                         # the "host" command doesn't work with Flatname\NetBIOS names.
@@ -342,7 +343,7 @@ sub taillog {
                 $date=$1;
                 $alerthost=$2;
                 $datasource=$3;
-                if ($datasource=~ m/(\d+\.\d+\.\d+\.\d+)/){
+                if ($datasource=~ m/($IP)/){
                         $alerthost=$1;
                         $datasource="remoted";
                 }
@@ -362,7 +363,7 @@ sub taillog {
         $osseclevel=$level;  # Keep copy of OSSEC level as it will later be converted to snort level.
         $description= $3;
     }elsif ( m/src\s?ip:/i){
-        if ( m/($IP)/){
+        if ( m/src\s?ip:\s?(\S+)/i){
             $srcip=$1;
         }else{
             $srcip='1';  # Snorby doesn't like srcip\dstip = 0\null.
@@ -559,8 +560,8 @@ sub host2ip {
     # Validate if we were fed a flatnamed host or a FQDN.
     if ($host =~ m/.*\..+/){
         # FQDN
-        $CMD=`host $host 2>/dev/null | grep 'has address' `;
-        if ($CMD =~m/(\d+\.\d+\.\d+\.\d+)/ ){
+        $CMD=`host $host 2>/dev/null | grep 'has address\|has IPv6 address' `;
+        if ($CMD =~m/($IP)/ ){
             return($1);
         }else{
             return undef; # return False.
@@ -576,8 +577,8 @@ sub host2ip {
 
         # There is an extra "." after $domain, this is to ensure linux
         # does not append "localdomain" at the end of the host.
-        $CMD=`host $host.$domain. 2>/dev/null | grep 'has address' `;
-        if ($CMD =~m/(\d+\.\d+\.\d+\.\d+)/ ){
+        $CMD=`host $host.$domain. 2>/dev/null | grep 'has address\|has IPv6 address' `;
+        if ($CMD =~m/($IP)/ ){
             return($1);
         }else{
             return undef; # return False.

--- a/contrib/ossectop.pl
+++ b/contrib/ossectop.pl
@@ -1,7 +1,8 @@
 #!/usr/bin/perl -w
 #use strict;
-use Socket;
-use POSIX 'setsid';
+#use Socket;
+#use POSIX 'setsid';
+use Regexp::IPv6 qw($IPv6_re);
 # ---------------------------------------------------------------------------
 # Author: Meir Michanie (meirm@riunx.com)
 # File: ossectop.pl
@@ -48,7 +49,7 @@ $conf{resolve}=1;
 
 my($OCT) = '(?:25[012345]|2[0-4]\d|1?\d\d?)';
 
-my($IP) = $OCT . '\.' . $OCT . '\.' . $OCT . '\.' . $OCT;
+my($IP) = $OCT . '\.' . $OCT . '\.' . $OCT . '\.' . $OCT . '\|' . $IPv6_re;
 
 my $VERSION="0.1";
 my $sig_class_id=1;
@@ -146,8 +147,8 @@ sub taillog {
 				$dstip=$resolv{$alerthost};
 			}else{
 				if ($conf{'resolve'}){
-					$dstip=`host $alerthost 2>/dev/null | grep 'has address' `;
-					if ($dstip =~m/(\d+\.\d+\.\d+\.\d+)/ ){
+					$dstip=`host $alerthost 2>/dev/null | grep 'has address\|has IPv6 address' `;
+					if ($dstip =~m/($IP)/ ){
 						$dstip=$1;
 					}else{
 						$dstip=$srcip;
@@ -198,10 +199,10 @@ sub taillog {
 		$level=$2;
 		$description= $3;
 	}elsif ( m/Src IP:/){
-		if ( m/($IP)/){
+		if ( m/Src IP: (\S+)/){
                         $srcip=$1;
                 }else{
-                        $srcip='0.0.0.0';
+                        $srcip='';
                 }
 	}elsif ( m/User: (.*)$/){
                 $user=$1;


### PR DESCRIPTION
Addresses issue #892.  Requires the Regexp::IPv6 module but this should be installable as a package on most OS.