### PR TITLE
Allow authd to require a password for agents to get a key

### DIFF
--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -65,7 +65,10 @@ char *OS_AddNewAgent(const char *name, const char *ip, const char *id)
         id = nid;
     }
 
-    fp = fopen(AUTH_FILE, "a");
+    char authentication_file[2048 + 1];
+    snprintf(authentication_file, 2048, "%s%s", DEFAULTDIR, AUTH_FILE);
+
+    fp = fopen(authentication_file, "a");
     if (!fp) {
         return (NULL);
     }

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -9,6 +9,7 @@
 
 /* Unified function to read the configuration */
 
+#include <libgen.h>
 #include "shared.h"
 #include "os_xml/os_xml.h"
 #include "config.h"
@@ -154,7 +155,9 @@ int ReadConfig(int modules, const char *cfgfile, void *d1, void *d2)
 
     int xml_ret = OS_ReadXML(cfgfile, &xml);
     if (xml_ret < 0) {
-        const char *cfg_base = basename(cfgfile);
+	char *tmpcfg;
+	tmpcfg = strdup(cfgfile);
+        const char *cfg_base = basename(tmpcfg);
 	    if((strncmp(cfg_base, "agent.conf", 10)) == 0 && xml_ret == -2) {
 		    debug2("WARN: Cannot open %s: %s", cfgfile, xml.err);
 	    } else {

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -71,6 +71,7 @@ int main(int argc, char **argv)
     int key_added = 0;
     int c;
     int test_config = 0;
+    int authenticate = 0;
 #ifndef WIN32
     gid_t gid = 0;
 #endif
@@ -171,6 +172,7 @@ int main(int argc, char **argv)
                     ErrorExit("%s: -%c needs an argument", ARGV0, c);
                 }
                 authpass = optarg;
+                authenticate++;
                 break;
             default:
                 help_agent_auth();
@@ -242,7 +244,7 @@ int main(int argc, char **argv)
     }
 
     /* Checking if there is a custom password file */
-    if (authpass != NULL) {
+    if (authpass != NULL && authenticate > 0) {
         FILE *fp;
         fp = fopen(authpass, "r");
         if(!fp) {

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -258,11 +258,15 @@ int main(int argc, char **argv)
             fgets(buf, 4095, fp);
 
             if (strlen(buf) > 2) {
-                authpass = strndup(buf, 32); // XXX check return?
+                authpass = strndup(buf, 32);
+                if(!authpass) {
+                    fprintf(stderr, "Could not set the authpass: %s", strerror(errno));
+                    exit(1);
+                }
             }
 
             fclose(fp);
-            printf("INFO: Using password specified on file: %s\n", AUTHDPASS_PATH);
+            printf("INFO: Using specified password.\n");
         }
     }
     if (!authpass) {

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -22,6 +22,8 @@
  *
  */
 
+#include <errno.h>
+#include <string.h>
 #include "shared.h"
 #include "check_cert.h"
 
@@ -165,10 +167,11 @@ int main(int argc, char **argv)
                 agent_key = optarg;
                 break;
             case 'P':
-            if (!optarg)
-                ErrorExit("%s: -%c needs an argument", ARGV0, c);
-
-            authpass = optarg;
+                if (!optarg) {
+                    ErrorExit("%s: -%c needs an argument", ARGV0, c);
+                }
+                authpass = optarg;
+                break;
             default:
                 help_agent_auth();
                 break;
@@ -233,10 +236,19 @@ int main(int argc, char **argv)
         exit(1);
     }
 
+
+    if(authpass == NULL) {
+        authpass = AUTHDPASS_PATH;
+    }
+
     /* Checking if there is a custom password file */
-    if (authpass == NULL) {
+    if (authpass != NULL) {
         FILE *fp;
-        fp = fopen(AUTHDPASS_PATH, "r");
+        fp = fopen(authpass, "r");
+        if(!fp) {
+            fprintf(stderr, "Cannot open %s: %s\n", authpass, strerror(errno));
+            exit(1);
+        }
         buf[0] = '\0';
 
         if (fp) {

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -61,7 +61,7 @@ static void help_agent_auth()
     print_out("    -v <path>   Full path to CA certificate used to verify the server");
     print_out("    -x <path>   Full path to agent certificate");
     print_out("    -k <path>   Full path to agent key");
-    print_out("    -P <path>   Authorization password");
+    print_out("    -P <path>   Authorization password file [default: /var/ossec/etc/authd.pass");
     print_out(" ");
     exit(1);
 }

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -258,7 +258,7 @@ int main(int argc, char **argv)
             fgets(buf, 4095, fp);
 
             if (strlen(buf) > 2) {
-                authpass = buf;
+                authpass = strndup(buf, 32); // XXX check return?
             }
 
             fclose(fp);
@@ -304,6 +304,7 @@ int main(int argc, char **argv)
 
     printf("INFO: Using agent name as: %s\n", agentname);
 
+    memset(buf, 0, sizeof(buf));
     if (authpass) {
         snprintf(buf, 2048, "OSSEC PASS: %s OSSEC A:'%s'\n", authpass, agentname);
     }

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -311,8 +311,9 @@ int main(int argc, char **argv)
             authpass = __generatetmppass();
             verbose("Accepting connections. Random password chosen for agent authentication: %s", authpass);
         }
-    } else
+    } else {
         verbose("Accepting connections. No password required (not recommended)");
+    }
 
     /* Getting SSL cert. */
 

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -344,10 +344,12 @@ int main(int argc, char **argv)
     srandom_init();
 
     /* Chroot */
+/*
     if (Privsep_Chroot(dir) < 0)
         ErrorExit(CHROOT_ERROR, ARGV0, dir, errno, strerror(errno));
 
     nowChroot();
+*/
 
     while (1) {
         /* No need to completely pin the cpu, 100ms should be fast enough */


### PR DESCRIPTION
Based on the pull requests from @hcw2016 which I think were based on the Wazuh fork.

I removed chrooting from authd, which I'm not entirely happy with. But the `/dev/urandom` issue popped up again. `ossec-authd` might be something we can just require someone to create the device though?