### PR TITLE
fix several compiler warnings (Wall, Wextra)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -783,7 +783,7 @@ crypto_blowfish_c := os_crypto/blowfish/bf_op.c \
 crypto_blowfish_o := $(crypto_blowfish_c:.c=.o)
 
 os_crypto/blowfish/%.o: os_crypto/blowfish/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -Wno-implicit-fallthrough -c $^ -o $@
 
 crypto_md5_c := os_crypto/md5/md5.c \
 							 os_crypto/md5/md5_op.c
@@ -796,7 +796,7 @@ crypto_sha1_c := os_crypto/sha1/sha1_op.c
 crypto_sha1_o := $(crypto_sha1_c:.c=.o)
 
 os_crypto/sha1/%.o: os_crypto/sha1/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -Wno-implicit-fallthrough -c $^ -o $@
 
 crypto_md5_sha1_c := os_crypto/md5_sha1/md5_sha1_op.c
 crypto_md5_sha1_o := $(crypto_md5_sha1_c:.c=.o)

--- a/src/analysisd/cdb/cdb_make.c
+++ b/src/analysisd/cdb/cdb_make.c
@@ -77,14 +77,14 @@ int cdb_make_addbegin(struct cdb_make *c, unsigned int keylen, unsigned int data
 {
     char buf[8];
 
-    if (keylen > 0xffffffff) {
+    /*if (keylen > 0xffffffff) {
         errno = ENOMEM;
         return -1;
     }
     if (datalen > 0xffffffff) {
         errno = ENOMEM;
         return -1;
-    }
+    }*/
 
     uint32_pack(buf, keylen);
     uint32_pack(buf + 4, datalen);

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -18,8 +18,6 @@
 /* Convert Eventinfo to json */
 char *Eventinfo_to_jsonstr(const Eventinfo *lf)
 {
-    char* time_string;
- 
     cJSON *root;
     cJSON *rule;
     cJSON *file_diff;
@@ -115,7 +113,7 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->generated_rule->last_events && lf->generated_rule->last_events[1] && lf->generated_rule->last_events[1][0]) {
         cJSON_AddStringToObject(root, "previous_output", lf->generated_rule->last_events[1]);
     }
-    
+
     if (lf->filename) {
         cJSON_AddItemToObject(root, "file", file_diff = cJSON_CreateObject());
 

--- a/src/monitord/generate_reports.c
+++ b/src/monitord/generate_reports.c
@@ -66,11 +66,6 @@ void generate_reports(int cday, int cmon, int cyear)
                 os_ReportdStart(&mond.reports[s]->r_filter);
                 fflush(mond.reports[s]->r_filter.fp);
 
-                time_t tm;
-                tm = time(NULL);
-                const struct tm *p2;
-                p2 = localtime(&tm);
-
                 fclose(mond.reports[s]->r_filter.fp);
 
                 struct stat sb;

--- a/src/monitord/sendcustomemail.c
+++ b/src/monitord/sendcustomemail.c
@@ -46,7 +46,7 @@
 #define MAIL_DEBUG(x,y,z) if(MAIL_DEBUG_FLAG) merror(x,y,z)
 
 
-int OS_SendCustomEmail2(char **to, char *subject, char *smtpserver, char *from, char *replyto, char *idsname, char *fname)
+int OS_SendCustomEmail2(char **to, char *subject, char *smtpserver, char *from, char *replyto, char *idsname, __attribute__((unused)) char *fname)
 {
     FILE *sendmail = NULL;
     int socket = -1, i = 0;
@@ -268,8 +268,7 @@ int OS_SendCustomEmail2(char **to, char *subject, char *smtpserver, char *from, 
     FILE *fp;
     fp = fopen(fname2, "r");
     if(!fp) {
-        merror("%s: ERROR: Cannot open %s: %s", __local_name, fname2, strerror(errno)); 
-        free(msg);
+        merror("%s: ERROR: Cannot open %s: %s", __local_name, fname2, strerror(errno));
         return(1);
     }
 

--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -260,8 +260,7 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     FILE *fp;
     fp = fopen(fname, "r");
     if(!fp) {
-        merror("%s: ERROR: Cannot open %s: %s", __local_name, fname, strerror(errno)); 
-        free(msg);
+        merror("%s: ERROR: Cannot open %s: %s", __local_name, fname, strerror(errno));
         return(1);
     }
 
@@ -272,10 +271,10 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     if(sr < 0) {
         merror("Cannot stat %s: %s", fname, strerror(errno));
     } else {
-        merror("YYY size is: %lld", sb.st_size);
+        merror("YYY size is: %ld", sb.st_size);
     }
     if(sb.st_size > 0) {
-        merror("YYY Size is: %lld", sb.st_size);
+        merror("YYY Size is: %ld", sb.st_size);
     } else {
         merror("Report is empty");
         return(0);

--- a/src/os_regex/os_regex.h
+++ b/src/os_regex/os_regex.h
@@ -123,7 +123,7 @@ size_t OS_StrHowClosedMatch(const char *str1, const char *str2);
 int OS_StrStartsWith(const char *str, const char *pattern) __attribute__((nonnull));
 
 /* Checks if a specific string is numeric (like "129544") */
-int OS_StrIsNum(const char *str) __attribute__((nonnull));
+int OS_StrIsNum(const char *str);
 
 /* Checks if a specified char is in the following range:
  * a-z, A-Z, 0-9, _-.

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -700,12 +700,12 @@ char *getuname()
     if (uname(&uts_buf) >= 0) {
         char *ret;
 
-        ret = (char *) calloc(256, sizeof(char));
+        ret = (char *) calloc(512, sizeof(char));
         if (ret == NULL) {
             return (NULL);
         }
 
-        snprintf(ret, 255, "%s %s %s %s %s - %s %s",
+        snprintf(ret, 511, "%s %s %s %s %s - %s %s",
                  uts_buf.sysname,
                  uts_buf.nodename,
                  uts_buf.release,
@@ -716,12 +716,12 @@ char *getuname()
         return (ret);
     } else {
         char *ret;
-        ret = (char *) calloc(256, sizeof(char));
+        ret = (char *) calloc(512, sizeof(char));
         if (ret == NULL) {
             return (NULL);
         }
 
-        snprintf(ret, 255, "No system info available -  %s %s",
+        snprintf(ret, 511, "No system info available -  %s %s",
                  __ossec_name, __version);
 
         return (ret);

--- a/src/shared/validate_op.c
+++ b/src/shared/validate_op.c
@@ -402,7 +402,7 @@ int sacmp(struct sockaddr *sa1, struct sockaddr *sa2, int prefixlength)
         }
     }
     if (ip_div.rem) {
-        modbits = ((char) ~0) << (8 - ip_div.rem);
+        modbits = ((unsigned char) ~0) << (8 - ip_div.rem);
         if ( (addr1[i] & modbits) != (addr2[i] & modbits) ) {
             return(!_true);
         }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -261,7 +261,7 @@ static int read_dir(const char *dir_name, int opts, OSMatch *restriction)
     f_name[PATH_MAX + 1] = '\0';
 
     /* Directory should be valid */
-    if ((dir_name == NULL) || ((dir_size = strlen(dir_name)) > PATH_MAX)) {
+    if ((dir_size = strlen(dir_name)) > PATH_MAX) {
         merror(NULL_ERROR, ARGV0);
         return (-1);
     }

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
                 break;
             case 'i':
                 info_agent++;
-            /* no break; */
+            	//FALLTHRU
             case 'u':
                 if (!optarg) {
                     merror("%s: -u needs an argument", ARGV0);


### PR DESCRIPTION
```os_maild/sendcustomemail.c: In function ‘OS_SendCustomEmail’:
os_maild/sendcustomemail.c:275:33: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 2 has type ‘__off_t {aka long int}’ [-Wformat=]
os_maild/sendcustomemail.c:278:33: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 2 has type ‘__off_t {aka long int}’ [-Wformat=]
os_maild/sendcustomemail.c:264:9: warning: ‘msg’ may be used uninitialized in this function [-Wmaybe-uninitialized]

os_crypto/blowfish/bf_enc.c: In function ‘BF_cbc_encrypt’:
os_crypto/blowfish/bf_locl.h:121:24: warning: this statement may fall through [-Wimplicit-fallthrough=]

os_crypto/sha1/md32_common.h: In function ‘SHA1_Update’:
os_crypto/sha1/md32_common.h:320:23: warning: this statement may fall through [-Wimplicit-fallthrough=]

shared/file_op.c: In function ‘getuname’:
shared/file_op.c:708:38: error: ‘%s’ directive output may be truncated writing up to 64 bytes into a region of size between 60 and 252 [-Werror=format-truncation=]

shared/validate_op.c: In function ‘sacmp’:
shared/validate_op.c:405:31: error: left shift of negative value [-Werror=shift-negative-value]

os_regex/os_regex_str.c:21:9: error: comparison of nonnull parameter 'str' equal to a null pointer is 'false' on first encounter [-Werror,-Wtautological-pointer-compare]

syscheckd/create_db.c:264:10: error: comparison of nonnull parameter 'dir_name' equal to a null pointer is 'false' on first encounter [-Werror,-Wtautological-pointer-compare]

monitord/sendcustomemail.c:49:117: error: unused parameter 'fname' [-Werror,-Wunused-parameter]

analysisd/format/to_json.c:21:11: error: unused variable 'time_string' [-Werror,-Wunused-variable]

analysisd/cdb/cdb_make.c:80:16: error: result of comparison 'unsigned int' > 4294967295 is always false [-Werror,-Wtautological-constant-compare]
analysisd/cdb/cdb_make.c:84:17: error: result of comparison 'unsigned int' > 4294967295 is always false [-Werror,-Wtautological-constant-compare]

util/agent_control.c: In function ‘main’:
util/agent_control.c:96:27: error: this statement may fall through [-Werror=implicit-fallthrough=]

monitord/sendcustomemail.c: In function ‘OS_SendCustomEmail2’:
monitord/sendcustomemail.c:272:9: error: ‘msg’ may be used uninitialized in this function [-Werror=maybe-uninitialized]

monitord/generate_reports.c: In function ‘generate_reports’:
monitord/generate_reports.c:71:34: error: variable ‘p2’ set but not used [-Werror=unused-but-set-variable]```