### PR TITLE
vsftpd_connect decoder left a trailing double quotes in the srcip field.

### DIFF
--- a/contrib/ossec-testing/tests/vsftpd.ini
+++ b/contrib/ossec-testing/tests/vsftpd.ini
@@ -1,0 +1,8 @@
+[CONNECT]
+log 1 pass = Wed Jul 27 18:32:27 2016 [pid 2] CONNECT: Client "fe80::baac:6fff:fe7d:d2e0"
+log 2 pass = Wed Jul 27 18:32:27 2016 [pid 2] CONNECT: Client "10.11.12.13"
+
+rule = 11401
+alert = 3
+decoder = vsftpd
+

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -639,7 +639,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="vsftpd_connect">
   <parent>vsftpd</parent>
   <prematch offset="after_parent">^CONNECT:</prematch>
-  <regex offset="after_parent">(CONNECT): Client "(\S+)"$</regex>
+  <regex offset="after_parent">(CONNECT): Client "(\S+\w+)"$</regex>
   <order>action,srcip</order>
 </decoder>
 


### PR DESCRIPTION
This fix doesn't actually make a lot of sense to me, but it works.

Submitted in issue #906 by nemapl. The test is based on the sample log
provided in the issue.