### PR TITLE
Some memory fixes

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -294,6 +294,7 @@ int ReadDecodeXML(const char *file)
         /* Add decoder */
         if (!addDecoder2list(pi->name)) {
             merror(MEM_ERROR, ARGV0, errno, strerror(errno));
+            free(pi->name);
             free(pi);
             return (0);
         }

--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -63,7 +63,7 @@ int connect_to_remoted(void);
  * agentless logs octal permissions, local syscheck decimal st_mode
  * Returns a pointer to a local static array
  */
-char *agent_file_perm(char *perm);
+const char *agent_file_perm(char *perm);
 #endif
 
 /* Sends a message to an agent
@@ -82,4 +82,3 @@ int send_msg_to_agent(int msocket, const char *msg, const char *agt_id, const ch
 #define GA_STATUS_INV       14
 
 #endif
-

--- a/src/shared/custom_output_search_replace.c
+++ b/src/shared/custom_output_search_replace.c
@@ -10,7 +10,6 @@ char *searchAndReplace(const char *orig, const char *search, const char *value)
 
     size_t inx_start;
     char *tmp = NULL;
-    char *tmp2 = NULL;
     size_t tmp_offset = 0;
     size_t total_bytes_allocated = 1;
     size_t from;
@@ -37,42 +36,36 @@ char *searchAndReplace(const char *orig, const char *search, const char *value)
     while (p != NULL) {
         /* Copy replacement */
         total_bytes_allocated += value_len;
-        tmp2 = (char *) realloc(tmp, total_bytes_allocated);
+        os_realloc(tmp, total_bytes_allocated, tmp);
 
-        if (tmp2 != NULL) {
-            tmp = tmp2;
-            strncpy(tmp + tmp_offset, value, value_len);
-            tmp_offset += value_len;
+        strncpy(tmp + tmp_offset, value, value_len);
+        tmp_offset += value_len;
 
-            /* Search for further occurrences */
-            p = strstr(orig + inx_start + search_len, search);
-            if (p != NULL) {
-                size_t inx_start2 = (size_t) (p - orig);
+        /* Search for further occurrences */
+        p = strstr(orig + inx_start + search_len, search);
+        if (p != NULL) {
+            size_t inx_start2 = (size_t) (p - orig);
 
-                /* Copy content between matches, if any */
-                if (inx_start2 > from) {
-                    size_t gap = inx_start2 - from;
-                    total_bytes_allocated += gap;
-                    tmp = (char *) realloc(tmp, total_bytes_allocated);
-                    strncpy(tmp + tmp_offset, orig + from, gap);
-                    tmp_offset += gap;
-                }
-
-                inx_start = inx_start2;
+            /* Copy content between matches, if any */
+            if (inx_start2 > from) {
+                size_t gap = inx_start2 - from;
+                total_bytes_allocated += gap;
+                os_realloc(tmp, total_bytes_allocated, tmp);
+                strncpy(tmp + tmp_offset, orig + from, gap);
+                tmp_offset += gap;
             }
 
-            /* Set position for copying content after last match */
-            from = inx_start + search_len;
-        } else {
-            free(tmp);
-            /* And handle error */
+            inx_start = inx_start2;
         }
+
+        /* Set position for copying content after last match */
+        from = inx_start + search_len;
     }
 
     /* Copy content after last match, if any */
     if ((from < orig_len) && from > 0) {
         total_bytes_allocated += orig_len - from;
-        tmp = (char *) realloc(tmp, total_bytes_allocated);
+        os_realloc(tmp, total_bytes_allocated, tmp);
         strncpy(tmp + tmp_offset, orig + from, orig_len - from);
     }
 

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -863,7 +863,7 @@ int connect_to_remoted()
     return (arq);
 }
 
-char *agent_file_perm(char *perm) 
+const char *agent_file_perm(char *perm)
 {
 	/* rwxrwxrwx0 -> 10 */
 	static char permissions[10];
@@ -881,6 +881,7 @@ char *agent_file_perm(char *perm)
 	permissions[6] = (mode & S_IROTH) ? 'r' : '-';
 	permissions[7] = (mode & S_IWOTH) ? 'w' : '-';
 	permissions[8] = (mode & S_ISVTX) ? 't' : (mode & S_IXOTH) ? 'x' : '-';
+    permissions[9] = '\0';
 
 	return &permissions[0];
 }
@@ -1251,4 +1252,3 @@ char **get_agents(int flag)
     closedir(dp);
     return (f_files);
 }
-


### PR DESCRIPTION
Hi,

I propose these changes, that should fix three issues detected from previous commits:

1. PR https://github.com/ossec/ossec-hids/pull/930 prevents a memory leak by freeing `pi` structure, but `pi->name` should be deleted before.

2. At function https://github.com/ossec/ossec-hids/pull/885/commits/09e9f5be4c5bd81463217e73f42143cecf1199d8#diff-7c75ce14fc99e77cf2ac6208fbb99946R1233 a string is created and filled but neither it's not initialized. We'll write the last NULL character and declare the function as returning a constant string.

3. At PR https://github.com/ossec/ossec-hids/pull/931 a test to check that `realloc` returns a valid pointer is performed, but in case of error, old memory is freed and the loop continues using the variable pointing to an invalid address. `os_realloc` checks whether memory is available and if it isn't, will make the program to exit.

Best regards.

