### PR TITLE
Feature/syscheck decoders json ohmy

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -480,6 +480,8 @@ int ReadDecodeXML(const char *file)
                         pi->order[order_int] = (void (*)(void *, char *)) Status_FP;
                     } else if (strstr(*norder, "system_name") != NULL) {
                         pi->order[order_int] = (void (*)(void *, char *)) SystemName_FP;
+                    } else if (strstr(*norder, "filename") != NULL) {
+                        pi->order[order_int] = (void (*)(void *, char *)) FileName_FP;
                     } else {
                         ErrorExit("decode-xml: Wrong field '%s' in the order"
                                   " of decoder '%s'", *norder, pi->name);

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -398,6 +398,19 @@ void *SystemName_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
+void *FileName_FP(Eventinfo *lf, char *field)
+{
+#ifdef TESTRULE
+    if (!alert_only) {
+        print_out("       filename: '%s'", field);
+    }
+#endif
+
+    lf->filename = field;
+    return (NULL);
+}
+
+
 void *None_FP(__attribute__((unused)) Eventinfo *lf, char *field)
 {
     free(field);

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -150,6 +150,7 @@ void *Url_FP(Eventinfo *lf, char *field);
 void *Data_FP(Eventinfo *lf, char *field);
 void *Status_FP(Eventinfo *lf, char *field);
 void *SystemName_FP(Eventinfo *lf, char *field);
+void *FileName_FP(Eventinfo *lf, char *field);
 void *None_FP(Eventinfo *lf, char *field);
 
 #endif /* _EVTINFO__H */

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -54,6 +54,9 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->action) {
         cJSON_AddStringToObject(root, "action", lf->action);
     }
+    if (lf->protocol) {
+        cJSON_AddStringToObject(root, "protocol", lf->protocol);
+    }
     if (lf->srcip) {
         cJSON_AddStringToObject(root, "srcip", lf->srcip);
     }
@@ -112,6 +115,24 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
             cJSON_AddNumberToObject(file_diff, "perm_before", lf->perm_before);
             cJSON_AddNumberToObject(file_diff, "perm_after", lf->perm_after);
         }
+    }
+    if ( lf->data ) {
+        cJSON_AddStringToObject(root, "data", lf->data);
+    }
+    if ( lf->action ) {
+        cJSON_AddStringToObject(root, "action", lf->action);
+    }
+    if ( lf->url ) {
+        cJSON_AddStringToObject(root, "url", lf->url);
+    }
+    if ( lf->systemname ) {
+        cJSON_AddStringToObject(root, "system_name", lf->systemname);
+    }
+    if ( lf->status ) {
+        cJSON_AddStringToObject(root, "status", lf->status);
+    }
+    if ( lf->program_name ) {
+        cJSON_AddStringToObject(root, "program_name", lf->program_name);
     }
     out = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -36,7 +36,7 @@
 
 /* Some global names */
 #define __ossec_name    "OSSEC HIDS"
-#define __version       "v2.8"
+#define __version       "v2.9.0"
 #define __author        "Trend Micro Inc."
 #define __contact       "contact@ossec.net"
 #define __site          "http://www.ossec.net"

--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -11,7 +11,7 @@ DIR=`dirname $PWD`;
 
 ###  Do not modify bellow here ###
 NAME="OSSEC HIDS"
-VERSION="v2.8"
+VERSION="v2.9.0"
 AUTHOR="Trend Micro Inc."
 DAEMONS="ossec-logcollector ossec-syscheckd ossec-agentd ossec-execd"
 

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -19,7 +19,7 @@ if [ $? = 0 ]; then
 fi
 
 NAME="OSSEC HIDS"
-VERSION="v2.8"
+VERSION="v2.9.0"
 AUTHOR="Trend Micro Inc."
 DAEMONS="ossec-monitord ossec-logcollector ossec-syscheckd ossec-analysisd ossec-maild ossec-execd ${DB_DAEMON} ${CSYSLOG_DAEMON} ${AGENTLESS_DAEMON}"
 

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -19,7 +19,7 @@ if [ $? = 0 ]; then
 fi
 
 NAME="OSSEC HIDS"
-VERSION="v2.8"
+VERSION="v2.9.0"
 AUTHOR="Trend Micro Inc."
 
 [ -f /etc/ossec-init.conf ] && . /etc/ossec-init.conf;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -320,8 +320,13 @@ static int read_dir(const char *dir_name, int opts, OSMatch *restriction)
 
     /* Check for real time flag */
     if (opts & CHECK_REALTIME) {
-#ifdef INOTIFY_ENABLED
+#if defined(INOTIFY_ENABLED) || defined(WIN32)
         realtime_adddir(dir_name);
+#else
+        merror("%s: WARN: realtime monitoring request on unsupported system for '%s'",
+                ARGV0,
+                dir_name
+        );
 #endif
     }
 
@@ -394,11 +399,7 @@ int create_db()
     __counter = 0;
     do {
         if (read_dir(syscheck.dir[i], syscheck.opts[i], syscheck.filerestrict[i]) == 0) {
-#ifdef WIN32
-            if (syscheck.opts[i] & CHECK_REALTIME) {
-                realtime_adddir(syscheck.dir[i]);
-            }
-#endif
+            debug2("%s: Directory loaded from syscheck db: %s", ARGV0, syscheck.dir[i]);
         }
         i++;
     } while (syscheck.dir[i] != NULL);

--- a/src/win32/help.txt
+++ b/src/win32/help.txt
@@ -1,4 +1,4 @@
-** OSSEC Windows Agent v2.8 **
+** OSSEC Windows Agent v2.9 **
 ** Copyright (C) 2014 Trend Micro Inc. **
 
 

--- a/src/win32/ossec-installer.nsi
+++ b/src/win32/ossec-installer.nsi
@@ -25,7 +25,7 @@
 ; general
 !define MUI_ICON favicon.ico
 !define MUI_UNICON ossec-uninstall.ico
-!define VERSION "2.8"
+!define VERSION "2.9.0"
 !define NAME "OSSEC HIDS"
 !define SERVICE "OssecSvc"
 


### PR DESCRIPTION
A few fixes, but most importantly the ability to set the filename attribute from a decoder.  This will help create automated pipelines for FIM Verification.  I currently need to compare FIM events against 1) Puppet, 2) GIT, and 3) RPM.  This patch allows FIM events to be intercepted by my custom FIM Verification script, which generates logging events which OSSEC can read and turn back into an event with the filename attribute set.