### PR TITLE
fix memory leak in decode-xml.c

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -294,6 +294,7 @@ int ReadDecodeXML(const char *file)
         /* Add decoder */
         if (!addDecoder2list(pi->name)) {
             merror(MEM_ERROR, ARGV0, errno, strerror(errno));
+            free(pi);
             return (0);
         }
 


### PR DESCRIPTION
On line no. 298 of '[decode-xml.c](https://github.com/ossec/ossec-hids/blob/master/src/analysisd/decoders/decode-xml.c#L297)' there is a memory leak, which is a bug. Memory is a finite resource within running programs, and failing to free memory means consuming a finite resource without replenishing it.  Eventually memory will run out and this program will crash.

Found by https://github.com/bryongloden/cppcheck

