### PR TITLE
Looking for a existing entry - hosts.deny

### DIFF
--- a/active-response/firewall-drop.sh
+++ b/active-response/firewall-drop.sh
@@ -32,7 +32,8 @@ IP=$3
 PWD=`pwd`
 LOCK="${PWD}/fw-drop"
 LOCK_PID="${PWD}/fw-drop/pid"
-
+IPV4F="$(cat /proc/sys/net/ipv4/ip_forward)"
+IPV6F="$(cat /proc/sys/net/ipv6/conf/all/forwarding)"
 
 LOCAL=`dirname $0`;
 cd $LOCAL
@@ -175,6 +176,14 @@ if [ "X${UNAME}" = "XLinux" ]; then
    
    COUNT=0;
    while [ 1 ]; do
+        #
+        # Looking for IPV4 and IPV6 FORWARD
+        #
+        if [ "$IPV4F" == "0" ] && [ "$IPV6F" == "0" ]
+        then
+                break
+        fi
+
         ${IPTABLES} ${ARG2}
         RES=$?
         if [ $RES = 0 ]; then

--- a/active-response/firewall-drop.sh
+++ b/active-response/firewall-drop.sh
@@ -32,8 +32,8 @@ IP=$3
 PWD=`pwd`
 LOCK="${PWD}/fw-drop"
 LOCK_PID="${PWD}/fw-drop/pid"
-IPV4F="$(cat /proc/sys/net/ipv4/ip_forward)"
-IPV6F="$(cat /proc/sys/net/ipv6/conf/all/forwarding)"
+IPV4F="/proc/sys/net/ipv4/ip_forward"
+IPV6F="/proc/sys/net/ipv6/conf/all/forwarding"
 
 LOCAL=`dirname $0`;
 cd $LOCAL
@@ -179,7 +179,20 @@ if [ "X${UNAME}" = "XLinux" ]; then
         #
         # Looking for IPV4 and IPV6 FORWARD
         #
-        if [ "$IPV4F" == "0" ] && [ "$IPV6F" == "0" ]
+        if [ -e "$IPV4F" ]
+        then
+                IPV4KEY="$(cat "$IPV4F")"
+        else
+                IPV4KEY="0"
+        fi
+        if [ -e "$IPV6F" ]
+        then
+                IPV6KEY="$(cat "$IPV6F")"
+        else
+                IPV6KEY="0"
+        fi
+                
+        if [ "$IPV4KEY" == "0" ] && [ "$IPV6KEY" == "0" ]
         then
                 break
         fi

--- a/active-response/host-deny.sh
+++ b/active-response/host-deny.sh
@@ -83,7 +83,15 @@ if [ "x${IP}" = "x" ]; then
    echo "$0: Missing argument <action> <user> (ip)" 
    exit 1;
 fi
-
+#
+#       Looking for duplication
+#
+IPKEY=$(grep -w "${IP}" /etc/hosts.deny)
+if [ ! -z "$IPKEY" ]
+then
+        echo "`date` Duplicate ip/hostname entry: ${IP}" >> ${PWD}/../logs/active-responses.log
+        exit 1
+fi
 
 # Checking for invalid entries (lacking "." or ":", etc)
 echo "${IP}" | egrep "\.|\:" > /dev/null 2>&1


### PR DESCRIPTION
More one simple condition/test before submit a ip/hostname to hosts.deny.

~~~~
bash -x host-deny.sh add ncaio 190.80.12.180
+ ACTION=add
+ USER=ncaio
+ IP=190.80.12.180
++ dirname host-deny.sh
+ LOCAL=.
+ cd .
+ cd ../
++ pwd
+ PWD=/var/ossec/active-response
+ LOCK=/var/ossec/active-response/host-deny-lock
+ LOCK_PID=/var/ossec/active-response/host-deny-lock/pid
++ uname
+ UNAME=Linux
+ MAX_ITERATION=50
++ date
+ echo 'Wed Mar 29 09:54:51 BRT 2017 host-deny.sh add ncaio 190.80.12.180  '
+ '[' x190.80.12.180 = x ']'
+ echo 190.80.12.180
+ grep '\.'
+ '[' '!' 0 = 0 ']'
++ grep -w 190.80.12.180 /etc/hosts.deny
+ IPKEY='ALL: 190.80.12.180'
+ '[' '!' -z 'ALL: 190.80.12.180' ']'
++ date
+ echo 'Wed Mar 29 09:54:51 BRT 2017 Duplicate ip/hostname entry: 190.80.12.180'
+ exit 1
~~~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1099)
<!-- Reviewable:end -->
