### PR TITLE
Fix the useradd and groupadd script on OpenBSD

### DIFF
--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -45,6 +45,10 @@ else
         GROUPADD="/usr/sbin/mkgroup"
         USERADD="/usr/sbin/useradd"
         OSMYSHELL="/bin/false"
+    elif [ "$UNAME" = "OpenBSD" ]; then
+        GROUPADD="/usr/sbin/groupadd"
+        USERADD="/usr/sbin/useradd"
+        OSMYSHELL="/sbin/nologin"
     else
 	# All current linux distributions should support system accounts for
 	# users/groups. If not, leave the GROUPADD/USERADD as it was before


### PR DESCRIPTION
Apparently OpenBSD doesn't like the new force options when adding the users and groups. So don't require them. Apparently I don't do enough fresh installations.