### PR TITLE
Updates to rule_ids.txt

### DIFF
--- a/doc/rule_ids.txt
+++ b/doc/rule_ids.txt
@@ -80,6 +80,12 @@
 40900 - 40999 Firewalld
 
 51500 - 51999 OpenBSD rules.
-52000 - XXXXX Apparmor rules.
+52000 - 52499 Apparmor rules.
+52500 - 53199 clam av rules
+53200 - 53499 nsd rules
+53500 - 53299 opensmtpd rules
+53300 - 53399 owncloud rules
+53400 - xxxxx proxmox ve rules
+56000 - 56200 FreeBSD rules
 
 100000 - 109999 User defined rules


### PR DESCRIPTION
From @mobstef in issue #1366
Added a section for FreeBSD rules, although these may stay with the
port.