### PR TITLE
Update "shell" on ossec-hids-solaris.init

### DIFF
--- a/src/init/ossec-hids-solaris.init
+++ b/src/init/ossec-hids-solaris.init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # OSSEC         Controls OSSEC HIDS on Solaris systems
 # Author:       Kayvan A. Sylvan <kayvan@sylvan.com>
 # Author:       Daniel B. Cid <dcid@ossec.net>


### PR DESCRIPTION
"sh" shell generates error, but using "bash" it gets solved.
Tested on Solaris 11.2 Intel & SPARC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1158)
<!-- Reviewable:end -->
