### PR TITLE
Patches 13 and 14

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -51,7 +51,7 @@ static void clean_exit(SSL_CTX *ctx, int sock) __attribute__((noreturn));
 static void help_authd()
 {
     print_header();
-    print_out("  %s: -[Vhdti] [-g group] [-D dir] [-p port] [-v path] [-x path] [-k path]", ARGV0);
+    print_out("  %s: -[Vhdti] [-g group] [-D dir] [-p port] [-P] [-v path] [-x path] [-k path]", ARGV0);
     print_out("    -V          Version and license message");
     print_out("    -h          This help message");
     print_out("    -d          Execute in debug mode. This parameter");
@@ -62,7 +62,7 @@ static void help_authd()
     print_out("    -g <group>  Group to run as (default: %s)", GROUPGLOBAL);
     print_out("    -D <dir>    Directory to chroot into (default: %s)", DEFAULTDIR);
     print_out("    -p <port>   Manager port (default: %s)", DEFAULT_PORT);
-    print_out("    -n          Disable shared password authentication (not recommended).\n");
+    print_out("	   -P	       Enable shared password authentication (at %s or random).", AUTHDPASS_PATH);
     print_out("    -v <path>   Full path to CA certificate used to verify clients");
     print_out("    -x <path>   Full path to server certificate");
     print_out("    -k <path>   Full path to server key");
@@ -147,7 +147,8 @@ int main(int argc, char **argv)
     int process_pool[POOL_SIZE];
     /* Count of pids we are wait()ing on */
     int c = 0, test_config = 0, use_ip_address = 0, pid = 0, status, i = 0, active_processes = 0;
-    int use_pass = 1;
+    int m_queue = 0;
+    int use_pass = 0;
     gid_t gid;
     int client_sock = 0, sock = 0, portnum, ret = 0;
     char *port = DEFAULT_PORT;
@@ -171,7 +172,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    while ((c = getopt(argc, argv, "Vdhtig:D:m:p:v:x:k:n")) != -1) {
+    while ((c = getopt(argc, argv, "Vdhtig:D:m:p:v:x:k:PF:")) != -1) {
         switch (c) {
             case 'V':
                 print_version();
@@ -200,8 +201,8 @@ int main(int argc, char **argv)
             case 't':
                 test_config = 1;
                 break;
-            case 'n':
-                use_pass = 0;
+            case 'P':
+                use_pass = 1;
                 break;
             case 'p':
                 if (!optarg) {
@@ -293,14 +294,14 @@ int main(int argc, char **argv)
         }
 
         if (buf[0] != '\0')
-            verbose("Accepting connections. Using password specified on file: %s",AUTHDPASS_PATH);
+            verbose("Accepting connections. Using password specified on file: %s", AUTHDPASS_PATH);
         else {
             /* Getting temporary pass. */
             authpass = __generatetmppass();
             verbose("Accepting connections. Random password chosen for agent authentication: %s", authpass);
         }
     } else
-        verbose("Accepting insecure connections. No password required (not recommended)");
+        verbose("Accepting insecure connections. No password required.");
 
     /* Getting SSL cert. */
 
@@ -441,6 +442,7 @@ int main(int argc, char **argv)
                     char *finalkey = NULL;
                     response[2048] = '\0';
                     fname[2048] = '\0';
+                    
                     if (!OS_IsValidName(agentname)) {
                         merror("%s: ERROR: Invalid agent name: %s from %s", ARGV0, agentname, srcip);
                         snprintf(response, 2048, "ERROR: Invalid agent name: %s\n\n", agentname);
@@ -451,22 +453,7 @@ int main(int argc, char **argv)
                         exit(0);
                     }
 
-                    /* Check for duplicate names */
-                    strncpy(fname, agentname, 2048);
-                    while (NameExist(fname)) {
-                        snprintf(fname, 2048, "%s%d", agentname, acount);
-                        acount++;
-                        if (acount > 256) {
-                            merror("%s: ERROR: Invalid agent name %s (duplicated)", ARGV0, agentname);
-                            snprintf(response, 2048, "ERROR: Invalid agent name: %s\n\n", agentname);
-                            SSL_write(ssl, response, strlen(response));
-                            snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
-                            SSL_write(ssl, response, strlen(response));
-                            sleep(1);
-                            exit(0);
-                        }
-                    }
-                    agentname = fname;
+
 
                     /* Add the new agent */
                     if (use_ip_address) {
@@ -483,6 +470,25 @@ int main(int argc, char **argv)
                         sleep(1);
                         exit(0);
                     }
+                    
+                    /* Check for duplicated names */
+                    strncpy(fname, agentname, 2048);
+                    
+                    while (NameExist(fname)) {
+                        snprintf(fname, 2048, "%s%d", agentname, acount);
+                        acount++;
+                        if (acount > 256) {
+                            merror("%s: ERROR: Invalid agent name %s (duplicated)", ARGV0, agentname);
+                            snprintf(response, 2048, "ERROR: Invalid agent name: %s\n\n", agentname);
+                            SSL_write(ssl, response, strlen(response));
+                            snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
+                            SSL_write(ssl, response, strlen(response));
+                            sleep(1);
+                            exit(0);
+                        }
+                    }
+                    
+                    agentname = fname;
 
                     snprintf(response, 2048, "OSSEC K:'%s'\n\n", finalkey);
                     verbose("%s: INFO: Agent key generated for %s (requested by %s)", ARGV0, agentname, srcip);


### PR DESCRIPTION
Autd won't use password by default (flag added in the help menu). Additonally, Avoided ossec-authd to rename agent when removing an older one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ossec/ossec-hids/1169)
<!-- Reviewable:end -->
