### PR TITLE
Fix SID syntax for group membership changes

### DIFF
--- a/etc/rules/msauth_rules.xml
+++ b/etc/rules/msauth_rules.xml
@@ -499,7 +499,7 @@
 
   <rule id="18218" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-1-0}</regex>
+    <regex> ID:\s+S-1-1-0</regex>
     <description>Everyone Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -507,7 +507,7 @@
 
   <rule id="18219" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-9}</regex>
+    <regex> ID:\s+S-1-5-9</regex>
     <description>Enterprise Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -515,7 +515,7 @@
 
   <rule id="18220" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-11}</regex>
+    <regex> ID:\s+S-1-5-11</regex>
     <description>Authenticated Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -523,7 +523,7 @@
 
   <rule id="18221" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-13}</regex>
+    <regex> ID:\s+S-1-5-13</regex>
     <description>Terminal Server Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -531,7 +531,7 @@
 
   <rule id="18222" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-512}</regex>
+    <regex> ID:\s+S-1-5-21\S+-512</regex>
     <description>Domain Admins Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -539,7 +539,7 @@
 
   <rule id="18223" level="5">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-513}</regex>
+    <regex> ID:\s+S-1-5-21\S+-513</regex>
     <description>Domain Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -554,7 +554,7 @@
 
   <rule id="18225" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-514}</regex>
+    <regex> ID:\s+S-1-5-21\S+-514</regex>
     <description>Domain Guests Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -562,7 +562,7 @@
 
   <rule id="18226" level="5">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-515}</regex>
+    <regex> ID:\s+S-1-5-21\S+-515</regex>
     <description>Domain Computers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -570,7 +570,7 @@
 
   <rule id="18227" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-516}</regex>
+    <regex> ID:\s+S-1-5-21\S+-516</regex>
     <description>Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -578,7 +578,7 @@
 
   <rule id="18228" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-517}</regex>
+    <regex> ID:\s+S-1-5-21\S+-517</regex>
     <description>Cert Publishers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -586,7 +586,7 @@
 
   <rule id="18229" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\.+-518}</regex>
+    <regex> ID:\s+S-1-5-21\.+-518</regex>
     <description>Schema Admins Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -594,7 +594,7 @@
 
   <rule id="18230" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-519}</regex>
+    <regex> ID:\s+S-1-5-21\S+-519</regex>
     <description>Enterprise Admins Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -602,7 +602,7 @@
 
   <rule id="18231" level="10">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+%{S-1-5-21\S+-520}</regex>
+    <regex> ID:\s+S-1-5-21\S+-520</regex>
     <description>Group Policy Creator Owners Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -610,7 +610,7 @@
 
   <rule id="18232" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex>\w* ID:\s+%{S-1-5-21\S+-553}</regex>
+    <regex>\w* ID:\s+S-1-5-21\S+-553</regex>
     <description>RAS and IAS Servers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -618,7 +618,7 @@
 
   <rule id="18233" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-545}</regex>
+    <regex> ID:\s+S-1-5-32-545</regex>
     <description>Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -626,7 +626,7 @@
 
   <rule id="18234" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-546}</regex>
+    <regex> ID:\s+S-1-5-32-546</regex>
     <description>Guests Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -634,7 +634,7 @@
 
   <rule id="18235" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-547}</regex>
+    <regex> ID:\s+S-1-5-32-547</regex>
     <description>Power Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -642,7 +642,7 @@
 
   <rule id="18236" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-548}</regex>
+    <regex> ID:\s+S-1-5-32-548</regex>
     <description>Account Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -650,7 +650,7 @@
 
   <rule id="18237" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-549}</regex>
+    <regex> ID:\s+S-1-5-32-549</regex>
     <description>Server Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -658,7 +658,7 @@
 
   <rule id="18238" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex>\w* ID:\s+%{S-1-5-32-550}</regex>
+    <regex>\w* ID:\s+S-1-5-32-550</regex>
     <description>Print Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -666,7 +666,7 @@
 
   <rule id="18239" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-551}</regex>
+    <regex> ID:\s+S-1-5-32-551</regex>
     <description>Backup Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -674,7 +674,7 @@
 
   <rule id="18240" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-552}</regex>
+    <regex> ID:\s+S-1-5-32-552</regex>
     <description>Replicators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -682,7 +682,7 @@
 
   <rule id="18241" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-554}</regex>
