### PR TITLE
fix common realloc mistake in custom_output_search_replace.c

### DIFF
--- a/src/shared/custom_output_search_replace.c
+++ b/src/shared/custom_output_search_replace.c
@@ -10,6 +10,7 @@ char *searchAndReplace(const char *orig, const char *search, const char *value)
 
     size_t inx_start;
     char *tmp = NULL;
+    char *tmp2 = NULL;
     size_t tmp_offset = 0;
     size_t total_bytes_allocated = 1;
     size_t from;
@@ -36,29 +37,36 @@ char *searchAndReplace(const char *orig, const char *search, const char *value)
     while (p != NULL) {
         /* Copy replacement */
         total_bytes_allocated += value_len;
-        tmp = (char *) realloc(tmp, total_bytes_allocated);
-        strncpy(tmp + tmp_offset, value, value_len);
-        tmp_offset += value_len;
+        tmp2 = (char *) realloc(tmp, total_bytes_allocated);
 
-        /* Search for further occurrences */
-        p = strstr(orig + inx_start + search_len, search);
-        if (p != NULL) {
-            size_t inx_start2 = (size_t) (p - orig);
+        if (tmp2 != NULL) {
+            tmp = tmp2;
+            strncpy(tmp + tmp_offset, value, value_len);
+            tmp_offset += value_len;
 
-            /* Copy content between matches, if any */
-            if (inx_start2 > from) {
-                size_t gap = inx_start2 - from;
-                total_bytes_allocated += gap;
-                tmp = (char *) realloc(tmp, total_bytes_allocated);
-                strncpy(tmp + tmp_offset, orig + from, gap);
-                tmp_offset += gap;
+            /* Search for further occurrences */
+            p = strstr(orig + inx_start + search_len, search);
+            if (p != NULL) {
+                size_t inx_start2 = (size_t) (p - orig);
+
+                /* Copy content between matches, if any */
+                if (inx_start2 > from) {
+                    size_t gap = inx_start2 - from;
+                    total_bytes_allocated += gap;
+                    tmp = (char *) realloc(tmp, total_bytes_allocated);
+                    strncpy(tmp + tmp_offset, orig + from, gap);
+                    tmp_offset += gap;
+                }
+
+                inx_start = inx_start2;
             }
 
-            inx_start = inx_start2;
+            /* Set position for copying content after last match */
+            from = inx_start + search_len;
+        } else {
+            free(tmp);
+            /* And handle error */
         }
-
-        /* Set position for copying content after last match */
-        from = inx_start + search_len;
     }
 
     /* Copy content after last match, if any */


### PR DESCRIPTION
Passing one pointer into realloc() and assigning the result directly into that same pointer variable can cause a memory leak if the reallocation fails, because the original allocation will still exist. The correct way to do this is to use a temporary pointer variable.

Found by https://github.com/bryongloden/cppcheck