### PR TITLE
New known malicious user agents

### DIFF
--- a/etc/rules/web_appsec_rules.xml
+++ b/etc/rules/web_appsec_rules.xml
@@ -88,7 +88,7 @@
   <!-- BAD/Annoying user agents -->
   <rule id="31508" level="6">
     <if_sid>31100</if_sid>
-    <match> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af.sourceforge.net|MJ12bot/v</match>
+    <match> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af.sourceforge.net|MJ12bot/v| Jorgee"|"Proxy Gear Pro|"DataCha0s</match>
     <description>Blacklisted user agent (known malicious user agent).</description>
   </rule>
 


### PR DESCRIPTION
See e.g. http://www.skepticism.us/2015/05/new-malware-user-agent-value-jorgee/ (might be a good source for a few more malicious user agents)

Cross-Ref: https://github.com/wazuh/wazuh-ruleset/pull/79

Log-Sampe is:

``
1.2.3.4 - - [21/Oct/2017:16:27:00 +0200] "HEAD http://4.3.2.1:80/phppma/ HTTP/1.1" 404 0 "-" "Mozilla/5.0 Jorgee"
``