### PR TITLE
Bugfixes for OS_IPFound, OS_IPFoundList, OS_IsValidIP.

### DIFF
--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -153,6 +153,20 @@ int OS_IPFound(const char *ip_address, const os_ip *that_ip)
     int _true = 1;
     os_ip temp_ip;
 
+    /* If negate is set */
+    char *ip = that_ip->ip;
+    if (ip[0] == '!') {
+        ip++;
+        _true = 0;
+    }
+
+    /* The simplest case is the 'any' case.
+     *  We just return true
+     */
+    if( strcmp(ip, "any") == 0 ) {
+        return _true;
+    }
+
     memset(&temp_ip, 0, sizeof(struct _os_ip));
 
     /* Extract IP address */
@@ -160,13 +174,9 @@ int OS_IPFound(const char *ip_address, const os_ip *that_ip)
         return (!_true);
     }
 
-    /* If negate is set */
-    if (that_ip->ip[0] == '!') {
-        _true = 0;
-    }
 
     /* Check if IP is in thatip & netmask */
-    if (sacmp((struct sockaddr *) &temp_ip.ss, 
+    if (sacmp((struct sockaddr *) &temp_ip.ss,
               (struct sockaddr *) &that_ip->ss,
               that_ip->prefixlength)) {
         return (_true);
@@ -195,12 +205,24 @@ int OS_IPFoundList(const char *ip_address, os_ip **list_of_ips)
     while (*list_of_ips) {
         os_ip *l_ip = *list_of_ips;
 
-        if (l_ip->ip[0] == '!') {
+        char *ip = l_ip->ip;
+        if (ip[0] == '!') {
+            ip++;
             _true = 0;
+        }
+        else {
+            _true = 1;
+        }
+
+        /* Simplest case, if the list contains an any
+         * ip, we return true.
+         */
+        if( strcmp(ip,"any" ) == 0 ) {
+            return _true;
         }
 
         /* Checking if ip is in thatip & netmask */
-        if (sacmp((struct sockaddr *) &temp_ip.ss, 
+        if (sacmp((struct sockaddr *) &temp_ip.ss,
                   (struct sockaddr *) &l_ip->ss,
                   l_ip->prefixlength)) {
             return (_true);
@@ -216,18 +238,24 @@ int OS_IPFoundList(const char *ip_address, os_ip **list_of_ips)
  * Returns 0 if doesn't match or 1 if it is an IP or 2 an IP with CIDR.
  * WARNING: On success this function may modify the value of ip_address
  */
-int OS_IsValidIP(const char *ip_address, os_ip *final_ip)
+int OS_IsValidIP(const char *in_address, os_ip *final_ip)
 {
     char *tmp_str;
     int cidr = -1, prefixlength;
     struct addrinfo hints, *result;
+    char *ip_address = NULL;
 
     /* Can't be null */
-    if (!ip_address) {
+    if (!in_address) {
         return (0);
     }
 
-    /* Assign the IP address */
+    /* We mess with in_address later and we set 'const'
+     *  in the signature, so we need to copy it
+     *  here.
+     */
+    os_strdup(in_address, ip_address);
+
     if (final_ip) {
         os_strdup(ip_address, final_ip->ip);
     }
@@ -236,8 +264,12 @@ int OS_IsValidIP(const char *ip_address, os_ip *final_ip)
         ip_address++;
     }
 
+    /* Use IPv6 here, because it doesn't matter
+     * OS_IPFound and OS_IPFoundList will
+     * return true if the os_ip.ip element is 'any'
+     */
     if(strcmp(ip_address, "any") == 0) {
-        strcpy((char *) ip_address, "::/0");   
+        strcpy(ip_address, "::/0");
     }
 
     /* Getting the cidr/netmask if available */
@@ -250,6 +282,7 @@ int OS_IsValidIP(const char *ip_address, os_ip *final_ip)
         if(strlen(tmp_str) <= 3) {
             cidr = atoi(tmp_str);
         } else {
+            free(ip_address);
             return(0);
         }
     }
@@ -258,6 +291,7 @@ int OS_IsValidIP(const char *ip_address, os_ip *final_ip)
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_flags = AI_NUMERICHOST;
     if (getaddrinfo(ip_address, NULL, &hints, &result) != 0) {
+        free(ip_address);
         return(0);
     }
 
@@ -271,6 +305,7 @@ int OS_IsValidIP(const char *ip_address, os_ip *final_ip)
             prefixlength = 32;
             break;
         }
+        free(ip_address);
         return(0);
     case AF_INET6:
         if (cidr >=0 && cidr <= 128) {
@@ -280,8 +315,10 @@ int OS_IsValidIP(const char *ip_address, os_ip *final_ip)
             prefixlength = 128;
             break;
         }
+        free(ip_address);
         return(0);
-    default:  
+    default:
+        free(ip_address);
         return(0);
     }
 
@@ -291,6 +328,7 @@ int OS_IsValidIP(const char *ip_address, os_ip *final_ip)
     }
 
     freeaddrinfo(result);
+    free(ip_address);
     return((cidr >= 0) ? 2 : 1);
 }
 


### PR DESCRIPTION
OS_IsValidIP violated it's `const` constraint when the ip_addr element
was set to 'any'.  This caused some unexplained behavior when subsequent
calls.  This is corrected.

OS_IPFound and OS_IPFoundList where call sacmp(), but if OS_IsValidIP
was called with "any", the sockaddr_store.ss_family would be AF_INET6.
AFAICT, this meant any comparison of "any" to an IPv4 address would
fail.  This affected the ossec-remoted when validating IPv4 keys issued
by authd which set 'any' as the IP address to verify.

This would also cause failures *everywhere* in the rules, analysis,
exec, and activeresponse code where the src/dst IP being compared to any
was IPv4.