### PR TITLE
Fixes for PIX 6-308001 6-605005, and 6-605004

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1347,10 +1347,10 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   - %PIX-6-305012: Teardown dynamic UDP translation from inside:1.1.1.1/12 to outside:1.2.1.2/11 duration 0:00:11.
   - %PIX-3-305005: No translation group found for icmp src outside:x.x.x.x dst inside:x.x.x.x (type 3, code 0)
   - %ASA-2-106001: Inbound TCP connection denied from 1.2.3.4/1234 to 213.207.99.248/445 flags SYN on interface outside (Message repeated 2 times)
-	- %ASA-6-308001: Console enable password incorrect for 3 tries (from ssh (remote 198.18.1.100))
+  - %ASA-6-308001: Console enable password incorrect for 3 tries (from ssh (remote 198.18.1.100))
   - %PIX-6-605004: Login denied from 192.168.2.10/32597 to outside:192.168.2.14/ssh for user "root"
   - %ASA-6-605004: Login denied from 198.18.1.100/56332 to outside:198.18.1.254/ssh for user "*****" 
-	- %ASA-6-605005: Login permitted from 198.18.1.100/47849 to outside:198.18.1.254/ssh for user "us3rn@m3"
+  - %ASA-6-605005: Login permitted from 198.18.1.100/47849 to outside:198.18.1.254/ssh for user "us3rn@m3"
   - %PIX-6-605005: Login permitted from 192.168.1.2/2953 to inside:192.168.1.1/telnet for user ""
   - %PIX-6-305011: Built dynamic UDP translation from inside:192.168.1.2/1026 to outside:192.168.2.14/1163
   - %PIX-6-305011: Built dynamic TCP translation from inside:192.168.1.3/54946 to outside:192.168.2.14/1033

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1457,19 +1457,26 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <order>id, srcip</order>
 </decoder>
 
-<decoder name="pix-srcip">
+<decoder name="pix-enable-failed">
   <parent>pix</parent>
   <prematch offset="after_parent">^6-308001</prematch>
-  <regex offset="after_parent">^(\S+): \.+ (\S+)</regex>
-  <order>id, srcip</order>
+  <regex offset="after_parent">^(\S+):</regex>
+  <order>id</order>
 </decoder>
 
-<decoder name="pix-srcip-port">
+<decoder name="pix-srcip-port-denied">
   <parent>pix</parent>
-  <prematch offset="after_parent">^6-605004|^6-605005</prematch>
+  <prematch offset="after_parent">^6-605004</prematch>
+  <regex offset="after_parent">^(\S+): Login (\S+) from (\S+)/(\d+)</regex>
+  <order>id, action, srcip, srcport</order>
+</decoder>
+
+<decoder name="pix-srcip-port-permitted">
+  <parent>pix</parent>
+  <prematch offset="after_parent">^6-605005</prematch>
   <regex offset="after_parent">^(\S+): Login (\S+) from (\S+)/(\d+) \.+user "(\w+)"</regex>
   <order>id, action, srcip, srcport, user</order>
-</decoder>
+ </decoder>
 
 <decoder name="pix-generic">
   <parent>pix</parent>

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1347,8 +1347,11 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   - %PIX-6-305012: Teardown dynamic UDP translation from inside:1.1.1.1/12 to outside:1.2.1.2/11 duration 0:00:11.
   - %PIX-3-305005: No translation group found for icmp src outside:x.x.x.x dst inside:x.x.x.x (type 3, code 0)
   - %ASA-2-106001: Inbound TCP connection denied from 1.2.3.4/1234 to 213.207.99.248/445 flags SYN on interface outside (Message repeated 2 times)
-  - %PIX-6-605005: Login permitted from 192.168.1.2/2953 to inside:192.168.1.1/telnet for user ""
+	- %ASA-6-308001: Console enable password incorrect for 3 tries (from ssh (remote 198.18.1.100))
   - %PIX-6-605004: Login denied from 192.168.2.10/32597 to outside:192.168.2.14/ssh for user "root"
+  - %ASA-6-605004: Login denied from 198.18.1.100/56332 to outside:198.18.1.254/ssh for user "*****" 
+	- %ASA-6-605005: Login permitted from 198.18.1.100/47849 to outside:198.18.1.254/ssh for user "us3rn@m3"
+  - %PIX-6-605005: Login permitted from 192.168.1.2/2953 to inside:192.168.1.1/telnet for user ""
   - %PIX-6-305011: Built dynamic UDP translation from inside:192.168.1.2/1026 to outside:192.168.2.14/1163
   - %PIX-6-305011: Built dynamic TCP translation from inside:192.168.1.3/54946 to outside:192.168.2.14/1033
   - %PIX-6-302015: Built outbound UDP connection 156 for outside:192.168.2.10/1514 (192.168.2.10/1514) to inside:192.168.1.2/1026 (192.168.2.14/1163)


### PR DESCRIPTION
Through further testing with PIX and ASA we have updated the decoder once more to support the current state of the ASA software. 

It was noticed that in Cisco ASA as apposed to PIX. the username is not provided in 6-605004. We think this is a security enhancement Cisco made, if a user fails to log in it is possible that a password was improperly put into the username field and thus it shouldn't be logged. Cisco instead puts asterisks(*) in place for the user on 605004

The only way we could see to fix the decoder for this was to remove the username from being selected. Perhaps someone with a better understanding of OSSEC regex could create something better.

Some more example logs and their phase 2 output before the fix.
Examples are also in the comment section of the decoder.xml.
```
%ASA-6-308001: Console enable password incorrect for 3 tries (from ssh (remote 198.18.1.100))
**Phase 2: Completed decoding.
       decoder: 'pix'
       id: '6-308001'
       srcip: 'enable'


%ASA-6-605005: Login permitted from 198.18.1.100/47849 to outside:198.18.1.254/ssh for user "t@stuser123"
**Phase 2: Completed decoding.
       decoder: 'pix'
       id: '6-605004'
       action: 'denied'
       srcip: '198.18.1.100'
       srcport: '56332'
       dstuser: 't@stuser123'

%ASA-6-605004: Login denied from 198.18.1.100/56332 to outside:198.18.1.254/ssh for user "*****"

**Phase 2: Completed decoding.
       decoder: 'pix'
```

Log test output after the fix.
```
%ASA-6-308001: Console enable password incorrect for 3 tries (from ssh (remote 198.18.1.100))
**Phase 2: Completed decoding.
       decoder: 'pix'
       id: '6-308001'

%ASA-6-605005: Login permitted from 198.18.1.100/47849 to outside:198.18.1.254/ssh for user "us3rn@m3"
**Phase 2: Completed decoding.
       decoder: 'pix'
       id: '6-605005'
       action: 'permitted'
       srcip: '198.18.1.100'
       srcport: '47849'
       dstuser: 'us3rn@m3'

%ASA-6-605004: Login denied from 198.18.1.100/56332 to outside:198.18.1.254/ssh for user "*****" 
**Phase 2: Completed decoding.
       decoder: 'pix'
       id: '6-605004'
       action: 'denied'
       srcip: '198.18.1.100'
       srcport: '56332'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1124)
<!-- Reviewable:end -->
