### PR TITLE
Stop a double-free.

### DIFF
--- a/src/shared/report_op.c
+++ b/src/shared/report_op.c
@@ -522,7 +522,7 @@ void os_ReportdStart(report_filter *r_filter)
                     mgroup++;
                 }
 
-                free(mgroup);
+                //free(mgroup);
             } else {
                 tmp_str = al_data->group;
                 while (*tmp_str == ' ') {


### PR DESCRIPTION
Reported by Keith-mo in issue #1084 
If this is the right fix, it'll have to be backported to 2.9.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1088)
<!-- Reviewable:end -->
