### PR TITLE
Fixed some bugs referred to GeoIP

### DIFF
--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -84,11 +84,11 @@ void OS_LogOutput(Eventinfo *lf)
 {
 #ifdef LIBGEOIP_ENABLED
     if (Config.geoipdb_file) {
-        if (lf->srcip) {
-                lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
+        if (lf->srcip && !lf->srcgeoip) {
+            lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
         }
-        if (lf->dstip) {
-                lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
+        if (lf->dstip && !lf->dstgeoip) {
+            lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
         }
     }
 #endif
@@ -169,11 +169,11 @@ void OS_Log(Eventinfo *lf)
 {
 #ifdef LIBGEOIP_ENABLED
     if (Config.geoipdb_file) {
-        if (lf->srcip) {
-                lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
+        if (lf->srcip && !lf->srcgeoip) {
+            lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
         }
-        if (lf->dstip) {
-                lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
+        if (lf->dstip && !lf->dstgeoip) {
+            lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
         }
     }
 #endif

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1228,10 +1228,6 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                 /* Mark rules that match this id */
                 OS_MarkID(NULL, config_ruleinfo);
-
-                /* Set function pointer */
-                config_ruleinfo->event_search = (void *(*)(void *, void *))
-                    Search_LastEvents;
             }
 
             /* Mark the rules that match if_matched_group */


### PR DESCRIPTION
This change should fix two issues:

When parsing rules with option `<if_matched_sid>` the searching function is assigned to `Search_LastSids()` and then it's overwritten with `Search_LastEvents()` (for rules with `<check_diff>`). This was done at commit https://github.com/ossec/ossec-hids/commit/3a36fec6017d839f4dc9eba87663bfb1eef50072, in fact the code to compare the geolocation string appears on `Search_LastSids()` and not at `Search_LastEvents()`.

On the other hand, geolocation info is always reloaded when printing the alert, this may cause a memory leak. I propose to check that the geolocation string hasn't been yet created.