### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@
 # New function AddTable to add support for OpenBSD pf rules in firewall-drop active response
 
 # Changelog 29 March 2012 - Adding hybrid mode (standalone + agent)
+# added fix for use of USER_AGENT_CONFIG_PROFILE in preloaded-vars
 
 
 
@@ -400,6 +401,10 @@ ConfigureClient()
         echo "    <server-ip>$IP</server-ip>" >> $NEWCONFIG
     elif [ "X${HNAME}" != "X" ]; then
         echo "    <server-hostname>$HNAME</server-hostname>" >> $NEWCONFIG
+    fi
+    if [ "$X{USER_AGENT_CONFIG_PROFILE}" != "X" ]; then      
+         PROFILE=${USER_AGENT_CONFIG_PROFILE}
+         echo "    <config-profile>$PROFILE</config-profile>" >> $NEWCONFIG
     fi
     echo "  </client>" >> $NEWCONFIG
     echo "" >> $NEWCONFIG


### PR DESCRIPTION
No one ever bothered to add any fix for the "USER_AGENT_CONFIG_PROFILE" preloaded-vars.conf file usage.  This fixes that and adds a profile config line if the variable is defined. Very useful for unattended installs or binary installs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1027)
<!-- Reviewable:end -->
