### PR TITLE
Bug on key manager fix

### DIFF
--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -168,6 +168,8 @@ int main(int argc, char **argv)
     memset(process_pool, 0x0, POOL_SIZE * sizeof(*process_pool));
     bio_err = 0;
 
+    OS_PassEmptyKeyfile();
+
     /* Set the name */
     OS_SetName(ARGV0);
 

--- a/src/os_crypto/shared/keys.c
+++ b/src/os_crypto/shared/keys.c
@@ -16,7 +16,7 @@
 static void __memclear(char *id, char *name, char *ip, char *key, size_t size) __attribute((nonnull));
 static void __chash(keystore *keys, const char *id, const char *name, char *ip, const char *key) __attribute((nonnull));
 
-
+static int pass_empty_keyfile = 0;
 /* Clear keys entries */
 static void __memclear(char *id, char *name, char *ip, char *key, size_t size)
 {
@@ -418,4 +418,7 @@ int OS_IsAllowedDynamicID(keystore *keys, const char *id, const char *srcip)
 
     return (-1);
 }
-
+ /* Configure to pass if keys file is empty */
+ void OS_PassEmptyKeyfile() {
+     pass_empty_keyfile = 1;
+ }


### PR DESCRIPTION
Fixed bug on key manager that made it to always ignore an empty key file. Additionally, OS_PassEmptyKeyfile function was implemented in keys.c.