### PR TITLE
Allow the auth ciphers to be specified with the -c option

### DIFF
--- a/src/os_auth/auth.h
+++ b/src/os_auth/auth.h
@@ -45,10 +45,11 @@
 extern BIO *bio_err;
 #define KEYFILE  "/etc/sslmanager.key"
 #define CERTFILE "/etc/sslmanager.cert"
+#define DEFAULT_CIPHERS "HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH"
 #define DEFAULT_PORT "1515"
 
-SSL_CTX *os_ssl_keys(int is_server, const char *os_dir, const char *cert, const char *key, const char *ca_cert);
-SSL_CTX *get_ssl_context(void);
+SSL_CTX *os_ssl_keys(int is_server, const char *os_dir, const char *ciphers, const char *cert, const char *key, const char *ca_cert);
+SSL_CTX *get_ssl_context(const char *ciphers);
 int load_cert_and_key(SSL_CTX *ctx, const char *cert, const char *key);
 int load_ca_cert(SSL_CTX *ctx, const char *ca_cert);
 int verify_callback(int ok, X509_STORE_CTX *store);

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -44,7 +44,7 @@ static void help_agent_auth(void) __attribute__((noreturn));
 static void help_agent_auth()
 {
     print_header();
-    print_out("  %s: -[Vhdt] [-g group] [-D dir] [-m IP address] [-p port] [-A name] [-v path] [-x path] [-k path]", ARGV0);
+    print_out("  %s: -[Vhdt] [-g group] [-D dir] [-m IP address] [-p port] [-A name] [-c ciphers] [-v path] [-x path] [-k path]", ARGV0);
     print_out("    -V          Version and license message");
     print_out("    -h          This help message");
     print_out("    -d          Execute in debug mode. This parameter");
@@ -56,6 +56,7 @@ static void help_agent_auth()
     print_out("    -m <addr>   Manager IP address");
     print_out("    -p <port>   Manager port (default: %s)", DEFAULT_PORT);
     print_out("    -A <name>   Agent name (default: hostname)");
+    print_out("    -c          SSL cipher list (default: %s)", DEFAULT_CIPHERS);
     print_out("    -v <path>   Full path to CA certificate used to verify the server");
     print_out("    -x <path>   Full path to agent certificate");
     print_out("    -k <path>   Full path to agent key");
@@ -75,6 +76,7 @@ int main(int argc, char **argv)
 
     int sock = 0, portnum, ret = 0;
     char *port = DEFAULT_PORT;
+    char *ciphers = DEFAULT_CIPHERS;
     const char *dir = DEFAULTDIR;
     const char *group = GROUPGLOBAL;
     char *authpass = NULL;
@@ -98,7 +100,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    while ((c = getopt(argc, argv, "Vdhtg:m:p:A:v:x:k:D:P:")) != -1) {
+    while ((c = getopt(argc, argv, "Vdhtg:m:p:A:c:v:x:k:D:P:")) != -1) {
         switch (c) {
             case 'V':
                 print_version();
@@ -145,6 +147,12 @@ int main(int argc, char **argv)
                     ErrorExit("%s: Invalid port: %s", ARGV0, optarg);
                 }
                 port = optarg;
+                break;
+            case 'c':
+                if (!optarg) {
+                    ErrorExit("%s: -%c needs an argument", ARGV0, c);
+                }
+                ciphers = optarg;
                 break;
             case 'v':
                 if (!optarg) {
@@ -222,7 +230,7 @@ int main(int argc, char **argv)
     }
 
     /* Start SSL */
-    ctx = os_ssl_keys(0, dir, agent_cert, agent_key, ca_cert);
+    ctx = os_ssl_keys(0, dir, ciphers, agent_cert, agent_key, ca_cert);
     if (!ctx) {
         merror("%s: ERROR: SSL error. Exiting.", ARGV0);
         exit(1);

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -51,7 +51,7 @@ static void clean_exit(SSL_CTX *ctx, int sock) __attribute__((noreturn));
 static void help_authd()
 {
     print_header();
-    print_out("  %s: -[Vhdti] [-g group] [-D dir] [-p port] [-v path] [-x path] [-k path]", ARGV0);
+    print_out("  %s: -[Vhdti] [-g group] [-D dir] [-p port] [-c ciphers] [-v path] [-x path] [-k path]", ARGV0);
     print_out("    -V          Version and license message");
     print_out("    -h          This help message");
     print_out("    -d          Execute in debug mode. This parameter");
@@ -63,6 +63,7 @@ static void help_authd()
     print_out("    -D <dir>    Directory to chroot into (default: %s)", DEFAULTDIR);
     print_out("    -p <port>   Manager port (default: %s)", DEFAULT_PORT);
     print_out("    -n          Disable shared password authentication (not recommended).\n");
+    print_out("    -c          SSL cipher list (default: %s)", DEFAULT_CIPHERS);
     print_out("    -v <path>   Full path to CA certificate used to verify clients");
     print_out("    -x <path>   Full path to server certificate");
     print_out("    -k <path>   Full path to server key");
@@ -151,6 +152,7 @@ int main(int argc, char **argv)
     gid_t gid;
     int client_sock = 0, sock = 0, portnum, ret = 0;
     char *port = DEFAULT_PORT;
+    char *ciphers = DEFAULT_CIPHERS;
     const char *dir  = DEFAULTDIR;
     const char *group = GROUPGLOBAL;
     const char *server_cert = NULL;
@@ -171,7 +173,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    while ((c = getopt(argc, argv, "Vdhtig:D:m:p:v:x:k:n")) != -1) {
+    while ((c = getopt(argc, argv, "Vdhtig:D:m:p:c:v:x:k:n")) != -1) {
         switch (c) {
             case 'V':
                 print_version();
@@ -212,6 +214,12 @@ int main(int argc, char **argv)
                     ErrorExit("%s: Invalid port: %s", ARGV0, optarg);
                 }
                 port = optarg;
+                break;
+            case 'c':
+                if (!optarg) {
+                    ErrorExit("%s: -%c needs an argument", ARGV0, c);
+                }
+                ciphers = optarg;
                 break;
             case 'v':
                 if (!optarg) {
@@ -312,7 +320,7 @@ int main(int argc, char **argv)
     fclose(fp);
 
     /* Start SSL */
-    ctx = os_ssl_keys(1, dir, server_cert, server_key, ca_cert);
+    ctx = os_ssl_keys(1, dir, ciphers, server_cert, server_key, ca_cert);
     if (!ctx) {
         merror("%s: ERROR: SSL error. Exiting.", ARGV0);
         exit(1);

--- a/src/os_auth/ssl.c
+++ b/src/os_auth/ssl.c
@@ -35,11 +35,11 @@ BIO *bio_err;
  * then load the file containing the CA chain and verify the certifcate
  * sent by the peer.
  */
-SSL_CTX *os_ssl_keys(int is_server, const char *os_dir, const char *cert, const char *key, const char *ca_cert)
+SSL_CTX *os_ssl_keys(int is_server, const char *os_dir, const char *ciphers, const char *cert, const char *key, const char *ca_cert)
 {
     SSL_CTX *ctx = NULL;
 
-    if (!(ctx = get_ssl_context())) {
+    if (!(ctx = get_ssl_context(ciphers))) {
         goto SSL_ERROR;
     }
 
@@ -94,7 +94,7 @@ SSL_ERROR:
     return (SSL_CTX *)NULL;
 }
 
-SSL_CTX *get_ssl_context()
+SSL_CTX *get_ssl_context(const char *ciphers)
 {
     const SSL_METHOD *sslmeth = NULL;
     SSL_CTX *ctx = NULL;
@@ -111,7 +111,7 @@ SSL_CTX *get_ssl_context()
 
     /* Explicitly set options and cipher list */
     SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2);
-    if (!(SSL_CTX_set_cipher_list(ctx, "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"))) {
+    if (!(SSL_CTX_set_cipher_list(ctx, ciphers))) {
         goto CONTEXT_ERR;
     }
 


### PR DESCRIPTION
The current list is too weak for PCI-DSS.