+    <regex> ID:\s+S-1-5-32-554</regex>
     <description>Pre-Windows 2000 Compatible Access Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -690,7 +690,7 @@
 
   <rule id="18242" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-555}</regex>
+    <regex> ID:\s+S-1-5-32-555</regex>
     <description>Remote Desktop Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -698,7 +698,7 @@
 
   <rule id="18243" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-556}</regex>
+    <regex> ID:\s+S-1-5-32-556</regex>
     <description>Network Configuration Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -706,7 +706,7 @@
 
   <rule id="18244" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-557}</regex>
+    <regex> ID:\s+S-1-5-32-557</regex>
     <description>Incoming Forest Trust Builders Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -714,7 +714,7 @@
 
   <rule id="18245" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-558}</regex>
+    <regex> ID:\s+S-1-5-32-558</regex>
     <description>Performance Monitor Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -722,7 +722,7 @@
 
   <rule id="18246" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-559}</regex>
+    <regex> ID:\s+S-1-5-32-559</regex>
     <description>Performance Log Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -730,7 +730,7 @@
 
   <rule id="18247" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-560}</regex>
+    <regex> ID:\s+S-1-5-32-560</regex>
     <description>Windows Authorization Access Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -738,7 +738,7 @@
 
   <rule id="18248" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-561}</regex>
+    <regex> ID:\s+S-1-5-32-561</regex>
     <description>Terminal Server License Servers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -746,7 +746,7 @@
 
   <rule id="18249" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-562}</regex>
+    <regex> ID:\s+S-1-5-32-562</regex>
     <description>Distributed COM Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -754,7 +754,7 @@
 
   <rule id="18250" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-498}</regex>
+    <regex> ID:\s+S-1-5-\s*21\.+\s*-498</regex>
     <description>Enterprise Read-only Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -762,7 +762,7 @@
 
   <rule id="18251" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-529}</regex>
+    <regex> ID:\s+S-1-5-\s*21\.+\s*-529</regex>
     <description>Read-only Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -770,7 +770,7 @@
 
   <rule id="18252" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-569}</regex>
+    <regex> ID:\s+S-1-5-32-569</regex>
     <description>Cryptographic Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -778,7 +778,7 @@
 
   <rule id="18253" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-571}</regex>
+    <regex> ID:\s+S-1-5-\s*21\.+\s*-571</regex>
     <description>Allowed RODC Password Replication Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -786,7 +786,7 @@
 
   <rule id="18254" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-572}</regex>
+    <regex> ID:\s+S-1-5-\s*21\.+\s*-572</regex>
     <description>Denied RODC Password Replication Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -794,7 +794,7 @@
 
   <rule id="18255" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-573}</regex>
+    <regex> ID:\s+S-1-5-32-573</regex>
     <description>Event Log Readers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -802,7 +802,7 @@
 
   <rule id="18256" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+%{S-1-5-32-574}</regex>
+    <regex> ID:\s+S-1-5-32-574</regex>
     <description>Certificate Service DCOM Access Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>

--- a/etc/rules/msauth_rules.xml
+++ b/etc/rules/msauth_rules.xml
@@ -499,7 +499,7 @@
 
   <rule id="18218" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-1-0</regex>
+    <regex> ID:\s+%{S-1-1-0}| ID:\s+S-1-1-0</regex>
     <description>Everyone Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -507,7 +507,7 @@
 
   <rule id="18219" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-9</regex>
+    <regex> ID:\s+%{S-1-5-9}| ID:\s+S-1-5-9</regex>
     <description>Enterprise Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -515,7 +515,7 @@
 
   <rule id="18220" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-11</regex>
+    <regex> ID:\s+%{S-1-5-11}| ID:\s+S-1-5-11</regex>
     <description>Authenticated Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -523,7 +523,7 @@
 
   <rule id="18221" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-13</regex>
+    <regex> ID:\s+%{S-1-5-13}| ID:\s+S-1-5-13</regex>
     <description>Terminal Server Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -531,7 +531,7 @@
 
   <rule id="18222" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+S-1-5-21\S+-512</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-512}| ID:\s+S-1-5-21\S+-512</regex>
     <description>Domain Admins Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -539,22 +539,22 @@
 
   <rule id="18223" level="5">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+S-1-5-21\S+-513</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-513}| ID:\s+S-1-5-21\S+-513</regex>
     <description>Domain Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
   </rule>
 
