### PR TITLE
Patch branch5/6/67

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,7 @@ EXTERNAL_LUA=external/lua/
 EXTERNAL_ZLIB=external/zlib-1.2.8/
 LUA_PLAT=posix
 MAXAGENTS?=2048
+REUSE_ID?=no
 # XXX Becareful NO EXTRA Spaces here
 PREFIX?=/var/ossec
 PG_CONFIG?=pg_config
@@ -38,6 +39,10 @@ DEFINES+=-DREMUSER=\"${OSSEC_USER_REM}\"
 DEFINES+=-DGROUPGLOBAL=\"${OSSEC_GROUP}\"
 DEFINES+=-DMAILUSER=\"${OSSEC_USER_MAIL}\"
 DEFINES+=-D${uname_S}
+
+ifneq (,$(filter ${REUSE_ID},yes y Y 1))
+	DEFINES+=-DREUSE_ID
+endif
 
 OSSEC_LDFLAGS=${LDFLAGS} -lm
 
@@ -491,6 +496,7 @@ help: failtarget
 	@echo "   make DEBUG=1          Build with symbols and without optimization"
 	@echo "   make PREFIX=/path     Install OSSEC to '/path'. Defaults to /var/ossec"
 	@echo "   make MAXAGENTS=NUMBER Set the number of maximum agents to NUMBER. Defaults to 2048"
+	@echo "   make REUSE_ID=yes     Enables agent ID re-use"
 	@echo
 	@echo "Database options: "
 	@echo "   make DATABASE=mysql  Build with MYSQL Support"
@@ -515,6 +521,7 @@ settings:
 	@echo "    DEBUGAD           ${DEBUGAD}"
 	@echo "    PREFIX:           ${PREFIX}"
 	@echo "    MAXAGENTS:        ${MAXAGENTS}"
+	@echo "    REUSE_ID:         ${REUSE_ID}"
 	@echo "    DATABASE:         ${DATABASE}"
 	@echo "    ONEWAY:           ${ONEWAY}"
 	@echo "    CLEANFULL:        ${CLEANFULL}"

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -33,8 +33,11 @@ int OS_IsValidName(const char *u_name);
 int OS_IsValidID(const char *id);
 int IDExist(const char *id);
 int NameExist(const char *u_name);
+char *IPExist(const char *u_name);
 char *getFullnameById(const char *id);
 char *OS_AddNewAgent(const char *name, const char *ip, const char *id);
+int  OS_RemoveAgent(const char *id);
+double OS_AgentAntiquity(const char *id);
 void FormatID(char *id);
 
 /* Print available agents */

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -91,7 +91,7 @@ int OS_RemoveAgent(const char *u_id) {
     if (!id_exist)
         return 0;
 
-    fp = fopen(AUTH_FILE, "r+");
+    fp = fopen(isChroot() ? AUTH_FILE : KEYSFILE_PATH, "r+");
 
     if (!fp)
         return 0;

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -449,7 +449,7 @@ double OS_AgentAntiquity(const char *id)
     if (stat(file_name, &file_stat) < 0)
         return -1;
 
-    return difftime(time(NULL), file_stat.st_mtim.tv_sec);
+    return difftime(time(NULL), file_stat.st_mtime);
 }
 
 /* Print available agents */


### PR DESCRIPTION
Added 3 patches, which avoid adding duplicated IPs into authd, a time limit for deletion of agents with a duplicated IP, and enables an option for re-using an agent's ID in authd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1161)
<!-- Reviewable:end -->
