### PR TITLE
Modify rule token different_geoip rule  to different_srcgeoip

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -235,7 +235,7 @@ int main_analysisd(int argc, char **argv)
         geoipdb = GeoIP_open(Config.geoipdb_file, GEOIP_INDEX_CACHE);
         if (geoipdb == NULL)
         {
-            merror("%s: Unable to open GeoIP database from: %s (disabling GeoIP).", ARGV0, Config.geoipdb_file);
+            merror("%s: ERROR: Unable to open GeoIP database from: %s (disabling GeoIP).", ARGV0, Config.geoipdb_file);
         }
     }
 #endif

--- a/src/analysisd/decoders/geoip.c
+++ b/src/analysisd/decoders/geoip.c
@@ -47,7 +47,7 @@ char *GetGeoInfobyIP(char *ip_addr)
         return(NULL);
     }
     
-    if(geoiprecord->country_code == NULL || geoiprecord->country_code == NULL)
+    if(geoiprecord->country_code == NULL)
     {
         GeoIPRecord_delete(geoiprecord);
         return(NULL);

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -135,6 +135,17 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
             }
         }
 
+        /* GEOIP version of check for repetitions from same src_ip */
+        if (rule->context_opts & DIFFERENT_SRCGEOIP) {
+            if ((!lf->srcgeoip) || (!my_lf->srcgeoip)) {
+                continue;
+            }
+
+            if (strcmp(lf->srcgeoip, my_lf->srcgeoip) == 0) {
+                continue;
+            }
+        }
+
         /* Check if the number of matches worked */
         if (rule->__frequency <= 10) {
             rule->last_events[rule->__frequency]
@@ -402,6 +413,8 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
                 continue;
             }
         }
+
+
 
 
         /* Check if the number of matches worked */

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -112,7 +112,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
     const char *xml_different_url = "different_url";
     const char *xml_different_srcip = "different_srcip";
-    const char *xml_different_geoip = "different_geoip";
+    const char *xml_different_geoip = "different_srcgeoip";
 
     const char *xml_notsame_source_ip = "not_same_source_ip";
     const char *xml_notsame_user = "not_same_user";
@@ -825,8 +825,8 @@ int Rules_OP_ReadRules(const char *rulefile)
                         if(!(config_ruleinfo->alert_opts & SAME_EXTRAINFO))
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
                     } else if(strcmp(rule_opt[k]->element,
-                                   xml_different_geoip) == 0) {
-                        config_ruleinfo->context_opts|= DIFFERENT_GEOIP;
+                                   xml_different_srcgeoip) == 0) {
+                        config_ruleinfo->context_opts|= DIFFERENT_SRCGEOIP;
 
                         if(!(config_ruleinfo->alert_opts & SAME_EXTRAINFO))
                             config_ruleinfo->alert_opts |= SAME_EXTRAINFO;
@@ -1228,6 +1228,10 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Mark rules that match this id */
                 OS_MarkID(NULL, config_ruleinfo);
+
+                /* Set function pointer */
+                config_ruleinfo->event_search = (void *(*)(void *, void *))
+                    Search_LastEvents;
             }
 
             /* Mark the rules that match if_matched_group */

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -112,7 +112,7 @@ int Rules_OP_ReadRules(const char *rulefile)
 
     const char *xml_different_url = "different_url";
     const char *xml_different_srcip = "different_srcip";
-    const char *xml_different_geoip = "different_srcgeoip";
+    const char *xml_different_srcgeoip = "different_srcgeoip";
 
     const char *xml_notsame_source_ip = "not_same_source_ip";
     const char *xml_notsame_user = "not_same_user";

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -25,7 +25,7 @@
 #define SAME_LOCATION   0x008 /* 8   */
 #define DIFFERENT_URL   0x010 /* */
 #define DIFFERENT_SRCIP 0x200 
-#define DIFFERENT_GEOIP 0x400 
+#define DIFFERENT_SRCGEOIP 0x400 
 #define SAME_SRCPORT    0x020
 #define SAME_DSTPORT    0x040
 #define SAME_DODIFF     0x100

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -21,7 +21,7 @@
 #define SAME_LOCATION   0x008 /* 8   */
 #define DIFFERENT_URL   0x010
 #define DIFFERENT_SRCIP 0x200
-#define DIFFERENT_GEOIP 0x400 
+#define DIFFERENT_SRCGEOIP 0x400 
 #define SAME_SRCPORT    0x020
 #define SAME_DSTPORT    0x040
 #define SAME_DODIFF     0x100


### PR DESCRIPTION
This changes the token for different_geoip to 
different_srcgeoip. This is to allow for different_dstgeoip in the future. 

example rule:
```
  <rule id="5749" level="6" frequency="1" timeframe="28800">
    <if_matched_sid>5715</if_matched_sid>
    <same_user />
    <different_srcgeoip />
    <description>Multiple successful logins from same user from different countries.</description>
    <group>behaviour_anomaly,</group>
  </rule>
```
