### PR TITLE
Prevent manage_agents from chrooting in bulk mode

### DIFF
--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -89,6 +89,9 @@ int main(int argc, char **argv)
     int ret;
 #endif
 
+    extern int willchroot;
+    willchroot = 1;
+
     /* Set the name */
     OS_SetName(ARGV0);
 
@@ -139,6 +142,7 @@ int main(int argc, char **argv)
                     ErrorExit("%s: -f needs an argument.", ARGV0);
                 }
                 cmdbulk = optarg;
+                willchroot = 0;
                 printf("Bulk load file: %s\n", cmdbulk);
                 break;
             case 'l':
@@ -175,7 +179,9 @@ int main(int argc, char **argv)
     }
 
     /* Inside chroot now */
-    nowChroot();
+    if(willchroot > 0) {
+        nowChroot();
+    }
 
     /* Start signal handler */
     StartSIG2(ARGV0, manage_shutdown);

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -39,6 +39,7 @@ static void helpmsg()
     print_out("    -i <id>     Import authentication key (Agent only)");
     print_out("    -f <file>   Bulk generate client keys from file (Manager only)");
     print_out("                <file> contains lines in IP,NAME format");
+    print_out("                <file> should also exist within /var/ossec due to manage_agents chrooting");
     exit(1);
 }
 

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -82,17 +82,27 @@ int add_agent()
     os_ip c_ip;
     c_ip.ip = NULL;
 
+    char authfile[257];
+
+    if(willchroot > 0) {
+        snprintf(authfile, 256, "%s", AUTH_FILE);	//XXX
+    } else {
+        const char *dir = DEFAULTDIR;
+        snprintf(authfile, 256, "%s/%s", dir, AUTH_FILE);	//XXX
+    }
+
+
     /* Check if we can open the auth_file */
-    fp = fopen(AUTH_FILE, "a");
+    fp = fopen(authfile, "a");
     if (!fp) {
-        ErrorExit(FOPEN_ERROR, ARGV0, AUTH_FILE, errno, strerror(errno));
+        ErrorExit(FOPEN_ERROR, ARGV0, authfile, errno, strerror(errno));
     }
     fclose(fp);
 
 
 #ifndef WIN32
-    if (chmod(AUTH_FILE, 0440) == -1) {
-        ErrorExit(CHMOD_ERROR, ARGV0, AUTH_FILE, errno, strerror(errno));
+    if (chmod(authfile, 0440) == -1) {
+        ErrorExit(CHMOD_ERROR, ARGV0, authfile, errno, strerror(errno));
     }
 #endif
 
@@ -169,10 +179,10 @@ int add_agent()
     do {
         /* Default ID */
         i = MAX_AGENTS + 32512;
-        snprintf(id, 8, "%03d", i);
+        snprintf(id, 8, "%03d", i);	//XXX
         while (!IDExist(id)) {
             i--;
-            snprintf(id, 8, "%03d", i);
+            snprintf(id, 8, "%03d", i);	//XXX
 
             /* No key present, use id 0 */
             if (i <= 0) {
@@ -246,12 +256,12 @@ int add_agent()
             time3 = time(0);
             rand2 = random();
 
-            fp = fopen(AUTH_FILE, "a");
+            fp = fopen(authfile, "a");
             if (!fp) {
                 ErrorExit(FOPEN_ERROR, ARGV0, KEYS_FILE, errno, strerror(errno));
             }
 #ifndef WIN32
-            chmod(AUTH_FILE, 0440);
+            chmod(authfile, 0440);
 #endif
 
             /* Random 1: Time took to write the agent information
@@ -298,6 +308,17 @@ int remove_agent()
     int id_exist;
 
     u_id[FILE_SIZE] = '\0';
+
+    extern int willchroot;
+    char authfile[257];
+    if(willchroot > 0) {
+        snprintf(authfile, 256, "%s", AUTH_FILE);	//XXX
+    } else {
+        const char *dir = DEFAULTDIR;
+        snprintf(authfile, 256, "%s/%s", dir, AUTH_FILE);	//XXX
+    }
+        
+
 
     if (!print_agents(0, 0, 0)) {
         printf(NO_AGENT);
@@ -356,13 +377,13 @@ int remove_agent()
                 return (1);
             }
 
-            fp = fopen(AUTH_FILE, "r+");
+            fp = fopen(authfile, "r+");
             if (!fp) {
                 free(full_name);
-                ErrorExit(FOPEN_ERROR, ARGV0, AUTH_FILE, errno, strerror(errno));
+                ErrorExit(FOPEN_ERROR, ARGV0, authfile, errno, strerror(errno));
             }
 #ifndef WIN32
-            chmod(AUTH_FILE, 0440);
+            chmod(authfile, 0440);
 #endif
 
             /* Remove the agent, but keep the id */

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -139,3 +139,6 @@ extern fpos_t fp_pos;
 #define GMF_ERROR       ARGV0 ": Could not run GetModuleFileName.\n"
 #define GMF_BUFF_ERROR  ARGV0 ": Could not get path because it is too long and was shrunk by (%d) characters with a max of (%d).\n"
 #define GMF_UNKN_ERROR  ARGV0 ": Could not run GetModuleFileName which returned (%ld).\n"
+
+
+int willchroot;


### PR DESCRIPTION
Currently using `-f` will fail because of attempts to access random, which isn't possible in the chroot (without extra work). Prevent the chroot in this mode. Fixes issue #454 
Not sure this is ready yet, I'm hoping for comments. This may be the wrong way to solve it (it feels like a hack instead of a proper fix).

TODO:

- Possibly remove the restriction of requiring the file to be in `/var/ossec`
- Check returns from snprintf
- Maybe check to make sure client.keys isn't a symlink.