### PR TITLE
Remoted canary violation

### DIFF
--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -214,7 +214,6 @@ start()
                 unlock;
                 exit 1;
             fi
-	fi
     done
 
     # After we start we give 2 seconds for the daemons

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -214,6 +214,11 @@ start()
                 unlock;
                 exit 1;
             fi
+
+            echo "Started ${i}..."
+        else
+            echo "${i} already running..."
+        fi
     done
 
     # After we start we give 2 seconds for the daemons

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -219,6 +219,7 @@ start()
             else
                 echo "${i} already running..."
             fi
+	fi
     done
 
     # After we start we give 2 seconds for the daemons

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -269,7 +269,8 @@ int OS_IsValidIP(const char *in_address, os_ip *final_ip)
      * return true if the os_ip.ip element is 'any'
      */
     if(strcmp(ip_address, "any") == 0) {
-        strcpy(ip_address, "::/0");
+        //strcpy(ip_address, "::/0");
+	os_strdup("::/0", ip_address);
     }
 
     /* Getting the cidr/netmask if available */
@@ -329,12 +330,7 @@ int OS_IsValidIP(const char *in_address, os_ip *final_ip)
 
     freeaddrinfo(result);
 
-    /* XXX
-     * The following free creates an error on OpenBSD with malloc options SC:
-     * ossec-remoted(55078) in free(): chunk canary corrupted 0x1bae51e6c910 0x4@0x4
-     * This causes remoted to fail, which might be a bad thing.
-     */
-    //free(ip_address);
+    free(ip_address);
     return((cidr >= 0) ? 2 : 1);
 }
 

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -328,7 +328,13 @@ int OS_IsValidIP(const char *in_address, os_ip *final_ip)
     }
 
     freeaddrinfo(result);
-    free(ip_address);
+
+    /* XXX
+     * The following free creates an error on OpenBSD with malloc options SC:
+     * ossec-remoted(55078) in free(): chunk canary corrupted 0x1bae51e6c910 0x4@0x4
+     * This causes remoted to fail, which might be a bad thing.
+     */
+    //free(ip_address);
     return((cidr >= 0) ? 2 : 1);
 }
 


### PR DESCRIPTION
One of the free(ip_address) entries added in commit 0f776e8915be3421307b5c3885e05ef13011de17 causes remoted to crash with a canary violation.
```
OpenBSD 6.0-current (GENERIC.MP) #35: Wed Dec 14 10:38:03 MST 2016
[ddp@ix] :; ls -l /etc/malloc.conf
lrwxr-xr-x  1 root  wheel  2 Oct 31 11:09 /etc/malloc.conf -> SC
```

Actual error message:
```
ossec-remoted(55078) in free(): chunk canary corrupted 0x1bae51e6c910 0x4@0x4
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1017)
<!-- Reviewable:end -->
