### PR TITLE
Fixed "file name too long" nginx rule

### DIFF
--- a/contrib/ossec-testing/tests/nginx.ini
+++ b/contrib/ossec-testing/tests/nginx.ini
@@ -72,7 +72,7 @@ alert = 0
 decoder = nginx-errorlog
 
 [Invalid URI, file name too long.]
-log 1 pass = 2015/01/08 11:31:23 [crit] 80:2 yadda yadda failed (63: File name too long)
+log 1 pass = 2015/01/08 11:31:23 [error] 80:2 yadda yadda failed (36: File name too long)
 
 rule = 31320
 alert = 10

--- a/etc/rules/nginx_rules.xml
+++ b/etc/rules/nginx_rules.xml
@@ -77,8 +77,8 @@
   </rule>
 
   <rule id="31320" level="10">
-    <if_sid>31303</if_sid>
-    <match>failed (63: File name too long)</match>
+    <if_sid>31301</if_sid>
+    <match>failed (36: File name too long)</match>
     <description>Invalid URI, file name too long.</description>
     <group>invalid_request,</group>
   </rule>


### PR DESCRIPTION
As of nginx 1.8.1, "file name too long" is an error with errno 36. The rule and test have been updated to reflect this

Re-creation of PR 897