### PR TITLE
Hopefully handle logs with both srcport and without.

### DIFF
--- a/contrib/ossec-testing/tests/asterisk.ini
+++ b/contrib/ossec-testing/tests/asterisk.ini
@@ -6,3 +6,10 @@ rule = 6210
 alert = 5
 decoder = asterisk
 
+[invalid extension]
+log 1 pass = Aug 30 16:02:29 hostname asterisk[3284]: NOTICE[3734][C-00001c7a]: chan_sip.c:25650 in handle_request_invite: Call from '' (89.163.146.112:5071) to extension '70046313115067' rejected because extension not found in context 'default'.
+
+rule = 6258
+alert = 5
+decoder = asterisk
+

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -2244,8 +2244,8 @@ Sat May  7 03:27:57 CDT 2011 /var/ossec/active-response/bin/firewall-drop.sh del
 <decoder name="asterisk-denied2">
   <parent>asterisk</parent>
   <prematch>Registration from </prematch>
-  <regex offset="after_prematch">failed for '(\S+)'</regex>
-  <order>srcip</order>
+  <regex offset="after_prematch">failed for '(\S+):(\d+)'|failed for '(\S+)'</regex>
+  <order>srcip,srcport/order>
 </decoder>
 
 <decoder name="asterisk-iax-authentication-denied">

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -2248,6 +2248,13 @@ Sat May  7 03:27:57 CDT 2011 /var/ossec/active-response/bin/firewall-drop.sh del
   <order>srcip,srcport</order>
 </decoder>
 
+<decoder name="asterisk-denied3">
+  <parent>asterisk</parent>
+  <prematch>^NOTICE[\d+][\w+]: \S+ in \S+: Call from </prematch>
+  <regex offset="after_prematch">^'\S*' \((\S+):(\d+)\) to extension '(\S+)' rejected because extension not found in context '(\S+)'.$</regex>
+  <order>srcip, srcport, extra_data, extra_data</order>
+</decoder>
+
 <decoder name="asterisk-iax-authentication-denied">
   <parent>asterisk</parent>
   <prematch>^NOTICE[\d+]: \S+ in \S+: Host </prematch>

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -2245,7 +2245,7 @@ Sat May  7 03:27:57 CDT 2011 /var/ossec/active-response/bin/firewall-drop.sh del
   <parent>asterisk</parent>
   <prematch>Registration from </prematch>
   <regex offset="after_prematch">failed for '(\S+):(\d+)'|failed for '(\S+)'</regex>
-  <order>srcip,srcport/order>
+  <order>srcip,srcport</order>
 </decoder>
 
 <decoder name="asterisk-iax-authentication-denied">

--- a/etc/rules/asterisk_rules.xml
+++ b/etc/rules/asterisk_rules.xml
@@ -117,7 +117,13 @@
     <description>Multiple failed logins.</description>
   </rule>
 
-  
+  <rule id="6258" level="5">
+    <if_sid>6201</if_sid>
+    <match>No matching peer found|extension not found in context</match>
+    <description>Login session failed (invalid extension).</description>
+    <group>invalid_login,</group>
+  </rule>
+
 </group> <!-- ASTERISK -->
 
 <!-- EOF -->


### PR DESCRIPTION
 Log samples are sparse.
Should fix issue #1232