### PR TITLE
Pix decoders, Fixed 6-605004 and 6-605005

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -610,7 +610,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   - Sun Aug 16 15:48:02 2015 [pid 4832] [ftpuser] OK DELETE: Client "172.28.5.129", "/index.php"
   - Sun Aug 16 16:26:06 2015 [pid 4976] [ftpuser] OK CHMOD: Client "172.28.5.129", "/index.php 777"
   - Sun Aug 16 16:26:21 2015 [pid 4976] [ftpuser] OK RENAME: Client "172.28.5.129", "/index.php /4444index.php"
-  
+
 <decoder name="vsftpd">
   <prematch>^\w\w\w \w\w\w\s+\d+ \S+ \d+ [pid \d+] </prematch>
   <regex offset="after_prematch">Client "(\S+)"$</regex>
@@ -767,7 +767,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   -->
 <decoder name="imapd">
   <program_name>^imapd</program_name>
-  <regex offset="after_prematch">user=(\S+) \.+ [(\S+)]$</regex>    
+  <regex offset="after_prematch">user=(\S+) \.+ [(\S+)]$</regex>
   <order>user,srcip</order>
 </decoder>
 
@@ -897,7 +897,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <prematch offset="after_parent">^\w\w\w\w-login: Aborted login</prematch>
   <regex offset="after_prematch">: user=\p(\S+)\p, method=\S+, rip=(\S+), lip=(\S+), (\S*)$</regex>
   <order>user, srcip, dstip, protocol</order>
-</decoder> 
+</decoder>
 
 <decoder name="dovecot-fail">
   <parent>dovecot</parent>
@@ -966,7 +966,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 </decoder>
 
 <decoder name="named_from">
-  <parent>named</parent>  
+  <parent>named</parent>
   <regex offset="after_parent"> from [(\S+)]</regex>
   <order>srcip</order>
 </decoder>
