### PR TITLE
sshd support for maximum auth attempts logs

### DIFF
--- a/contrib/ossec-testing/tests/sshd.ini
+++ b/contrib/ossec-testing/tests/sshd.ini
@@ -139,3 +139,10 @@ rule = 5757
 alert = 0
 decoder = sshd
 
+[max auth attempts]
+log 1 pass = Dec 27 03:23:51 r1 sshd[21183]: error: maximum authentication attempts exceeded for root from 183.106.179.x port 34100 ssh2 [preauth]
+
+rule = 5758
+alert = 8
+decoder = sshd
+

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -302,7 +302,7 @@
 </decoder>
 -->
 
-<decoder name="ssh-exceed">
+<decoder name="sshd-exceed">
   <parent>sshd</parent>
   <prematch> exceeded for </prematch>
   <regex offset="after_prematch">^(\S+) from (\S+) port (\d+) </regex>

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -302,6 +302,14 @@
 </decoder>
 -->
 
+<decoder name="ssh-exceed">
+  <parent>sshd</parent>
+  <prematch> exceeded for </prematch>
+  <regex offset="after_prematch">^(\S+) from (\S+) port (\d+) </regex>
+  <order>user, srcip, srcport</order>
+</decoder>
+
+
 <!-- Dropbear rules -->
 <decoder name="dropbear">
   <program_name>^dropbear</program_name>

--- a/etc/rules/sshd_rules.xml
+++ b/etc/rules/sshd_rules.xml
@@ -393,6 +393,12 @@
     <description>Bad DNS mapping.</description>
   </rule>
 
+  <rule id="5758" level="8">
+    <decoded_as>sshd</decoded_as>
+    <match>^error: maximum authentication attempts exceeded </match>
+    <description>Maximum authentication attempts exceeded.</description>
+    <group>authentication_failed,</group>
+  </rule>
 
 </group> <!-- SYSLOG, SSHD -->
 


### PR DESCRIPTION
Add a rule, decoder, and test for max auth attempt messages

```
Dec 27 03:23:51 r1 sshd[21183]: error: maximum authentication attempts exceeded for root from 183.106.179.x port 34100 ssh2 [preauth]
```

This should complete issue #1012

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1013)
<!-- Reviewable:end -->
