### PR TITLE
Allow notify_timeout to be configured server-side.

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -78,6 +78,9 @@ monitord.sign=1
 # Monitord monitor_agents. (0=do not monitor, 1=monitor)
 monitord.monitor_agents=1
 
+# Monitord notify_time. Frequency of which the clients' availability needs
+# to be checked. (60-3600)
+monitord.notify_time=600
 
 # Syscheck checking/usage speed. To avoid large cpu/memory
 # usage, you can specify how much to sleep after generating

--- a/src/config/reports-config.h
+++ b/src/config/reports-config.h
@@ -28,6 +28,7 @@ typedef struct _monitor_config {
     short int sign;
     short int monitor_agents;
     int a_queue;
+    int notify_time;
 
     char *smtpserver;
     char *emailfrom;
@@ -38,4 +39,3 @@ typedef struct _monitor_config {
 } monitor_config;
 
 #endif /* _REPORTSCONFIG_H */
-

--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -41,6 +41,9 @@ int delete_agentinfo(const char *name) __attribute__((nonnull));
 /* Get all available agents */
 char **get_agents(int flag);
 
+/* Get all available agents with specified timeout */
+char **get_agents_with_timeout(int flag, int timeout);
+
 /* Free the agent list */
 void free_agents(char **agent_list);
 

--- a/src/monitord/main.c
+++ b/src/monitord/main.c
@@ -115,6 +115,7 @@ int main(int argc, char **argv)
     mond.compress = (short) getDefine_Int("monitord", "compress", 0, 1);
     mond.sign = (short) getDefine_Int("monitord", "sign", 0, 1);
     mond.monitor_agents = (short) getDefine_Int("monitord", "monitor_agents", 0, 1);
+    mond.notify_time = getDefine_Int("monitord", "notify_time", 60, 3600);
     mond.agents = NULL;
     mond.smtpserver = NULL;
     mond.emailfrom = NULL;
@@ -214,4 +215,3 @@ int main(int argc, char **argv)
     Monitord();
     exit(0);
 }
-

--- a/src/monitord/monitor_agents.c
+++ b/src/monitord/monitor_agents.c
@@ -17,7 +17,7 @@ void monitor_agents()
     char **cr_agents;
     char **av_agents;
 
-    av_agents = get_agents(GA_ACTIVE);
+    av_agents = get_agents_with_timeout(GA_ACTIVE, mond.notify_time);
 
     /* No agent saved */
     if (!mond.agents) {
@@ -60,4 +60,3 @@ void monitor_agents()
     mond.agents = av_agents;
     return;
 }
-

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -1176,8 +1176,8 @@ int get_agent_status(const char *agent_name, const char *agent_ip)
     return (GA_STATUS_NACTIVE);
 }
 
-/* List available agents */
-char **get_agents(int flag)
+/* List available agents with specified timeout */
+char **get_agents_with_timeout(int flag, int timeout)
 {
     size_t f_size = 0;
     char **f_files = NULL;
@@ -1215,7 +1215,7 @@ char **get_agents(int flag)
                 continue;
             }
 
-            if (file_status.st_mtime > (time(0) - (3 * NOTIFY_TIME + 30))) {
+            if (file_status.st_mtime > (time(0) - (3 * timeout + 30))) {
                 status = 1;
                 if (flag == GA_NOTACTIVE) {
                     continue;
@@ -1251,4 +1251,9 @@ char **get_agents(int flag)
 
     closedir(dp);
     return (f_files);
+}
+
+/* List available agents */
+char **get_agents(int flag) {
+  return get_agents_with_timeout(flag, NOTIFY_TIME);
 }


### PR DESCRIPTION
It wasn't possible to configure the time-out on the server after which
to create a notification that a HIDS agent went down.

This patch defines a configuration file entry and allows the NOTIFY_TIME
setting to be configured for monitord.

See https://groups.google.com/forum/#!topic/ossec-list/VQHP8c-pYxA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1020)
<!-- Reviewable:end -->
