### PR TITLE
Update Roundcube Decoders and Rules

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1659,30 +1659,47 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 
 <!-- Roundcube decoder
  - Will extract username and src IP from the logs, when available.
-   Examples:
- - Apr 10 22:45:20 hostname roundcube: [10-Apr-2009 22:45:20 -0500] IMAP
-   Error: Authentication for username failed (LOGIN): "a001 NO Authentication
-   failed." (POST /roundcube/?_task=&_action=login)
- - Apr 10 23:01:23 hostname roundcube: [10-Apr-2009 23:01:23 -0500]:
-   Successful login for username (id 1) from 127.0.0.1
+
+   Examples syslog: (older and newer versions of roundcube)
+ - Apr 10 22:45:20 hostname roundcube: [10-Apr-2009 22:45:20 -0500] IMAP Error: Authentication for username failed (LOGIN): "a001 NO Authentication failed." (POST /roundcube/?_task=&_action=login)
+ - Apr 10 23:01:23 hostname roundcube: [10-Apr-2009 23:01:23 -0500]: Successful login for username (id 1) from 127.0.0.1
+ - Oct 28 19:31:08 hostname roundcube: <isj89gtf> IMAP Error: Login failed for username from 127.0.0.1. AUTHENTICATE PLAIN: Authentication failed. in /var/www/html/roundcube/program/lib/Roundcube/rcube_imap.php on line 193 (POST /roundcube/?_task=login&_action=login)
+
+   Example from roundcube internal logfile (/path/to/roundcube/logs/errors):
+ - [04-Oct-2017 17:03:30 +0200]: <jkgnfe79> IMAP Error: Login failed for username from 127.0.0.1. AUTHENTICATE PLAIN: Authentication failed. in /var/www/html/roundcube/program/lib/Roundcube/rcube_imap.php on line 193 (POST /roundcube/?_task=login&_action=login)
+
+   Examples if log_logins is enabled (/path/to/roundcube/logs/userlogins):
+ - [04-Oct-2017 16:08:01 +0200]: <lrpo6s0r> Failed login for test from 127.0.0.1 in session abcdefg (error: 0)
+ - [04-Oct-2017 16:09:17 +0200]: <4bd4jqqc> Successful login for test (ID: 6) from 127.0.0.1 in session abcdefg
 -->
+
 <decoder name="roundcube">
   <program_name>^roundcube</program_name>
+</decoder>
+
+<decoder name="roundcube">
   <prematch>^[\d\d-\w\w\w-\d\d\d\d \d\d:\d\d:\d\d \S+]</prematch>
 </decoder>
 
 <decoder name="roundcube-success">
   <parent>roundcube</parent>
-  <prematch>^: Successful login for </prematch>
-  <regex offset="after_prematch">^(\S+) \(id \d+\) from (\S+)$</regex>
+  <prematch> Successful login for </prematch>
+  <regex offset="after_prematch">^(\S+) \(id \d+\) from (\S+)$|^(\S+) \(ID: \d+\) from (\S+)</regex>
   <order>user, srcip</order>
 </decoder>
 
-<decoder name="roundcube-denied">
+<decoder name="roundcube-denied-old">
   <parent>roundcube</parent>
-  <prematch>^ \w+ Error: Authentication </prematch>
-  <regex offset="after_prematch">^for (\.+) failed</regex>
+  <prematch>] \w+ Error: Authentication </prematch>
+  <regex offset="after_prematch">^for (\S+) failed</regex>
   <order>user</order>
+</decoder>
+
+<decoder name="roundcube-denied-new">
+  <parent>roundcube</parent>
+  <prematch>> \w+ Error: Login failed |> Failed login </prematch>
+  <regex offset="after_prematch">^for (\S+) from (\S+)\. |^for (\S+) from (\S+) in session </regex>
+  <order>user, srcip</order>
 </decoder>
 
 

--- a/etc/rules/roundcube_rules.xml
+++ b/etc/rules/roundcube_rules.xml
@@ -12,25 +12,32 @@
   -  License details: http://www.ossec.net/en/licensing.html
   -->
 
-<group name="syslog,roundcube,"> 
+<group name="syslog,roundcube,">
   <rule id="9400" level="0">
     <decoded_as>roundcube</decoded_as>
     <description>Roundcube messages grouped.</description>
   </rule>
-   
-  <rule id="9401" level="5">
+
+  <rule id="9401" level="6">
     <if_sid>9400</if_sid>
-    <match>failed (LOGIN)</match>
+    <match>failed (LOGIN)| Login failed | Authentication failed| Failed login </match>
     <description>Roundcube authentication failed.</description>
     <group>authentication_failed,</group>
   </rule>
-       
+
   <rule id="9402" level="3">
     <if_sid>9400</if_sid>
     <match>Successful login</match>
     <description>Roundcube authentication succeeded.</description>
     <group>authentication_success,</group>
-  </rule> 
+  </rule>
+
+  <rule id="9403" level="10" frequency="6" timeframe="120">
+    <if_matched_sid>9401</if_matched_sid>
+    <same_source_ip />
+    <description>Roundcube brute force (multiple failed logins).</description>
+    <group>authentication_failures,</group>
+  </rule>
 </group>
   
 


### PR DESCRIPTION
Fixes #1245

- Split the program_name and prematch decoders to catch the roundcube internal logfile as well
  - The prematch might be too lax so could be possible that this needs to be more strict
- Updated the roundcube-success decoder to catch logs of newer RC versions
- Renamed roundcube-denied into roundcube-denied-old and introduced an additional decoder for newer RC versions
- Raised the alert level of rule 9401 to 6 to match whats used in other failed login rules
- Added new rule for multiple failed logins

Cross-Ref: https://github.com/wazuh/wazuh-ruleset/pull/82