### PR TITLE
if getaddrinfo fails with EAI_FAMILY try ipv4

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -69,7 +69,7 @@ int OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
 
     s = getaddrinfo(_ip, _port, &hints, &result);
     /* Try to support legacy ipv4 only hosts */
-    if(s == EAI_FAMILY) {
+    if((s == EAI_FAMILY) || (s == EAI_NONAME)) {
         hints.ai_family = AF_INET;
         s = getaddrinfo(_ip, _port, &hints, &result);
     }

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -68,6 +68,11 @@ int OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
     }
 
     s = getaddrinfo(_ip, _port, &hints, &result);
+    /* Try to support legacy ipv4 only hosts */
+    if(s == EAI_FAMILY) {
+        hints.ai_family = AF_INET;
+        s = getaddrinfo(_ip, _port, &hints, &result);
+    }
     if (s != 0) {
         verbose("getaddrinfo: %s", gai_strerror(s));
         return(OS_INVALID);


### PR DESCRIPTION
Attempt to fix issue #1145 by possibly working with ipv4 only hosts.
Testing would be nice, I'm unable to do much right now.