### PR TITLE
Fixed FTS fetching at su decoder

### DIFF
--- a/contrib/ossec-testing/tests/su.ini
+++ b/contrib/ossec-testing/tests/su.ini
@@ -18,8 +18,8 @@ alert = 5
 decoder = su
 
 
-[su: work]
+[su: work fts]
 log 1 pass = Apr 22 17:51:51 enigma su: dcid to root on /dev/ttyp1
-rule = 5303
-alert = 3
+rule = 5305
+alert = 4
 decoder = su

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -496,18 +496,19 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <order>user</order>
 </decoder>
 
-<decoder name="su-detail2">
-  <parent>su</parent>
-  <regex>^BAD SU (\S+) to (\S+) on|</regex>
-  <regex>^failed: \S+ changing from (\S+) to (\S+)|</regex>
-  <regex>^\S \S+ (\S+)\p(\S+)$|^(\S+) to (\S+) on </regex>
+<decoder name="su">
+  <prematch>^SU \S+ \S+ </prematch>
+  <regex offset="after_prematch">^\S \S+ (\S+)-(\S+)$</regex>
   <order>srcuser, dstuser</order>
   <fts>name, srcuser, location</fts>
 </decoder>
 
-<decoder name="su">
-  <prematch>^SU \S+ \S+ </prematch>
-  <regex offset="after_prematch">^\S \S+ (\S+)-(\S+)$</regex>
+<decoder name="su-detail2">
+  <parent>su</parent>
+  <prematch> </prematch>
+  <regex>^BAD SU (\S+) to (\S+) on|</regex>
+  <regex>^failed: \S+ changing from (\S+) to (\S+)|</regex>
+  <regex>^\S \S+ (\S+)\p(\S+)$|^(\S+) to (\S+) on </regex>
   <order>srcuser, dstuser</order>
   <fts>name, srcuser, location</fts>
 </decoder>


### PR DESCRIPTION
The `su` decoder has a child, `su-detail2` with a FTS field group that will never fetch with the event since it has no `prematch` expression.

We changed the order of the decoders at the file and added a simple `prematch` in order to make the event to select the decoder and be able to use the FTS.

We also modified a rule test to prove this change.