### PR TITLE
Another windows decoder bug fix

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1896,7 +1896,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="windows1">
   <type>windows</type>
   <parent>windows</parent>
-  <regex offset="after_parent">^\.+: (\w+)\(\d+\): (\.+): </regex>
+  <regex offset="after_parent">^\.+: (\w+)\((\d+)\): (\.+): </regex>
   <regex>(\.+): \.+: (\S+): </regex>
   <order>status, id, extra_data, user, system_name</order>
   <fts>name, location, system_name</fts>


### PR DESCRIPTION
Missing '()' around the event id. This caused the wrong information to get put in the wrong buckets.
Found when looking at the decoder based on a message from Kevin Branch
on the user list.
Previously:
```
# /var/ossec/bin/ossec-logtest -q
2016 Nov 18 10:37:26 WinEvtLog: Application: INFORMATION(302): ESENT:
(no user): no domain: BNC-O9020: Music.UI (25428)
{87E550B7-AD4D-40F7-BE5E-263C3D44C124}: The database engine has
successfully completed recovery steps.2016/11/21 08:05:49

**Phase 1: Completed pre-decoding.
       full event: '2016 Nov 18 10:37:26 WinEvtLog: Application:
INFORMATION(302): ESENT: (no user): no domain: BNC-O9020: Music.UI
(25428) {87E550B7-AD4D-40F7-BE5E-263C3D44C124}: The database engine
has successfully completed recovery steps.'
       hostname: 'ix'
       program_name: 'WinEvtLog'
       log: 'Application: INFORMATION(302): ESENT: (no user): no
domain: BNC-O9020: Music.UI (25428)
{87E550B7-AD4D-40F7-BE5E-263C3D44C124}: The database engine has
successfully completed recovery steps.'

**Phase 2: Completed decoding.
       decoder: 'windows'
       status: 'INFORMATION'
       id: 'ESENT'
       extra_data: '(no user)'
       dstuser: 'BNC-O9020'
```

Current:
```
**Phase 1: Completed pre-decoding.
       full event: '2016 Nov 18 10:37:26 WinEvtLog: Application: INFORMATION(302): ESENT: (no user): no domain: BNC-O9020: Music.UI (25428) {87E550B7-AD4D-40F7-BE5E-263C3D44C124}: The database engine has successfully completed recovery steps.'
       hostname: 'ix'
       program_name: 'WinEvtLog'
       log: 'Application: INFORMATION(302): ESENT: (no user): no domain: BNC-O9020: Music.UI (25428) {87E550B7-AD4D-40F7-BE5E-263C3D44C124}: The database engine has successfully completed recovery steps.'

**Phase 2: Completed decoding.
       decoder: 'windows'
       status: 'INFORMATION'
       id: '302'
       extra_data: 'ESENT'
       dstuser: '(no user)'
       system_name: 'BNC-O9020'
```