### PR TITLE
Set more options from internal_options.conf on win32

### DIFF
--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -140,6 +140,8 @@ int local_start()
     }
     accept_manager_commands = getDefine_Int("logcollector",
                                             "remote_commands", 0, 1);
+    loop_timeout = getDefine_Int("logcollector",  "loop_timeout", 1, 120);
+    open_file_attempts = getDefine_Int("logcollector", "open_attempts", 2, 998);
 
     /* Configuration file not present */
     if (File_DateofChange(cfg) < 0) {


### PR DESCRIPTION
This was submitted in issue #976 by th0u.
loop_timeout and open_file_attempts are read by logcollector/main.c
 but not in win32/win_agent.c. This could be an issue for win32 agents.