-    <rule id="18224" level="0">
-      <if_sid>18223,18203</if_sid>
-      <match>Target Account Name: None</match>
-      <description>Local User Group NONE</description>
-      <info>Bogus group user added to upon creation</info>
-    </rule>
+  <rule id="18224" level="0">
+    <if_sid>18223,18203</if_sid>
+    <match>Target Account Name: None</match>
+    <description>Local User Group NONE</description>
+    <info>Bogus group user added to upon creation</info>
+  </rule>
 
   <rule id="18225" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+S-1-5-21\S+-514</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-514}| ID:\s+S-1-5-21\S+-514</regex>
     <description>Domain Guests Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -562,7 +562,7 @@
 
   <rule id="18226" level="5">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+S-1-5-21\S+-515</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-515}| ID:\s+S-1-5-21\S+-515</regex>
     <description>Domain Computers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -570,7 +570,7 @@
 
   <rule id="18227" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+S-1-5-21\S+-516</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-516}| ID:\s+S-1-5-21\S+-516</regex>
     <description>Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -578,7 +578,7 @@
 
   <rule id="18228" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-21\S+-517</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-517}| ID:\s+S-1-5-21\S+-517</regex>
     <description>Cert Publishers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -586,7 +586,7 @@
 
   <rule id="18229" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+S-1-5-21\.+-518</regex>
+    <regex> ID:\s+%{S-1-5-21\.+-518}| ID:\s+S-1-5-21\.+-518</regex>
     <description>Schema Admins Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -594,7 +594,7 @@
 
   <rule id="18230" level="12">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+S-1-5-21\S+-519</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-519}| ID:\s+S-1-5-21\S+-519</regex>
     <description>Enterprise Admins Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -602,7 +602,7 @@
 
   <rule id="18231" level="10">
     <if_sid>18203,18204</if_sid>
-    <regex> ID:\s+S-1-5-21\S+-520</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-520}| ID:\s+S-1-5-21\S+-520</regex>
     <description>Group Policy Creator Owners Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -610,7 +610,7 @@
 
   <rule id="18232" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex>\w* ID:\s+S-1-5-21\S+-553</regex>
+    <regex> ID:\s+%{S-1-5-21\S+-553}| ID:\s+S-1-5-21\S+-553</regex>
     <description>RAS and IAS Servers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -618,7 +618,7 @@
 
   <rule id="18233" level="5">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-545</regex>
+    <regex> ID:\s+%{S-1-5-32-545}| ID:\s+S-1-5-32-545</regex>
     <description>Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -626,7 +626,7 @@
 
   <rule id="18234" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-546</regex>
+    <regex> ID:\s+%{S-1-5-32-546}| ID:\s+S-1-5-32-546</regex>
     <description>Guests Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -634,7 +634,7 @@
 
   <rule id="18235" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-547</regex>
+    <regex> ID:\s+%{S-1-5-32-547}| ID:\s+S-1-5-32-547</regex>
     <description>Power Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -642,7 +642,7 @@
 
   <rule id="18236" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-548</regex>
+    <regex> ID:\s+%{S-1-5-32-548}| ID:\s+S-1-5-32-548</regex>
     <description>Account Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -650,7 +650,7 @@
 
   <rule id="18237" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-549</regex>
+    <regex> ID:\s+%{S-1-5-32-549}| ID:\s+S-1-5-32-549</regex>
     <description>Server Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -658,7 +658,7 @@
 
   <rule id="18238" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex>\w* ID:\s+S-1-5-32-550</regex>
+    <regex> ID:\s+%{S-1-5-32-550}| ID:\s+S-1-5-32-550</regex>
     <description>Print Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -666,7 +666,7 @@
 
   <rule id="18239" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-551</regex>
+    <regex> ID:\s+%{S-1-5-32-551}| ID:\s+S-1-5-32-551</regex>
     <description>Backup Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -674,7 +674,7 @@
 
   <rule id="18240" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-552</regex>
+    <regex> ID:\s+%{S-1-5-32-552}| ID:\s+S-1-5-32-552</regex>
     <description>Replicators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -682,7 +682,7 @@
 
   <rule id="18241" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-554</regex>
+    <regex> ID:\s+%{S-1-5-32-554}| ID:\s+S-1-5-32-554</regex>
     <description>Pre-Windows 2000 Compatible Access Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -690,7 +690,7 @@
 
   <rule id="18242" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-555</regex>
