### PR TITLE
Open received files in binary mode cause of cr/lf and let hashes match.

### DIFF
--- a/src/client-agent/receiver-win.c
+++ b/src/client-agent/receiver-win.c
@@ -151,7 +151,7 @@ void *receiver_thread(__attribute__((unused)) void *none)
                              SHAREDCFG_DIR,
                              tmp_msg);
 
-                    fp = fopen(file, "w");
+                    fp = fopen(file, "wb");
                     if (!fp) {
                         merror(FOPEN_ERROR, ARGV0, file, errno, strerror(errno));
                     }


### PR DESCRIPTION
We had issues with shared files on windows and tracked it down to a md5 hash missmatch caused by fopens textmode.
With this patch, received files are written in binary mode (and not deleted afterwards).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1100)
<!-- Reviewable:end -->
