### PR TITLE
The ossec-remoted unit file requires the forking config otherwise it …

### DIFF
--- a/src/systemd/server/ossec-remoted.service
+++ b/src/systemd/server/ossec-remoted.service
@@ -3,6 +3,7 @@ Description=OSSEC remoted
 PartOf=ossec-server.target
 
 [Service]
+Type=forking
 EnvironmentFile=/etc/ossec-init.conf
 Environment=DIRECTORY=/var/ossec
 


### PR DESCRIPTION
…dies immediately after a systemctl start ossec-remoted.service

Per https://www.freedesktop.org/software/systemd/man/systemd.service.html
```
Example 4. Traditional forking services

Many traditional daemons/services background (i.e. fork, daemonize) themselves when starting. Set Type=forking in the service's unit file to support this mode of operation. systemd will consider the service to be in the process of initialization while the original program is still running. Once it exits successfully and at least a process remains (and RemainAfterExit=no), the service is considered started.
```

Pre-change
```
# systemctl status ossec-remoted.service                                                                                                           
● ossec-remoted.service - OSSEC remoted
   Loaded: loaded (/usr/lib/systemd/system/ossec-remoted.service; enabled; vendor preset: disabled)
   Active: inactive (dead) since Tue 2017-04-25 20:38:32 UTC; 3s ago
  Process: 19192 ExecStart=/usr/bin/env ${DIRECTORY}/bin/ossec-remoted -f -ddd (code=exited, status=0/SUCCESS)
  Process: 19175 ExecStartPre=/usr/bin/env ${DIRECTORY}/bin/ossec-remoted -t (code=exited, status=0/SUCCESS)
 Main PID: 19192 (code=exited, status=0/SUCCESS)

Apr 25 20:38:32 myserver systemd[1]: Starting OSSEC remoted...
Apr 25 20:38:32 myserver systemd[1]: Started OSSEC remoted.
Apr 25 20:38:32 myserver env[19192]: 2017/04/25 20:38:32 ossec-remoted: DEBUG: Starting ...
Apr 25 20:38:32 myserver env[19192]: 2017/04/25 20:38:32 ossec-remoted: INFO: Started (pid: 19192).
Apr 25 20:38:32 myserver env[19192]: 2017/04/25 20:38:32 ossec-remoted: DEBUG: Forking remoted: '0'.
Apr 25 20:38:32 myserver env[19192]: 2017/04/25 20:38:32 ossec-remoted: INFO: Started (pid: 19200).
Apr 25 20:38:32 myserver env[19192]: 2017/04/25 20:38:32 ossec-remoted(1225): INFO: SIGNAL [(15)-(Terminated)] Received. Exit Cleaning...
```

Post change
```
# systemctl status ossec-remoted.service 
● ossec-remoted.service - OSSEC remoted
   Loaded: loaded (/usr/lib/systemd/system/ossec-remoted.service; enabled; vendor preset: disabled)
   Active: active (running) since Tue 2017-04-25 20:42:14 UTC; 19min ago
 Main PID: 19425 (ossec-remoted)
   CGroup: /system.slice/ossec-remoted.service
           └─19425 /var/ossec/bin/ossec-remoted -f

Apr 25 20:42:14 myserver systemd[1]: Starting OSSEC remoted...
Apr 25 20:42:14 myserver env[19423]: 2017/04/25 20:42:14 ossec-remoted: INFO: Started (pid: 19423).
Apr 25 20:42:14 myserver systemd[1]: Started OSSEC remoted.
Apr 25 20:42:14 myserver env[19423]: 2017/04/25 20:42:14 ossec-remoted: INFO: Started (pid: 19425).
Apr 25 20:42:14 myserver env[19423]: 2017/04/25 20:42:14 ossec-remoted(4111): INFO: Maximum number of agents allowed: '16384'.
Apr 25 20:42:14 myserver env[19423]: 2017/04/25 20:42:14 ossec-remoted(1410): INFO: Reading authentication keys file.
Apr 25 20:42:14 myserver env[19423]: 2017/04/25 20:42:14 ossec-remoted: INFO: Assigning counter for agent someagentserver...0:3280'.
Apr 25 20:42:14 myserver env[19423]: 2017/04/25 20:42:14 ossec-remoted: INFO: Assigning sender counter: 0:191
Hint: Some lines were ellipsized, use -l to show in full.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1116)
<!-- Reviewable:end -->
