### PR TITLE
Add bitcoin wallet scans to suspicious URL's

### DIFF
--- a/etc/rules/web_appsec_rules.xml
+++ b/etc/rules/web_appsec_rules.xml
@@ -155,7 +155,7 @@
     -->
   <rule id="31516" level="6">
     <if_sid>31100</if_sid>
-    <url>.swp$|.bak$|/.htaccess|/server-status|/.ssh|/.history</url>
+    <url>.swp$|.bak$|/.htaccess|/server-status|/.ssh|/.history|/wallet.dat</url>
     <description>Suspicious URL access.</description>
    </rule>
 


### PR DESCRIPTION
Example logfile entries:

```
192.168.0.1 - - [22/Oct/2017:12:39:42 +0200] "GET /wallet.dat.1 HTTP/1.1" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:42 +0200] "GET /wallet.dat.1 HTTP/1.0" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:29 +0200] "GET /bitcoin_wallet.dat.zip HTTP/1.0" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:29 +0200] "GET /bitcoin_wallet.dat.zip HTTP/1.1" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:26 +0200] "GET /Bitcoin/wallet.dat HTTP/1.0" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:26 +0200] "GET /Bitcoin/wallet.dat HTTP/1.1" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:15 +0200] "GET /bitcoin%20datadir/wallet.dat HTTP/1.0" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:14 +0200] "GET /hostname_wallet.dat HTTP/1.0" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:14 +0200] "GET /home/.bitcoin/wallet.dat HTTP/1.0" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:15 +0200] "GET /bitcoin%20datadir/wallet.dat HTTP/1.1" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:14 +0200] "GET /hostname_wallet.dat HTTP/1.1" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
192.168.0.1 - - [22/Oct/2017:12:39:14 +0200] "GET /home/.bitcoin/wallet.dat HTTP/1.1" 404 210 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0"
```

Cross-ref: https://github.com/wazuh/wazuh-ruleset/pull/87