### PR TITLE
Don't pass null variables to snprintf.

### DIFF
--- a/src/os_dbd/alert.c
+++ b/src/os_dbd/alert.c
@@ -167,8 +167,10 @@ int OS_Alert_InsertDB(const alert_data *al_data, DBConfig *db_config)
                  db_config->server_id, al_data->rule,
                  al_data->level,
                  (unsigned int)time(0), *loc_id,
-                 al_data->srcip, (unsigned short)s_port,
-                 al_data->dstip, (unsigned short)d_port,
+                 al_data->srcip,
+                 (unsigned short)s_port,
+                 al_data->dstip,
+                 (unsigned short)d_port,
                  al_data->alertid,
                  al_data->user, fulllog, al_data->srcgeoip);
 	break;
@@ -181,10 +183,13 @@ int OS_Alert_InsertDB(const alert_data *al_data, DBConfig *db_config)
                  db_config->server_id, al_data->rule,
                  al_data->level,
                  (unsigned int)time(0), *loc_id,
-                 al_data->srcip, (unsigned short)s_port,
-                 al_data->dstip, (unsigned short)d_port,
+                 al_data->srcip != NULL ? al_data->srcip : "NULL",
+                 (unsigned short)s_port,
+                 al_data->dstip != NULL ? al_data->dstip : "NULL",
+                 (unsigned short)d_port,
                  al_data->alertid,
-                 al_data->user, fulllog);
+                 al_data->user != NULL ? al_data->user : "NULL",
+                 fulllog);
 	break;
     }
 

--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -159,8 +159,13 @@ int main(int argc, char **argv)
 
     /* Maybe disable this debug? */
     debug1("%s: DEBUG: Connecting to '%s', using '%s', '%s', '%s', %d,'%s'.",
-           ARGV0, db_config.host, db_config.user,
-           db_config.pass, db_config.db, db_config.port, db_config.sock);
+           ARGV0,
+           db_config.host != NULL ? db_config.host : "NoHost",
+           db_config.user != NULL ? db_config.user : "NoUser",
+           db_config.pass != NULL ? db_config.pass : "NoPass",
+           db_config.db != NULL ? db_config.db : "NoDB",
+           db_config.port,
+           db_config.sock != NULL ? db_config.sock : "NoSock");
 
     /* Set config pointer */
     osdb_setconfig(&db_config);

--- a/src/os_dbd/rules.c
+++ b/src/os_dbd/rules.c
@@ -203,7 +203,8 @@ static void *_Rules_ReadInsertDB(RuleInfo *rule, void *db_config)
              "REPLACE INTO "
              "signature(rule_id, level, description) "
              "VALUES ('%u','%u','%s')",
-             rule->sigid, rule->level, rule->comment);
+             rule->sigid, rule->level,
+             rule->comment != NULL ? rule->comment : "NULL");
 
     /* XXX We don't actually insert!?
     if(!osdb_query_insert(dbc->conn, sql_query))


### PR DESCRIPTION
New logging from OpenBSD alerted me to the problem:

```
Sep  1 13:48:12 ix ossec-dbd: vfprintf %s NULL in "INSERT INTO alert(server_id,rule_id,level,timestamp,location_id,src_ip,src_port,dst_ip,dst_port,alertid,"user",full_log) VALUES ('%u', '%u','%u','%u', '%u', '%s', '%u', '%s', '%u', '%s', '%s', '%s')"
Sep  1 13:51:37 ix ossec-dbd: vfprintf %s NULL in "%s: DEBUG: Connecting to '%s', using '%s', '%s', '%s', %d,'%s'."
Sep  1 13:51:42 ix ossec-dbd: vfprintf %s NULL in "REPLACE INTO signature(rule_id, level, description) VALUES ('%u','%u','%s')"
Sep  1 13:53:01 ix ossec-dbd: vfprintf %s NULL in "REPLACE INTO signature(rule_id, level, description) VALUES ('%u','%u','%s')"
```

I'm not entirely sure it's all fixed yet, but putting this here so I at least don't forget about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/944)
<!-- Reviewable:end -->
