### PR TITLE
More Windows decoder

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1948,7 +1948,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="windows1">
   <type>windows</type>
   <parent>windows</parent>
-  <regex> Account Name:\s+(\w+)\s+Account</regex>
+  <regex> Account Name:\s+(\w+\.+)\s+Account</regex>
   <order>user</order>
 </decoder>
 

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1948,8 +1948,15 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="windows1">
   <type>windows</type>
   <parent>windows</parent>
-  <regex> Account Name: (\S+) Account</regex>
+  <regex> Account Name:\s+(\w+)\s+Account</regex>
   <order>user</order>
+</decoder>
+
+<decoder name="windows1">
+  <type>windows</type>
+  <parent>windows</parent>
+  <regex>Account Domain:\s\s+(\w\.+)\s\s+Logon ID:</regex>
+  <order>extra_data</order>
 </decoder>
 
 


### PR DESCRIPTION
Apparently Windows usernames and domains can contain spaces. Try to work around this deficiency in the decoder.
From InfoSec on the user list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1080)
<!-- Reviewable:end -->
