### PR TITLE
Prevent manage_agents from doing invalid actions on interactive mode

### DIFF
--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -248,14 +248,26 @@ int main(int argc, char **argv)
         switch (user_msg[0]) {
             case 'A':
             case 'a':
+#ifdef CLIENT
+                printf("\n ** Agent adding only available on a master ** \n\n");
+                break;
+#endif
                 add_agent();
                 break;
             case 'e':
             case 'E':
+#ifdef CLIENT
+                printf("\n ** Key export only available on a master ** \n\n");
+                break;
+#endif
                 k_extract(NULL);
                 break;
             case 'i':
             case 'I':
+#ifndef CLIENT
+                printf("\n ** Key import only available on an agent ** \n\n");
+                break;
+#endif
                 k_import(NULL);
                 break;
             case 'l':
@@ -264,6 +276,10 @@ int main(int argc, char **argv)
                 break;
             case 'r':
             case 'R':
+#ifdef CLIENT
+                printf("\n ** Key removal only available on a master ** \n\n");
+                break;
+#endif
                 remove_agent();
                 break;
             case 'q':
@@ -294,4 +310,3 @@ int main(int argc, char **argv)
 
     return (0);
 }
-


### PR DESCRIPTION
Despite `manage_agents` doesn't allow neither importing keys in a manager nor creating, removing or extracting keys in the agent version when executing from the command line, those operations are not controlled in the interactive mode. This could be dangerous since importing accidentally a key into a manger would erase the `client.keys` file.

This change makes the interactive mode to behave like the command line mode.