### PR TITLE
Json GEOIP output switch

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -27,6 +27,8 @@ analysisd.fts_min_size_for_str=14
 # 1 to enable, 0 to disable.
 analysisd.log_fw=1
 
+# Output GeoIP data at JSON alerts
+analysisd.geoip_jsonout=0
 
 # Logcollector file loop timeout (check every 2 seconds for file changes)
 logcollector.loop_timeout=2

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -228,6 +228,8 @@ int main_analysisd(int argc, char **argv)
 
 
 #ifdef LIBGEOIP_ENABLED
+     Config.geoip_jsonout = getDefine_Int("analysisd", "geoip_jsonout", 0, 1);
+
     /* Opening GeoIP DB */
     if(Config.geoipdb_file) {
         geoipdb = GeoIP_open(Config.geoipdb_file, GEOIP_INDEX_CACHE);

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -69,9 +69,13 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->srcip) {
         cJSON_AddStringToObject(root, "srcip", lf->srcip);
     }
-    if (lf->srcgeoip) {
+
+#ifdef LIBGEOIP_ENABLED
+    if (lf->srcgeoip && Config.geoip_jsonout) {
         cJSON_AddStringToObject(root, "srcgeoip", lf->srcgeoip);
     }
+#endif
+
     if (lf->srcport) {
         cJSON_AddStringToObject(root, "srcport", lf->srcport);
     }
@@ -81,9 +85,12 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->dstip) {
         cJSON_AddStringToObject(root, "dstip", lf->dstip);
     }
-    if (lf->dstgeoip) {
+#ifdef LIBGEOIP_ENABLED
+    if (lf->dstgeoip && Config.geoip_jsonout) {
         cJSON_AddStringToObject(root, "dstgeoip", lf->dstgeoip);
     }
+#endif
+
     if (lf->dstport) {
         cJSON_AddStringToObject(root, "dstport", lf->dstport);
     }

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -12,6 +12,7 @@
 #include "shared.h"
 #include "rules.h"
 #include "cJSON.h"
+#include "config.h"
 
 
 /* Convert Eventinfo to json */

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -90,6 +90,7 @@ typedef struct __Config {
     u_int8_t loggeoip;
     char *geoip_db_path;
     char *geoip6_db_path;
+    int geoip_jsonout;
 #endif
 
 } _Config;


### PR DESCRIPTION

The following needs to be added to documentation for the JSON output / internal options:

Internal options setting:

analysisd.geoip_jsonout=0

0 disabled
1 enabled