### PR TITLE
Add a rule to ignore alerts from a normal update in mailscanner.

### DIFF
--- a/contrib/ossec-testing/tests/mailscanner.ini
+++ b/contrib/ossec-testing/tests/mailscanner.ini
@@ -1,0 +1,6 @@
+[update phishing]
+log 1 fail = Feb 14 06:29:39 hostname update.bad.phishing.sites: Phishing bad sites list updated
+rule = 3752
+alert = 0
+decoder = 
+

--- a/etc/rules/mailscanner_rules.xml
+++ b/etc/rules/mailscanner_rules.xml
@@ -39,4 +39,13 @@
     <description>Multiple attempts of spam.</description>
     <group>multiple_spam,</group>
   </rule>
+
+  <rule id="3752" level="0">
+      <if_sid>1002</if_sid>
+      <program_name>update.bad.phishing.sites</program_name>
+      <match>^Phishing bad sites list updated</match>
+      <description>ignore</description>
+  </rule>
+
 </group> <!-- SYSLOG,MAILSCANNER -->
+


### PR DESCRIPTION
Based on information from Göran Lundberg on the user list.

The test was failing on my system (when I had it set to pass), so it's set to fail now until someone figures out why.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1066)
<!-- Reviewable:end -->
