### PR TITLE
Create OSSEC users and group as system members

### DIFF
--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -49,8 +49,8 @@ else
 	# All current linux distributions should support system accounts for
 	# users/groups. If not, leave the GROUPADD/USERADD as it was before
 	# this change
-	sys_acct_chk () { 
-	    $1 --help | grep -e " *-r.*system account" >/dev/null 2>&1 && echo "$1 -r" || echo "$1"
+	sys_acct_chk () {
+	    $1 --help 2>&1 | grep -e " *-r.*system account" >/dev/null 2>&1 && echo "$1 -r" || echo "$1"
 	  }
 	GROUPADD=$(sys_acct_chk "/usr/sbin/groupadd")
 	USERADD=$(sys_acct_chk "/usr/sbin/useradd")

--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -46,8 +46,14 @@ else
         USERADD="/usr/sbin/useradd"
         OSMYSHELL="/bin/false"
     else
-        GROUPADD="/usr/sbin/groupadd"
-        USERADD="/usr/sbin/useradd"
+	# All current linux distributions should support system accounts for
+	# users/groups. If not, leave the GROUPADD/USERADD as it was before
+	# this change
+	sys_acct_chk () { 
+	    $1 --help | grep -e " *-r.*system account" >/dev/null 2>&1 && echo "$1 -r" || echo "$1"
+	  }
+	GROUPADD=$(sys_acct_chk "/usr/sbin/groupadd")
+	USERADD=$(sys_acct_chk "/usr/sbin/useradd")
         OSMYSHELL="/sbin/nologin"
     fi
 


### PR DESCRIPTION
This commit was originally uploaded to the Wazuh repository by @DLGolden:

>This change causes the Linux groupadd and useradd to flag the ossec group and users as system accounts. This is supported by every Linux system that I have researched and should be all; however, if for some reason the system account option is not supported, it will add the group and users exactly as it did prior to the change.