### PR TITLE
Fix TimeStamp

### DIFF
--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -18,11 +18,8 @@
 /* Convert Eventinfo to json */
 char *Eventinfo_to_jsonstr(const Eventinfo *lf)
 {
-    time_t c_time;
     char* time_string;
-    c_time = time(NULL);
-    time_string = ctime(&c_time);
-
+ 
     cJSON *root;
     cJSON *rule;
     cJSON *file_diff;
@@ -38,12 +35,15 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if ( lf->time ) {
 
         char alert_id[19];
+        double timestamp_ms;
+        timestamp_ms = ((double)lf->time)*1000;
         alert_id[18] = '\0';
         if((snprintf(alert_id, 18, "%ld.%ld", (long int)lf->time, __crt_ftell)) < 0) {
             merror("snprintf failed");
         }
 
         cJSON_AddStringToObject(root, "id", alert_id);
+        cJSON_AddNumberToObject(root, "TimeStamp", timestamp_ms);
     }
 
     if (lf->generated_rule->comment) {
@@ -112,9 +112,7 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->full_log) {
         cJSON_AddStringToObject(root, "full_log", lf->full_log);
     }
-    if (lf->full_log){
-        cJSON_AddStringToObject(root, "TimeStamp", time_string);
-    }
+    
     if (lf->filename) {
         cJSON_AddItemToObject(root, "file", file_diff = cJSON_CreateObject());
 


### PR DESCRIPTION
The previous method (using ctime) has a number of issues that make it a bit weird to integrate with popular logging tools like ELK:

1. It appends a \n at the end of the timestamp which messes up date formatting for the unwary
2. It outputs time in the local timezone, without actually outputting the timezone... so logging tools like ELK will assume the date is in UTC, when actually it's GMT+2 or whatever... causing silly things like display logs in the future 

Easier method would be as proposed - simply output the timestamp in UNIX/EPOCH format. In this case it's millisecond epoch format - this is far more unambiguous for log parsers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1102)
<!-- Reviewable:end -->
