### PR TITLE
Fixed "file name too long." alert

### DIFF
--- a/etc/rules/nginx_rules.xml
+++ b/etc/rules/nginx_rules.xml
@@ -77,8 +77,8 @@
   </rule>
 
   <rule id="31320" level="10">
-    <if_sid>31303</if_sid>
-    <match>failed (63: File name too long)</match>
+    <if_sid>31301</if_sid>
+    <match>failed (36: File name too long)</match>
     <description>Invalid URI, file name too long.</description>
     <group>invalid_request,</group>
   </rule>


### PR DESCRIPTION
Error number for File name too long is 36 (not 63)
Comes through as an [error], not a [crit]

openSUSE Leap 42.1
nginx v1.8.1 release 5.1