### PR TITLE
Duplicated group field in alerts.json output.

### DIFF
--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -33,11 +33,6 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
 
     cJSON_AddNumberToObject(rule, "level", lf->generated_rule->level);
 
-    if (lf->generated_rule->group) {
-        cJSON_AddStringToObject(rule, "group", lf->generated_rule->group);
-    }
-
-
     if (lf->generated_rule->comment) {
         cJSON_AddStringToObject(rule, "comment", lf->generated_rule->comment);
     }


### PR DESCRIPTION
The group field is duplicated in alerts.json, and it shouldn't be. So let's not do that.
Found with http://jsonlint.com/