### PR TITLE
Added 'auth failed' pattern to dovecot rule 9705

### DIFF
--- a/etc/rules/dovecot_rules.xml
+++ b/etc/rules/dovecot_rules.xml
@@ -41,7 +41,7 @@
 
 <rule id="9705" level="5">
   <if_sid>9700</if_sid>
-  <match>user not found|User not known|unknown user</match>
+  <match>user not found|User not known|unknown user|auth failed</match>
   <description>Dovecot Invalid User Login Attempt.</description>
   <group>invalid_login,authentication_failed,</group>
 </rule>


### PR DESCRIPTION
On my server, dovecot `2.2.26.0` logs following messages on authentication failures:
```
Dec 19 06:21:06 ny dovecot: imap-login: Disconnected (auth failed, 7 attempts in 111 secs): user=<thousands>, method=PLAIN, rip=109.201.200.201, lip=67.205.141.203, sessi
on=<+hgd5vxDBMZtycjJ>
```

They are not covered by existing dovecot rules. My change aims to fix this.