### PR TITLE
Named rules improvement

### DIFF
--- a/etc/rules/named_rules.xml
+++ b/etc/rules/named_rules.xml
@@ -68,11 +68,12 @@
     <description>DNS update using RFC2136 Dynamic protocol.</description>
   </rule>
 
-  <rule id="12108" level="0">
+  <rule id="12108" level="5">
     <if_sid>12100</if_sid>
     <match>query (cache) denied|: query (cache)</match>
     <description>Query cache denied (probably config error).</description>
     <info type="link">http://www.reedmedia.net/misc/dns/errors.html</info>
+    <group>connection_attempt,</group>
   </rule>
   
   <rule id="12109" level="12">
@@ -313,5 +314,12 @@
     <match>: parsing failed$</match>
     <description>Parsing of a configuration file has failed.</description>
   </rule>
+  
+  <rule id="12149" level="10" frequency="6" timeframe="120">
+   <if_matched_sid>12108</if_matched_sid>
+   <same_source_ip />
+   <description> Multiple query (cache) failures.</description>
+   <group>connection_attempt,</group>
+</rule>
 
 </group> <!-- SYSLOG,NAMED -->


### PR DESCRIPTION
Protection against a host that don't has recursion permission and/or authorization to local cache query. there is a different between allow-query and allow-query-cache. 

ref: 
* https://kb.isc.org/article/AA-00503/0/Whats-the-difference-between-allow-query-cache-and-allow-recursion.html
* http://www.zytrax.com/books/dns/ch7/queries.html#allow-query-cache