### PR TITLE
Add some ifdefs for the md5 whitelist database.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -562,6 +562,7 @@ settings:
 	@echo "    USE_PRELUDE:      ${USE_PRELUDE}"
 	@echo "    USE_OPENSSL:      ${USE_OPENSSL}"
 	@echo "    USE_INOTIFY:      ${USE_INOTIFY}"
+	@echo "    USE_SQLITE:       ${USE_SQLITE}"
 	@echo "Mysql settings:"
 	@echo "    includes:         ${MI}"
 	@echo "    libs:             ${ML}"

--- a/src/Makefile
+++ b/src/Makefile
@@ -116,7 +116,7 @@ ifdef DEBUGAD
 endif
 
 OSSEC_CFLAGS=${CFLAGS}
-ANALYSISD_FLAGS="-lsqlite3"
+#ANALYSISD_FLAGS="-lsqlite3"
 
 ifdef DEBUG
 	OSSEC_CFLAGS+=-g
@@ -209,6 +209,10 @@ ifneq (,$(filter ${USE_GEOIP},auto yes y Y 1))
 	OSSEC_LDFLAGS+=-lGeoIP
 endif # USE_GEOIP
 
+ifneq (,$(filter ${USE_SQLITE},auto yes y Y 1))
+	DEFINES+=-DSQLITE_ENABLED
+	ANALYSISD_FLAGS="-lsqlite3"
+endif # USE_SQLITE
 
 MI :=
 PI :=

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -41,7 +41,9 @@
 #include "output/zeromq.h"
 #endif
 
+#ifdef SQLITE_ENABLED
 #include "syscheck-sqlite.h"
+#endif
 
 /** Prototypes **/
 void OS_ReadMSG(int m_queue);
@@ -656,6 +658,7 @@ void OS_ReadMSG_analysisd(int m_queue)
         Free_Eventinfo(lf);
     }
 
+#ifdef SQLITE_ENABLED
     /* Open the sqlite db */
     extern sqlite3 *conn;
     int s_error = 0;
@@ -666,6 +669,7 @@ void OS_ReadMSG_analysisd(int m_queue)
         }
 
     }
+#endif
 
     debug1("%s: DEBUG: Startup completed. Waiting for new messages..", ARGV0);
 

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -15,8 +15,9 @@
 #include "alerts/alerts.h"
 #include "decoder.h"
 
-//#include <sqlite3.h>
+#ifdef SQLITE_ENABLED
 #include "syscheck-sqlite.h"
+#endif
 
 typedef struct __sdb {
     char buf[OS_MAXSTR + 1];
@@ -622,7 +623,9 @@ int DecodeSyscheck(Eventinfo *lf)
 
     char *p;
     char stmt[OS_MAXSTR + 1];
+#ifdef SQLITE_ENABLED
     sqlite3_stmt *res;
+#endif
     int error = 0;
     int rec_count = 0;
     const char *tail;
@@ -678,6 +681,7 @@ int DecodeSyscheck(Eventinfo *lf)
      * Sample message:
      * 0:0:0:0:78f5c869675b1d09ddad870adad073f9:bd6c8d7a58b462aac86475e59af0e22954039c50
      */
+#ifdef SQLITE_ENABLED
     if (Config.md5_whitelist)  {
         extern sqlite3 *conn;
         if ((p = extract_token(c_sum, ":", 4))) {
@@ -702,6 +706,7 @@ int DecodeSyscheck(Eventinfo *lf)
             sqlite3_finalize(res);
         }
     }
+#endif
  
 
     /* Search for file changes */

--- a/src/analysisd/syscheck-sqlite.h
+++ b/src/analysisd/syscheck-sqlite.h
@@ -1,4 +1,5 @@
+#ifdef SQLITE_ENABLED
 #include <sqlite3.h>
 
 sqlite3 *conn;
-
+#endif

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -126,8 +126,10 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
     const char *xml_geoip6_db_path = "geoip6_db_path";
 #endif
 
+#ifdef SQLITE_ENABLED
     /* MD5 DB */
     char *xml_md5_whitelist = "md5_whitelist";
+#endif
 
     _Config *Config;
     MailConfig *Mail;
@@ -493,12 +495,15 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
             }
         }
 #endif
+
+#ifdef SQLITE_ENABLED
         /* MD5 DB */
         else if(strcmp(node[i]->element, xml_md5_whitelist) == 0) {
             if(Config) {
                 os_strdup(node[i]->content, Config->md5_whitelist);
             }
         }
+#endif
 
         else {
             merror(XML_INVELEM, __local_name, node[i]->element);


### PR DESCRIPTION
This should make it optional. Use USE_SQLITE to enable it.