### PR TITLE
Allow alerts.log to be turned off

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -284,8 +284,8 @@ int main_analysisd(int argc, char **argv)
 
     /* Make sure at least 1 logging option is available */
     if(!Config.alertout_output && !Config.jsonout_output && !Config.zeromq_output) {
-      merror("%s: No alert logging has been configured!", ARGV0);
-    fi
+      merror("%s: ERROR: No alert logging has been configured!", ARGV0);
+    }
 
     /* Set the group */
     if (Privsep_SetGroup(gid) < 0) {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -913,10 +913,12 @@ void OS_ReadMSG_analysisd(int m_queue)
                 if (currently_rule->alert_opts & DO_LOGALERT) {
                     __crt_ftell = ftell(_aflog);
 
-                    if (Config.custom_alert_output) {
-                        OS_CustomLog(lf, Config.custom_alert_output_format);
-                    } else {
-                        OS_Log(lf);
+                    if(Config.alertout_output) {
+                        if (Config.custom_alert_output) {
+                            OS_CustomLog(lf, Config.custom_alert_output_format);
+                        } else {
+                            OS_Log(lf);
+                        }
                     }
                     /* Log to json file */
                     if (Config.jsonout_output) {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -282,6 +282,11 @@ int main_analysisd(int argc, char **argv)
     }
 #endif
 
+    /* Make sure at least 1 logging option is available */
+    if(!Config.alertout_output && !Config.jsonout_output && !Config.zeromq_output) {
+      merror("%s: No alert logging has been configured!", ARGV0);
+    fi
+
     /* Set the group */
     if (Privsep_SetGroup(gid) < 0) {
         ErrorExit(SETGID_ERROR, ARGV0, group, errno, strerror(errno));

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -107,6 +107,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
     const char *xml_zeromq_output_server_cert = "zeromq_server_cert";
     const char *xml_zeromq_output_client_cert = "zeromq_client_cert";
     const char *xml_jsonout_output = "jsonout_output";
+    const char *xml_alerts_output = "alertout_output";
     const char *xml_stats = "stats";
     const char *xml_memorysize = "memory_size";
     const char *xml_white_list = "white_list";
@@ -272,6 +273,21 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
             } else {
                 merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
                 return (OS_INVALID);
+            }
+        }
+        /* Multi-line alerts.log output */
+        else if (strcmp(node[i]-> element, xml_alerts_output) == 0) {
+            if(strncmp(node[i]->content, "yes", 3) == 0) {
+                if(Config) {
+                    Config->alertout_output = 1;
+                }
+            } else if(strncmp(node[i]->content, "no", 2) == 0) {
+                if(Config) {
+                    Config->alertout_output = 0;
+                }
+            } else {
+                merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
+                return(OS_INVALID);
             }
         }
         /* Log all */

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -43,6 +43,8 @@ typedef struct __Config {
 
     /* JSONOUT Export */
     u_int8_t jsonout_output;
+    /* Multi-line alerts.log export */
+    u_int8_t alertout_output;
 
     /* Not currently used */
     u_int8_t keeplogdate;


### PR DESCRIPTION
This has obvious implications in that maild and csyslogd will stop working. Possibly others.
But if those aren't used, and only the json output is used, maybe it's worth it.