### PR TITLE
Add a field "id" to the json log.

### DIFF
--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -146,6 +146,13 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if ( lf->program_name ) {
         cJSON_AddStringToObject(root, "program_name", lf->program_name);
     }
+    if ( lf->time ) {
+        char *alert_id;
+        if((snprintf(alert_id, 16, "%ld.%ld", (long int)lf->time, __crt_ftell)) < 0) {
+            merror("snprintf failed");
+        }
+        cJSON_AddStringToObject(root, "alert_id", alert_id);
+    }
     out = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     return out;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -28,10 +28,23 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     cJSON *file_diff;
     char *out;
 
+    extern long int __crt_ftell;
+
     root = cJSON_CreateObject();
     cJSON_AddItemToObject(root, "rule", rule = cJSON_CreateObject());
 
     cJSON_AddNumberToObject(rule, "level", lf->generated_rule->level);
+
+    if ( lf->time ) {
+
+        char alert_id[19];
+        alert_id[18] = '\0';
+        if((snprintf(alert_id, 18, "%ld.%ld", (long int)lf->time, __crt_ftell)) < 0) {
+            merror("snprintf failed");
+        }
+
+        cJSON_AddStringToObject(root, "id", alert_id);
+    }
 
     if (lf->generated_rule->comment) {
         cJSON_AddStringToObject(rule, "comment", lf->generated_rule->comment);
@@ -146,13 +159,7 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if ( lf->program_name ) {
         cJSON_AddStringToObject(root, "program_name", lf->program_name);
     }
-    if ( lf->time ) {
-        char *alert_id;
-        if((snprintf(alert_id, 16, "%ld.%ld", (long int)lf->time, __crt_ftell)) < 0) {
-            merror("snprintf failed");
-        }
-        cJSON_AddStringToObject(root, "alert_id", alert_id);
-    }
+
     out = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     return out;


### PR DESCRIPTION
This should match up to the number following Alert in the regular alert log. I'm not sure "id" is descriptive enough, but I wanted to keep it short. Also, I'm not sure it's in the right spot of the log message. Maybe that doesn't even matter.

```
{"rule":{"level":3,"comment":"Login session closed.","sidid":5502,"group":"pam,syslog,"},"id":"1489183089.253799","decoder":"pam","location":"/var/log/syslog-ng/messages","full_log":"Mar  8 20:13:39 ubnt sudo: pam_unix(sudo:session): session closed for user root","TimeStamp":"Fri Mar 10 16:58:09 2017\n","hostname":"ubnt","program_name":"sudo"}
```
```
** Alert 1489183089.253799: - pam,syslog,
2017 Mar 10 16:58:09 ubnt->/var/log/syslog-ng/messages
Rule: 5502 (level 3) -> 'Login session closed.'
Mar  8 20:13:39 ubnt sudo: pam_unix(sudo:session): session closed for user root
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1090)
<!-- Reviewable:end -->
