### PR TITLE
Make rootcheck sleep interval configurable

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -89,6 +89,10 @@ monitord.notify_time=600
 syscheck.sleep=2
 syscheck.sleep_after=15
 
+# Rootcheck checking/usage speed. Rootcheck will pause for this
+# duration after scanning a PID or port.
+rootcheck.sleep=2
+
 
 # Database - maximum number of reconnect attempts
 dbd.reconnect_attempts=10

--- a/src/config/rootcheck-config.h
+++ b/src/config/rootcheck-config.h
@@ -32,6 +32,10 @@ typedef struct _rkconfig {
     int disabled;
     short skip_nfs;
 
+#ifdef OSSECHIDS
+    unsigned int tsleep;
+#endif /* OSSECHIDS */
+
     int time;
     int queue;
 

--- a/src/rootcheck/check_rc_pids.c
+++ b/src/rootcheck/check_rc_pids.c
@@ -173,7 +173,8 @@ static void loop_all_pids(const char *ps, pid_t max_pid, int *_errors, int *_tot
 
         /* If we are run in the context of OSSEC-HIDS, sleep here (no rush) */
 #ifdef OSSECHIDS
-        sleep(2);
+        debug1("%s: DEBUG: pause for %u", ARGV0, rootcheck.tsleep);
+        sleep(rootcheck.tsleep);
 #endif
 
         /* Everything fine, move on */

--- a/src/rootcheck/check_rc_ports.c
+++ b/src/rootcheck/check_rc_ports.c
@@ -140,7 +140,8 @@ static void test_ports(int proto, int *_errors, int *_total)
 
 #ifdef OSSECHIDS
             /* If we are in the context of OSSEC-HIDS, sleep here (no rush) */
-            sleep(2);
+            debug1("%s: DEBUG: pause for %u", ARGV0, rootcheck.tsleep);
+            sleep(rootcheck.tsleep);
 #endif
 
             if (!run_netstat(proto, i) && conn_port(proto, i)) {

--- a/src/rootcheck/rootcheck.c
+++ b/src/rootcheck/rootcheck.c
@@ -90,6 +90,11 @@ int rootcheck_init(int test_config)
     rootcheck.checks.rc_ports = 1;
     rootcheck.checks.rc_sys = 1;
     rootcheck.checks.rc_trojans = 1;
+
+#ifdef OSSECHIDS
+    rootcheck.tsleep = (unsigned int) getDefine_Int("rootcheck", "sleep", 0, 64);
+#endif
+
 #ifdef WIN32
     rootcheck.checks.rc_winaudit = 1;
     rootcheck.checks.rc_winmalware = 1;

--- a/src/rootcheck/run_rk_check.c
+++ b/src/rootcheck/run_rk_check.c
@@ -239,34 +239,40 @@ void run_rk_check()
     if (rootcheck.checks.rc_dev) {
         debug1("%s: DEBUG: Going into check_rc_dev", ARGV0);
         check_rc_dev(rootcheck.basedir);
+        debug1("%s: DEBUG: Exiting check_rc_dev", ARGV0);
     }
 
     /* Scan the whole system for additional issues */
     if (rootcheck.checks.rc_sys) {
         debug1("%s: DEBUG: Going into check_rc_sys", ARGV0);
         check_rc_sys(rootcheck.basedir);
+        debug1("%s: DEBUG: Exiting check_rc_sys", ARGV0);
     }
 
     /* Check processes */
     if (rootcheck.checks.rc_pids) {
         debug1("%s: DEBUG: Going into check_rc_pids", ARGV0);
         check_rc_pids();
+        debug1("%s: DEBUG: Exiting check_rc_pids", ARGV0);
     }
 
     /* Check all ports */
     if (rootcheck.checks.rc_ports) {
         debug1("%s: DEBUG: Going into check_rc_ports", ARGV0);
         check_rc_ports();
+        debug1("%s: DEBUG: Exiting check_rc_ports", ARGV0);
 
         /* Check open ports */
         debug1("%s: DEBUG: Going into check_open_ports", ARGV0);
         check_open_ports();
+        debug1("%s: DEBUG: Exiting check_open_ports", ARGV0);
     }
 
     /* Check interfaces */
     if (rootcheck.checks.rc_if) {
         debug1("%s: DEBUG: Going into check_rc_if", ARGV0);
         check_rc_if();
+        debug1("%s: DEBUG: Exiting check_rc_if", ARGV0);
     }
 
     debug1("%s: DEBUG: Completed with all checks.", ARGV0);


### PR DESCRIPTION
Sleeping for 2 seconds after each PID may be very slow on a busy system
(and during this time, syscheckd is not processing new events), and in
some cases it might be preferable to use other means of throttling (e.g.
cgroups) to limit rootcheck's impact on the system.

This flag lets the user customize rootcheck's sleep interval however
they want it (in our case, we're using 0 seconds and cgroups).