### PR TITLE
Update ownCloud decoder for oC 10

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -3022,6 +3022,7 @@ s=2 SFwdQ=0 SDupQ=0 SErr=0 RQ=2 RIQ=0 RFwdQ=0 RDupQ=0 RTCP=0 SFwdR=0 SFail=0 SFE
 
 <!-- ownCloud
    - Examples owncloud.log (Note that the syntax of failed login logs differs between oler and newer ownCloud versions):
+   - {"reqId":"Jrd4fkwIcXhVjtP8qODR","level":2,"time":"2017-09-20T15:44:23+02:00","remoteAddr":"127.0.0.1","user":"--","app":"core","method":"POST","url":"\/login","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')"}
    - {"reqId":"wlioIFa6pOvt6DIAoeHE","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')","level":2,"time":"2016-04-12T22:28:20+02:00","method":"POST","url":"\/","user":"--"}
    - {"reqId":"prLlx9+QIfl1jHtz9C5o","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')","level":2,"time":"2015-07-08T12:12:41+02:00"}
    - {"reqId":"wLP7a3MdzTo8wgCWret9","remoteAddr":"127.0.0.1","app":"core","message":"Login failed: 'admin' (Remote IP: '127.0.0.1')","level":2,"time":"2015-07-15T09:40:35+02:00","method":"POST","url":"\/"}
@@ -3043,7 +3044,7 @@ s=2 SFwdQ=0 SDupQ=0 SErr=0 RQ=2 RIQ=0 RFwdQ=0 RDupQ=0 RTCP=0 SFwdR=0 SFail=0 SFE
 -->
 
 <decoder name="owncloud">
-  <prematch>^{"reqId":"\S+","message":"\.+","level":\d,"time":"\.+"}$|^{"app":"\S+","message":"\.+","level":\d,"time":"\.+"}$</prematch>
+  <prematch>^{"reqId":"\S+","message":"\.+","level":\d,"time":"\.+"}$|^{"app":"\S+","message":"\.+","level":\d,"time":"\.+"}$|^{"reqId":"\S+","level":\d,"time":"\S+","message":"\.+"}$</prematch>
 </decoder>
 
 <!-- Note: This defaults to "ownCloud" but users can change the syslog tag: https://github.com/owncloud/core/blob/v10.0.2/config/config.sample.php#L608-L614 -->


### PR DESCRIPTION
This is a follow-up of https://github.com/ossec/ossec-hids/pull/1246

Seems they have changed the log order / syntax once more in ownCloud 10: https://github.com/owncloud/core/pull/27562