### PR TITLE
Fixes newer (?) versions of check.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -45,6 +45,9 @@ ifneq (,$(filter ${REUSE_ID},yes y Y 1))
 endif
 
 OSSEC_LDFLAGS=${LDFLAGS} -lm
+ifeq (${TARGET},test)
+	OSSEC_LDFLAGS+= -lsubunit
+endif
 
 ifneq (${TARGET},winagent)
 ifeq (${uname_S},Linux)


### PR DESCRIPTION
Some versions of check require `-lsubunit`
Hopefully this doesn't affect the version on travis.