+    <regex> ID:\s+%{S-1-5-32-555}| ID:\s+S-1-5-32-555</regex>
     <description>Remote Desktop Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -698,7 +698,7 @@
 
   <rule id="18243" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-556</regex>
+    <regex> ID:\s+%{S-1-5-32-556}| ID:\s+S-1-5-32-556</regex>
     <description>Network Configuration Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -706,7 +706,7 @@
 
   <rule id="18244" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-557</regex>
+    <regex> ID:\s+%{S-1-5-32-557}| ID:\s+S-1-5-32-557</regex>
     <description>Incoming Forest Trust Builders Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -714,7 +714,7 @@
 
   <rule id="18245" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-558</regex>
+    <regex> ID:\s+%{S-1-5-32-558}| ID:\s+S-1-5-32-558</regex>
     <description>Performance Monitor Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -722,7 +722,7 @@
 
   <rule id="18246" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-559</regex>
+    <regex> ID:\s+%{S-1-5-32-559}| ID:\s+S-1-5-32-559</regex>
     <description>Performance Log Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -730,7 +730,7 @@
 
   <rule id="18247" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-560</regex>
+    <regex> ID:\s+%{S-1-5-32-560}| ID:\s+S-1-5-32-560</regex>
     <description>Windows Authorization Access Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -738,7 +738,7 @@
 
   <rule id="18248" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-561</regex>
+    <regex> ID:\s+%{S-1-5-32-561}| ID:\s+S-1-5-32-561</regex>
     <description>Terminal Server License Servers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -746,7 +746,7 @@
 
   <rule id="18249" level="8">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-562</regex>
+    <regex> ID:\s+%{S-1-5-32-562}| ID:\s+S-1-5-32-562</regex>
     <description>Distributed COM Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -754,7 +754,7 @@
 
   <rule id="18250" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-\s*21\.+\s*-498</regex>
+    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-498}| ID:\s+S-1-5-\s*21\.+\s*-498</regex>
     <description>Enterprise Read-only Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -762,7 +762,7 @@
 
   <rule id="18251" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-\s*21\.+\s*-529</regex>
+    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-529}| ID:\s+S-1-5-\s*21\.+\s*-529</regex>
     <description>Read-only Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -770,7 +770,7 @@
 
   <rule id="18252" level="12">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-569</regex>
+    <regex> ID:\s+%{S-1-5-32-569}| ID:\s+S-1-5-32-569</regex>
     <description>Cryptographic Operators Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -778,7 +778,7 @@
 
   <rule id="18253" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-\s*21\.+\s*-571</regex>
+    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-571}| ID:\s+S-1-5-\s*21\.+\s*-571</regex>
     <description>Allowed RODC Password Replication Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -786,7 +786,7 @@
 
   <rule id="18254" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-\s*21\.+\s*-572</regex>
+    <regex> ID:\s+%{S-1-5-\s*21\.+\s*-572}| ID:\s+S-1-5-\s*21\.+\s*-572</regex>
     <description>Denied RODC Password Replication Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -794,7 +794,7 @@
 
   <rule id="18255" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-573</regex>
+    <regex> ID:\s+%{S-1-5-32-573}| ID:\s+S-1-5-32-573</regex>
     <description>Event Log Readers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -802,7 +802,7 @@
 
   <rule id="18256" level="10">
     <if_sid>18207,18208</if_sid>
-    <regex> ID:\s+S-1-5-32-574</regex>
+    <regex> ID:\s+%{S-1-5-32-574}| ID:\s+S-1-5-32-574</regex>
     <description>Certificate Service DCOM Access Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>


### PR DESCRIPTION
SIDs in logs from Active Directory are not contained within curly brackets, nor are they prefixed with a %. Perhaps this is from old NT days. This is an example log:

2018 Mar 01 00:00:00 WinEvtLog: Security: AUDIT_SUCCESS(4728): Microsoft-Windows-Security-Auditing: (no user): no domain: domaincontroller.lan.local: A member was added to a security-enabled global group. Subject:  Security ID:  S-1-5-21-0000000000-0000000000-000000000-00012  Account Name:  admin_account  Account Domain:  LAN  Logon ID:  0x11cc0174  Member:  Security ID:  S-1-5-21-0000000000-000000000-000000000-00675  Account Name:  CN=added_account,OU=lan,DC=lan,DC=local  Group:  Security ID:  S-1-5-21-0000000000-0000000000-000000000-512  Group Name:  Domain Admins  Group Domain:  LAN  Additional Information:  Privileges:  -