### PR TITLE
Update intcheck_op.c

### DIFF
--- a/src/client-agent/intcheck_op.c
+++ b/src/client-agent/intcheck_op.c
@@ -17,8 +17,8 @@
 int intcheck_file(const char *file_name, const char *dir)
 {
     struct stat statbuf;
-    os_md5 mf_sum;
-    os_sha1 sf_sum;
+    os_md5 mf_sum = 0;
+    os_sha1 sf_sum = 0;
     char newsum[912 + 1];
 
     newsum[0] = '\0';

--- a/src/client-agent/intcheck_op.c
+++ b/src/client-agent/intcheck_op.c
@@ -17,8 +17,8 @@
 int intcheck_file(const char *file_name, const char *dir)
 {
     struct stat statbuf;
-    os_md5 mf_sum = 0;
-    os_sha1 sf_sum = 0;
+    os_md5 mf_sum = NULL;
+    os_sha1 sf_sum = NULL;
     char newsum[912 + 1];
 
     newsum[0] = '\0';

--- a/src/client-agent/intcheck_op.c
+++ b/src/client-agent/intcheck_op.c
@@ -17,8 +17,8 @@
 int intcheck_file(const char *file_name, const char *dir)
 {
     struct stat statbuf;
-    os_md5 mf_sum = NULL;
-    os_sha1 sf_sum = NULL;
+    os_md5 mf_sum = "";
+    os_sha1 sf_sum = "";
     char newsum[912 + 1];
 
     newsum[0] = '\0';


### PR DESCRIPTION
```
Checking ./ossec-hids-master/src/client-agent/intcheck_op.c...
[./ossec-hids-master/src/client-agent/intcheck_op.c:65]: (error) Uninitialized variable: mf_sum
[./ossec-hids-master/src/client-agent/intcheck_op.c:66]: (error) Uninitialized variable: sf_sum
Checking ./ossec-hids-master/src/client-agent/intcheck_op.c: WIN32...
```

It's always good to initialize the elements of a char array, at least to "", because if you try to retrieve an element before it gets assigned any actual (non-garbage) value, then you run the risk of retrieving a garbage value that might cause your program to crash, or worse, might corrupt memory.

Found by https://github.com/bryongloden/cppcheck