### PR TITLE
Fix bug that prevents ossec-control from starting ossec-maild on server

### DIFF
--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -204,21 +204,20 @@ start()
              if [ $? = 0 ]; then
                  continue
              fi
-        else
+        fi
 
-            pstatus ${i};
-            if [ $? = 0 ]; then
-                ${DIR}/bin/${i} ${DEBUG_CLI};
-                if [ $? != 0 ]; then
-                    echo "${i} did not start correctly.";
-                    unlock;
-                    exit 1;
-                fi
-
-                echo "Started ${i}..."
-            else
-                echo "${i} already running..."
+        pstatus ${i};
+        if [ $? = 0 ]; then
+            ${DIR}/bin/${i} ${DEBUG_CLI};
+            if [ $? != 0 ]; then
+                echo "${i} did not start correctly.";
+                unlock;
+                exit 1;
             fi
+
+            echo "Started ${i}..."
+        else
+            echo "${i} already running..."
         fi
     done
 

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -219,6 +219,7 @@ start()
             else
                 echo "${i} already running..."
             fi
+        fi
     done
 
     # After we start we give 2 seconds for the daemons


### PR DESCRIPTION
An "else" instead of "fi" (introduced in commit 89e7f5e)
was causing the the actual start up of ossec-maild to be skipped, even if the XML tag was
set to "yes".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1016)
<!-- Reviewable:end -->