@@ -1444,7 +1444,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <parent>pix</parent>
   <prematch offset="after_parent">^5-304002: </prematch>
   <regex offset="after_parent">^(\S+): Access (denied) URL (http\w*://\.+) </regex>
-  <regex>SRC (\S+) DEST (\S+) on interface</regex>  
+  <regex>SRC (\S+) DEST (\S+) on interface</regex>
   <order>id, action, url, srcip, dstip</order>
 </decoder>
 
@@ -1459,9 +1459,16 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 
 <decoder name="pix-srcip">
   <parent>pix</parent>
-  <prematch offset="after_parent">^6-605004|^6-308001|^6-605005</prematch>
+  <prematch offset="after_parent">^6-308001</prematch>
   <regex offset="after_parent">^(\S+): \.+ (\S+)</regex>
   <order>id, srcip</order>
+</decoder>
+
+<decoder name="pix-srcip-port">
+  <parent>pix</parent>
+  <prematch offset="after_parent">^6-605004|^6-605005</prematch>
+  <regex offset="after_parent">^(\S+): Login (\S+) from (\S+)/(\d+) \.+user "(\w+)"</regex>
+  <order>id, action, srcip, srcport, user</order>
 </decoder>
 
 <decoder name="pix-generic">
@@ -1604,7 +1611,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <parent>horde_imp</parent>
   <prematch offset="after_parent">^FAILED LOGIN</prematch>
   <regex offset="after_prematch">^ (\S+) to \S+ as (\S+) </regex>
-  <order>srcip, user</order> 
+  <order>srcip, user</order>
 </decoder>
 
 
@@ -1729,7 +1736,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="nginx-errorlog-ip">
   <parent>nginx-errorlog</parent>
   <prematch offset="after_parent">, client: \S+, server: \S+, request: "\S+ </prematch>
-  <regex offset="after_parent">, client: (\S+), </regex> 
+  <regex offset="after_parent">, client: (\S+), </regex>
   <order>srcip</order>
 </decoder>
 
@@ -2852,18 +2859,18 @@ Jul 26 13:57:56 mx1.example.org outbound/smtp: 127.0.0.1 1406297159-06f4a35b4df2
 </decoder>
 
 
-<!-- 
+<!--
   - Decoder for Sysmon Event ID 1: Process Created
-  - Maintained by Josh Brower, Josh@DefensiveDepth.com 
+  - Maintained by Josh Brower, Josh@DefensiveDepth.com
   -
   -  OSSEC to Sysmon Fields Mapping:
   -  user = User
   -  status = Image
   -  url = Hash
   -  extra_data = ParentImage
-  
+
   - Examples:
-  - 2014 Dec 20 14:29:48 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE 
+  - 2014 Dec 20 14:29:48 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE
 -->
 
 <decoder name="Sysmon-EventID#1">

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -610,7 +610,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   - Sun Aug 16 15:48:02 2015 [pid 4832] [ftpuser] OK DELETE: Client "172.28.5.129", "/index.php"
   - Sun Aug 16 16:26:06 2015 [pid 4976] [ftpuser] OK CHMOD: Client "172.28.5.129", "/index.php 777"
   - Sun Aug 16 16:26:21 2015 [pid 4976] [ftpuser] OK RENAME: Client "172.28.5.129", "/index.php /4444index.php"
-
+  
 <decoder name="vsftpd">
   <prematch>^\w\w\w \w\w\w\s+\d+ \S+ \d+ [pid \d+] </prematch>
   <regex offset="after_prematch">Client "(\S+)"$</regex>
@@ -767,7 +767,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   -->
 <decoder name="imapd">
   <program_name>^imapd</program_name>
-  <regex offset="after_prematch">user=(\S+) \.+ [(\S+)]$</regex>
+  <regex offset="after_prematch">user=(\S+) \.+ [(\S+)]$</regex>    
   <order>user,srcip</order>
 </decoder>
 
@@ -897,7 +897,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <prematch offset="after_parent">^\w\w\w\w-login: Aborted login</prematch>
   <regex offset="after_prematch">: user=\p(\S+)\p, method=\S+, rip=(\S+), lip=(\S+), (\S*)$</regex>
   <order>user, srcip, dstip, protocol</order>
-</decoder>
+</decoder> 
 
 <decoder name="dovecot-fail">
   <parent>dovecot</parent>
@@ -966,7 +966,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 </decoder>
 
 <decoder name="named_from">
-  <parent>named</parent>
+  <parent>named</parent>  
   <regex offset="after_parent"> from [(\S+)]</regex>
   <order>srcip</order>
 </decoder>
@@ -1444,7 +1444,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <parent>pix</parent>
   <prematch offset="after_parent">^5-304002: </prematch>
   <regex offset="after_parent">^(\S+): Access (denied) URL (http\w*://\.+) </regex>
-  <regex>SRC (\S+) DEST (\S+) on interface</regex>
+  <regex>SRC (\S+) DEST (\S+) on interface</regex>  
   <order>id, action, url, srcip, dstip</order>
 </decoder>
 
@@ -1611,7 +1611,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <parent>horde_imp</parent>
   <prematch offset="after_parent">^FAILED LOGIN</prematch>
   <regex offset="after_prematch">^ (\S+) to \S+ as (\S+) </regex>
-  <order>srcip, user</order>
+  <order>srcip, user</order> 
 </decoder>
 
 
@@ -1736,7 +1736,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="nginx-errorlog-ip">
   <parent>nginx-errorlog</parent>
   <prematch offset="after_parent">, client: \S+, server: \S+, request: "\S+ </prematch>
-  <regex offset="after_parent">, client: (\S+), </regex>
+  <regex offset="after_parent">, client: (\S+), </regex> 
   <order>srcip</order>
 </decoder>
 
@@ -2859,18 +2859,18 @@ Jul 26 13:57:56 mx1.example.org outbound/smtp: 127.0.0.1 1406297159-06f4a35b4df2
 </decoder>
 
 
-<!--
+<!-- 
   - Decoder for Sysmon Event ID 1: Process Created
-  - Maintained by Josh Brower, Josh@DefensiveDepth.com
+  - Maintained by Josh Brower, Josh@DefensiveDepth.com 
   -
   -  OSSEC to Sysmon Fields Mapping:
   -  user = User
   -  status = Image
   -  url = Hash
   -  extra_data = ParentImage
-
+  
   - Examples:
-  - 2014 Dec 20 14:29:48 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE
+  - 2014 Dec 20 14:29:48 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE 
 -->
 
 <decoder name="Sysmon-EventID#1">


### PR DESCRIPTION
6-308001 is a very different format and cannot be in the same entry as the others
6-605004 and 6-605005 Also added support for action (Permitted, Denied), srcip, srcport, and User.

Tested with real traffic and with the ossec-logtest tool via this example log
%PIX-6-605004: Login denied from 192.168.1.100/25678 to inside:192.168.1.254/ssh for user "t@st123user" 

The original rule selects permitted or denied as the srcip.
**Phase 2: Completed decoding.
       decoder: 'pix'
       id: '6-605004'
       srcip: 'denied'

Corrected rule produces this output
**Phase 2: Completed decoding.
       decoder: 'pix'
       id: '6-605004'
       action: 'denied'
       srcip: '192.168.1.100'
       srcport: '25678'
       dstuser: 't@st123user'


This issue was found by our SOC when ELK was failing to import the json being produced by OSSEC-HIDS 2.9.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1120)
<!-- Reviewable:end -->
