### PR TITLE
Fix mysql support

### DIFF
--- a/src/os_dbd/main.c
+++ b/src/os_dbd/main.c
@@ -22,7 +22,7 @@ static void help_dbd(void) __attribute__((noreturn));
 /* Print information regarding enabled databases */
 static void print_db_info()
 {
-#ifdef UMYSQL_DATABASE_ENABLED
+#ifdef MYSQL_DATABASE_ENABLED
     print_out("    Compiled with MySQL support");
 #endif
 


### PR DESCRIPTION
UMYSQL_DATABASE_ENABLED does not exist in the tree except this one place.
From andrewm0374@gmail.com on the user list.

Copy of #1135 but for 2.9.1 branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1136)
<!-- Reviewable:end -->
