### PR TITLE
Fix missing "fi" in ossec-control (server version) startup() script.

### DIFF
--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -219,6 +219,7 @@ start()
             else
                 echo "${i} already running..."
             fi
+        fi
     done
 
     # After we start we give 2 seconds for the daemons


### PR DESCRIPTION
The template that ultimately becomes ossec-control has a missing "fi".  It _seems_ that the only effect was throwing an error message (because it interpreted the "done" as closing the if block), but this should at least fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1014)
<!-- Reviewable:end -->
