### PR TITLE
Bugfix/json field duplication

### DIFF
--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -43,6 +43,9 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->generated_rule->sigid) {
         cJSON_AddNumberToObject(rule, "sidid", lf->generated_rule->sigid);
     }
+    if (lf->generated_rule->group) {
+        cJSON_AddStringToObject(rule, "group", lf->generated_rule->group);
+    }
     if (lf->generated_rule->cve) {
         cJSON_AddStringToObject(rule, "cve", lf->generated_rule->cve);
     }

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -50,6 +50,12 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
         cJSON_AddStringToObject(rule, "info", lf->generated_rule->info);
     }
 
+    if( lf->decoder_info->name ) {
+        cJSON_AddStringToObject(root, "decoder", lf->decoder_info->name);
+    }
+    if( lf->decoder_info->parent ) {
+        cJSON_AddStringToObject(root, "decoder_parent", lf->decoder_info->parent);
+    }
 
     if (lf->action) {
         cJSON_AddStringToObject(root, "action", lf->action);
@@ -119,9 +125,6 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if ( lf->data ) {
         cJSON_AddStringToObject(root, "data", lf->data);
     }
-    if ( lf->action ) {
-        cJSON_AddStringToObject(root, "action", lf->action);
-    }
     if ( lf->url ) {
         cJSON_AddStringToObject(root, "url", lf->url);
     }
@@ -130,6 +133,9 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     }
     if ( lf->status ) {
         cJSON_AddStringToObject(root, "status", lf->status);
+    }
+    if ( lf->hostname ) {
+        cJSON_AddStringToObject(root, "hostname", lf->hostname);
     }
     if ( lf->program_name ) {
         cJSON_AddStringToObject(root, "program_name", lf->program_name);


### PR DESCRIPTION
This removes the double addition of the 'action' field and adds a few other interesting fields that I need for my analysis in ELK.  Most notably,  the rule.group is now passed out via the zmq output.