### PR TITLE
fix a dead loop in hash_op.c

### DIFF
--- a/src/shared/hash_op.c
+++ b/src/shared/hash_op.c
@@ -243,13 +243,9 @@ void *OSHash_Get(const OSHash *self, const char *key)
     /* Get entry */
     curr_node = self->table[index];
     while (curr_node != NULL) {
-        /* Skip null pointers */
-        if ( curr_node->key == NULL ) {
-            continue;
-        }
 
         /* We may have colisions, so double check with strcmp */
-        if (strcmp(curr_node->key, key) == 0) {
+        if (curr_node->key != NULL && strcmp(curr_node->key, key) == 0) {
             return (curr_node->data);
         }
 


### PR DESCRIPTION
dead loop when curr_node->key is  NULL