### PR TITLE
Fixed agents numbering issue

### DIFF
--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -212,7 +212,9 @@ int add_agent()
             strncpy(id, _id, FILE_SIZE - 1);
         }
 
-        if (!OS_IsValidID(id)) {
+        if (OS_IsValidID(id)) {
+            FormatID(id);
+        } else {
             printf(INVALID_ID, id);
         }
 
@@ -317,6 +319,7 @@ int remove_agent()
             return (0);
         }
 
+        FormatID(user_input);
         strncpy(u_id, user_input, FILE_SIZE);
 
         id_exist = IDExist(user_input);
@@ -400,4 +403,3 @@ int list_agents(int cmdlist)
 
     return (0);
 }
-

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -35,6 +35,7 @@ int IDExist(const char *id);
 int NameExist(const char *u_name);
 char *getFullnameById(const char *id);
 char *OS_AddNewAgent(const char *name, const char *ip, const char *id);
+void FormatID(char *id);
 
 /* Print available agents */
 int print_agents(int print_status, int active_only, int csv_output);
@@ -138,4 +139,3 @@ extern fpos_t fp_pos;
 #define GMF_ERROR       ARGV0 ": Could not run GetModuleFileName.\n"
 #define GMF_BUFF_ERROR  ARGV0 ": Could not get path because it is too long and was shrunk by (%d) characters with a max of (%d).\n"
 #define GMF_UNKN_ERROR  ARGV0 ": Could not run GetModuleFileName which returned (%ld).\n"
-

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -183,13 +183,14 @@ int k_import(const char *cmdimport)
 int k_extract(const char *cmdextract)
 {
     FILE *fp;
-    const char *user_input;
+    char *user_input;
     char *b64_enc;
     char line_read[FILE_SIZE + 1];
     char n_id[USER_SIZE + 1];
 
     if (cmdextract) {
-        user_input = cmdextract;
+        user_input = strdup(cmdextract);
+        FormatID(user_input);
 
         if (!IDExist(user_input)) {
             printf(NO_ID, user_input);
@@ -203,7 +204,7 @@ int k_extract(const char *cmdextract)
             return (0);
         }
 
-        do {
+        while (1) {
             printf(EXTRACT_KEY);
             fflush(stdout);
             user_input = read_from_user();
@@ -213,11 +214,15 @@ int k_extract(const char *cmdextract)
                 return (0);
             }
 
-            if (!IDExist(user_input)) {
+            FormatID(user_input);
+
+            if (IDExist(user_input)) {
+                break;
+            } else {
                 printf(NO_ID, user_input);
             }
 
-        } while (!IDExist(user_input));
+        }
     }
 
     /* Try to open the auth file */
@@ -413,4 +418,3 @@ cleanup:
     fclose(infp);
     return (0);
 }
-

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -422,3 +422,16 @@ int print_agents(int print_status, int active_only, int csv_output)
 
     return (0);
 }
+
+void FormatID(char *id) {
+    int number;
+    char *end;
+
+    if (id && *id) {
+        number = strtol(id, &end, 10);
+
+        if (!*end) {
+            sprintf(id, "%03d", number);
+        }
+    }
+}


### PR DESCRIPTION
OSSEC agent IDs can only be numbers but they are treated as strings. Because of this, it's possible to add the agent "00" and "000", or "1" and "00001" at the same time, and they can be confused on extracting keys or on deleting agents.

This fix always makes `manage_agents` to convert the user input into integers and re-format them into at least 3-digit strings (padded with zeroes). So user inputs referring agent ID "1" or "00001" will become "001".