### PR TITLE
A more thorough sudo decoder

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -456,8 +456,8 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   -->
 <decoder name="sudo">
   <program_name>^sudo</program_name>
-  <regex>^\s+(\S+)\s:</regex>
-  <order>user</order>
+  <regex>^\s+(\S+)\s:\sTTY=\S+\s;\sPWD=(\S+)\s;\sUSER=(\S+)\s;\sCOMMAND=(\.+)$</regex>
+  <order>id,url,dstuser,status</order>
   <fts>name,user,location</fts>
   <ftscomment>First time user executed the sudo command</ftscomment>
 </decoder>


### PR DESCRIPTION
 that pulls more information out of the log. Independently written by me and Jon Schipp who tossed his
into the ether at https://komunity.komand.com/learn/article/ossec-series-configuration-pitfalls/