### PR TITLE
Force groupadd to work.

### DIFF
--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -52,7 +52,7 @@ else
 	sys_acct_chk () {
 	    $1 --help 2>&1 | grep -e " *-r.*system account" >/dev/null 2>&1 && echo "$1 -r" || echo "$1"
 	  }
-	GROUPADD=$(sys_acct_chk "/usr/sbin/groupadd")
+	GROUPADD=$(sys_acct_chk "/usr/sbin/groupadd -f")
 	USERADD=$(sys_acct_chk "/usr/sbin/useradd")
         OSMYSHELL="/sbin/nologin"
     fi


### PR DESCRIPTION
 Based on a user reporting installation failures due to the group being in ldap. From Wazuh commit:
https://github.com/wazuh/wazuh/commit/deb7a7a8460c8cdbf0430e86b447415aced273ae

Small spelling fix as well.