### PR TITLE
Change the default AR level to 7. 

### DIFF
--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -146,7 +146,7 @@
       -->
     <command>host-deny</command>
     <location>local</location>
-    <level>6</level>
+    <level>7</level>
     <timeout>600</timeout>
   </active-response>
 
@@ -157,7 +157,7 @@
       -->
     <command>firewall-drop</command>
     <location>local</location>
-    <level>6</level>
+    <level>7</level>
     <timeout>600</timeout>    
   </active-response>  
 

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -150,7 +150,7 @@
       -->
     <command>host-deny</command>
     <location>local</location>
-    <level>6</level>
+    <level>7</level>
     <timeout>600</timeout>
   </active-response>
 
@@ -161,7 +161,7 @@
       -->
     <command>firewall-drop</command>
     <location>local</location>
-    <level>6</level>
+    <level>7</level>
     <timeout>600</timeout>    
   </active-response>  
 


### PR DESCRIPTION
The default email level is 7, and I'm not entirely convinced it's ok to block something automatically
with no notice whatsoever.
Brought up by Christina Plummer on the user list.