### PR TITLE
Fix false positives on IPv6 addresses containing 'bad'.

### DIFF
--- a/etc/rules/syslog_rules.xml
+++ b/etc/rules/syslog_rules.xml
@@ -18,7 +18,7 @@
 <!-- Bad words matching. Any log containing these messages
   -  will be triggered.
   -->
-<var name="BAD_WORDS">core_dumped|failure|error|attack|bad |illegal |denied|refused|unauthorized|fatal|failed|Segmentation Fault|Corrupted</var>
+<var name="BAD_WORDS">core_dumped|failure|error|attack| bad |illegal |denied|refused|unauthorized|fatal|failed|Segmentation Fault|Corrupted</var>
 
 
 <!-- Syslog errors. -->


### PR DESCRIPTION
This addresses issue #998 where IPv6 addresses containing 'bad' can trigger false positives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1039)
<!-- Reviewable:end -->
