### PR TITLE
Convert IPv4 regex from commit bb06c8e.

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -909,7 +909,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="dovecot-authfailed">
   <parent>dovecot</parent>
   <prematch offset="after_parent">^\w\w\w\w-login:</prematch>
-  <regex offset="after_prematch">\(auth failed, \d+ attempts in \d+ secs\): user=\p(\S+)\p, method=\w+, rip=(\d+.\d+.\d+.\d+), lip=(\d+.\d+.\d+.\d+)</regex>
+  <regex offset="after_prematch">\(auth failed, \d+ attempts in \d+ secs\): user=\p(\S+)\p, method=\w+, rip=(\S+), lip=(\S+)</regex>
   <order>user,srcip,dstip</order>
 </decoder>
 


### PR DESCRIPTION
Replace IPv4-centric regex from commit bb06c8e.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1038)
<!-- Reviewable:end -->
