### PR TITLE
Fix the subject handling. Issue submitted by Michael Starks #1370

### DIFF
--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -135,7 +135,7 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p,
     }
 
     /* We have two subject options - full and normal */
-    if (Mail->subject_full) {
+    if (Mail->subject_full == 0) {
         /* Option for a clean full subject (without ossec in the name) */
 #ifdef CLEANFULL
         snprintf(mail->subject, SUBJECT_SIZE - 1, MAIL_SUBJECT_FULL2,


### PR DESCRIPTION
If `CLEANFULL` is enabled during the build, and `maild.full_subject=0`
the email subjects should be smaller. At some point the logic may
have been reversed (or the documentation and memories of users are
backwards).

Either way, allow this to work the way it's understood to work.

I'm not sure if the default in `internal_options.conf` should change to 1. I think this would restore the default behavior people may be expecting, but I'm not sure how much it matters.