### PR TITLE
Modification to Correct IP Connectivity Issues on BSD Servers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -45,6 +45,11 @@ DEFINES+=-DGROUPGLOBAL=\"${OSSEC_GROUP}\"
 DEFINES+=-DMAILUSER=\"${OSSEC_USER_MAIL}\"
 DEFINES+=-D${uname_S}
 
+# Uncomment the DEFINES statement below if you are
+# running Linux and want to use AF_UNSPEC instead of
+# AF_INET6 to fully support IPv4 addresses.
+#DEFINES+=NOV4MAP
+
 ifneq (,$(filter ${REUSE_ID},yes y Y 1))
 	DEFINES+=-DREUSE_ID
 endif
@@ -81,11 +86,15 @@ ifeq (${uname_S},FreeBSD)
 		DEFINES+=-DFreeBSD
 		OSSEC_LDFLAGS+=-pthread
 		LUA_PLAT=freebsd
+		CFLAGS+=-I/usr/local/include
+		OSSEC_LDFLAGS+=-L/usr/local/lib
 else
 ifeq (${uname_S},NetBSD)
 		DEFINES+=-DNetBSD
 		OSSEC_LDFLAGS+=-pthread
 		LUA_PLAT=posix
+		CFLAGS+=-I/usr/local/include
+		OSSEC_LDFLAGS+=-L/usr/local/lib
 else
 ifeq (${uname_S},OpenBSD)
 #		DEFINES+=-DOpenBSD

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -14,6 +14,7 @@
 #define SECURE_CONN 2
 
 #include "shared.h"
+#include "os_net/os_net.h"
 
 /* socklen_t header */
 typedef struct _remoted {
@@ -28,6 +29,7 @@ typedef struct _remoted {
 
     int m_queue;
     int sock;
+    OSNetInfo *netinfo;
     socklen_t peer_size;
 } remoted;
 

--- a/src/external/lua-5.2.3/src/Makefile
+++ b/src/external/lua-5.2.3/src/Makefile
@@ -97,10 +97,10 @@ ansi:
 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_ANSI"
 
 bsd:
-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_POSIX -DLUA_USE_DLOPEN" SYSLIBS="-Wl,-E"
+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_POSIX -DLUA_USE_DLOPEN -I/usr/local/include" SYSLIBS="-Wl,-E -lreadline -L/usr/local/lib"
 
 freebsd:
-	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX" SYSLIBS="-Wl,-E -lreadline"
+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_LINUX -I/usr/local/include" SYSLIBS="-Wl,-E -lreadline -L/usr/local/lib"
 
 generic: $(ALL)
 

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -169,6 +169,10 @@ int main(int argc, char **argv)
     char srcip[IPSIZE + 1];
     struct sockaddr_storage _nc;
     socklen_t _ncl;
+    fd_set fdsave, fdwork;		/* select() work areas */
+    int fdmax;				/* max socket number + 1 */
+    OSNetInfo *netinfo;			/* bound network sockets */
+    int esc = 0;			/* while() escape flag */
 
     /* Initialize some variables */
     memset(srcip, '\0', IPSIZE + 1);
@@ -343,13 +347,16 @@ int main(int argc, char **argv)
     }
 
     /* Connect via TCP */
-    sock = OS_Bindporttcp(port, NULL);
-    if (sock <= 0) {
+    netinfo = OS_Bindporttcp(port, NULL);
+    if (netinfo->status < 0) {
         merror("%s: Unable to bind to port %s", ARGV0, port);
         exit(1);
     }
 
-    fcntl(sock, F_SETFL, O_NONBLOCK);
+    /* initialize select() save area */
+    fdsave = netinfo->fdset;
+    fdmax  = netinfo->fdmax;            /* value preset to max fd + 1 */
+
     debug1("%s: DEBUG: Going into listening mode.", ARGV0);
 
     /* Setup random */
@@ -385,156 +392,167 @@ int main(int argc, char **argv)
         memset(&_nc, 0, sizeof(_nc));
         _ncl = sizeof(_nc);
 
-        if ((client_sock = accept(sock, (struct sockaddr *) &_nc, &_ncl)) > 0) {
-            if (active_processes >= POOL_SIZE) {
-                merror("%s: Error: Max concurrency reached. Unable to fork", ARGV0);
-                break;
-            }
-            pid = fork();
-            if (pid) {
-                active_processes = active_processes + 1;
-                close(client_sock);
-                for (i = 0; i < POOL_SIZE; i++) {
-                    if (! process_pool[i]) {
-                        process_pool[i] = pid;
+        /* read through socket list for active socket */
+        for (sock = 0; sock <= fdmax; sock++) {
+            if (FD_ISSET (sock, &fdwork)) {
+                if ((client_sock = accept(sock, (struct sockaddr *) &_nc, &_ncl)) > 0) {
+                    if (active_processes >= POOL_SIZE) {
+                        merror("%s: Error: Max concurrency reached. Unable to fork", ARGV0);
+                        esc = 1; /* exit while(1) loop */
                         break;
                     }
-                }
-            } else {
-                satop((struct sockaddr *) &_nc, srcip, IPSIZE);
-                char *agentname = NULL;
-                ssl = SSL_new(ctx);
-                SSL_set_fd(ssl, client_sock);
-
-                do {
-                    ret = SSL_accept(ssl);
-
-                    if (ssl_error(ssl, ret)) {
-                        clean_exit(ctx, client_sock);
-                    }
-
-                } while (ret <= 0);
-                verbose("%s: INFO: New connection from %s", ARGV0, srcip);
-                buf[0] = '\0';
-
-                do {
-                    ret = SSL_read(ssl, buf, sizeof(buf));
-
-                    if (ssl_error(ssl, ret)) {
-                        clean_exit(ctx, client_sock);
-                    }
-
-                } while (ret <= 0);
-
-                int parseok = 0;
-                char *tmpstr = buf;
-
-                /* Checking for shared password authentication. */
-                if(authpass) {
-                    /* Format is pretty simple: OSSEC PASS: PASS WHATEVERACTION */
-                    if (strncmp(tmpstr, "OSSEC PASS: ", 12) == 0) {
-                        tmpstr = tmpstr + 12;
-
-                        if (strlen(tmpstr) > strlen(authpass) && strncmp(tmpstr, authpass, strlen(authpass)) == 0) {
-                            tmpstr += strlen(authpass);
-
-                            if (*tmpstr == ' ') {
-                                tmpstr++;
-                                parseok = 1;
+                    pid = fork();
+                    if (pid) {
+                        active_processes = active_processes + 1;
+                        close(client_sock);
+                        for (i = 0; i < POOL_SIZE; i++) {
+                            if (! process_pool[i]) {
+                                process_pool[i] = pid;
+                                break;
                             }
                         }
-                    }
-                    if (parseok == 0) {
-                        merror("%s: ERROR: Invalid password provided by %s. Closing connection.", ARGV0, srcip);
-                        SSL_CTX_free(ctx);
-                        close(client_sock);
-                        exit(0);
-                    }
-                }
-
-                /* Checking for action A (add agent) */
-                parseok = 0;
-                if (strncmp(tmpstr, "OSSEC A:'", 9) == 0) {
-                    agentname = tmpstr + 9;
-                    tmpstr += 9;
-                    while (*tmpstr != '\0') {
-                        if (*tmpstr == '\'') {
-                            *tmpstr = '\0';
-                            verbose("%s: INFO: Received request for a new agent (%s) from: %s", ARGV0, agentname, srcip);
-                            parseok = 1;
-                            break;
-                        }
-                        tmpstr++;
-                    }
-                }
-                if (parseok == 0) {
-                    merror("%s: ERROR: Invalid request for new agent from: %s", ARGV0, srcip);
-                } else {
-                    int acount = 2;
-                    char fname[2048 + 1];
-                    char response[2048 + 1];
-                    char *finalkey = NULL;
-                    response[2048] = '\0';
-                    fname[2048] = '\0';
-                    if (!OS_IsValidName(agentname)) {
-                        merror("%s: ERROR: Invalid agent name: %s from %s", ARGV0, agentname, srcip);
-                        snprintf(response, 2048, "ERROR: Invalid agent name: %s\n\n", agentname);
-                        SSL_write(ssl, response, strlen(response));
-                        snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
-                        SSL_write(ssl, response, strlen(response));
-                        sleep(1);
-                        exit(0);
-                    }
-
-                    /* Check for duplicate names */
-                    strncpy(fname, agentname, 2048);
-                    while (NameExist(fname)) {
-                        snprintf(fname, 2048, "%s%d", agentname, acount);
-                        acount++;
-                        if (acount > 256) {
-                            merror("%s: ERROR: Invalid agent name %s (duplicated)", ARGV0, agentname);
-                            snprintf(response, 2048, "ERROR: Invalid agent name: %s\n\n", agentname);
-                            SSL_write(ssl, response, strlen(response));
-                            snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
-                            SSL_write(ssl, response, strlen(response));
-                            sleep(1);
-                            exit(0);
-                        }
-                    }
-                    agentname = fname;
-
-                    /* Add the new agent */
-                    if (use_ip_address) {
-                        finalkey = OS_AddNewAgent(agentname, srcip, NULL);
                     } else {
-                        finalkey = OS_AddNewAgent(agentname, NULL, NULL);
-                    }
-                    if (!finalkey) {
-                        merror("%s: ERROR: Unable to add agent: %s (internal error)", ARGV0, agentname);
-                        snprintf(response, 2048, "ERROR: Internal manager error adding agent: %s\n\n", agentname);
-                        SSL_write(ssl, response, strlen(response));
-                        snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
-                        SSL_write(ssl, response, strlen(response));
-                        sleep(1);
-                        exit(0);
-                    }
-
-                    snprintf(response, 2048, "OSSEC K:'%s'\n\n", finalkey);
-                    verbose("%s: INFO: Agent key generated for %s (requested by %s)", ARGV0, agentname, srcip);
-                    ret = SSL_write(ssl, response, strlen(response));
-                    if (ret < 0) {
-                        merror("%s: ERROR: SSL write error (%d)", ARGV0, ret);
-                        merror("%s: ERROR: Agen key not saved for %s", ARGV0, agentname);
-                        ERR_print_errors_fp(stderr);
-                    } else {
-                        verbose("%s: INFO: Agent key created for %s (requested by %s)", ARGV0, agentname, srcip);
+                        satop((struct sockaddr *) &_nc, srcip, IPSIZE);
+                        char *agentname = NULL;
+                        ssl = SSL_new(ctx);
+                        SSL_set_fd(ssl, client_sock);
+        
+                        do {
+                            ret = SSL_accept(ssl);
+        
+                            if (ssl_error(ssl, ret)) {
+                                clean_exit(ctx, client_sock);
+                            }
+        
+                        } while (ret <= 0);
+                        verbose("%s: INFO: New connection from %s", ARGV0, srcip);
+                        buf[0] = '\0';
+        
+                        do {
+                            ret = SSL_read(ssl, buf, sizeof(buf));
+        
+                            if (ssl_error(ssl, ret)) {
+                                clean_exit(ctx, client_sock);
+                            }
+        
+                        } while (ret <= 0);
+        
+                        int parseok = 0;
+                        char *tmpstr = buf;
+        
+                        /* Checking for shared password authentication. */
+                        if(authpass) {
+                            /* Format is pretty simple: OSSEC PASS: PASS WHATEVERACTION */
+                            if (strncmp(tmpstr, "OSSEC PASS: ", 12) == 0) {
+                                tmpstr = tmpstr + 12;
+        
+                                if (strlen(tmpstr) > strlen(authpass) && strncmp(tmpstr, authpass, strlen(authpass)) == 0) {
+                                    tmpstr += strlen(authpass);
+        
+                                    if (*tmpstr == ' ') {
+                                        tmpstr++;
+                                        parseok = 1;
+                                    }
+                                }
+                            }
+                            if (parseok == 0) {
+                                merror("%s: ERROR: Invalid password provided by %s. Closing connection.", ARGV0, srcip);
+                                SSL_CTX_free(ctx);
+                                close(client_sock);
+                                exit(0);
+                            }
+                        }
+        
+                        /* Checking for action A (add agent) */
+                        parseok = 0;
+                        if (strncmp(tmpstr, "OSSEC A:'", 9) == 0) {
+                            agentname = tmpstr + 9;
+                            tmpstr += 9;
+                            while (*tmpstr != '\0') {
+                                if (*tmpstr == '\'') {
+                                    *tmpstr = '\0';
+                                    verbose("%s: INFO: Received request for a new agent (%s) from: %s", ARGV0, agentname, srcip);
+                                    parseok = 1;
+                                    break;
+                                }
+                                tmpstr++;
+                            }
+                        }
+                        if (parseok == 0) {
+                            merror("%s: ERROR: Invalid request for new agent from: %s", ARGV0, srcip);
+                        } else {
+                            int acount = 2;
+                            char fname[2048 + 1];
+                            char response[2048 + 1];
+                            char *finalkey = NULL;
+                            response[2048] = '\0';
+                            fname[2048] = '\0';
+                            if (!OS_IsValidName(agentname)) {
+                                merror("%s: ERROR: Invalid agent name: %s from %s", ARGV0, agentname, srcip);
+                                snprintf(response, 2048, "ERROR: Invalid agent name: %s\n\n", agentname);
+                                SSL_write(ssl, response, strlen(response));
+                                snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
+                                SSL_write(ssl, response, strlen(response));
+                                sleep(1);
+                                exit(0);
+                            }
+        
+                            /* Check for duplicate names */
+                            strncpy(fname, agentname, 2048);
+                            while (NameExist(fname)) {
+                                snprintf(fname, 2048, "%s%d", agentname, acount);
+                                acount++;
+                                if (acount > 256) {
+                                    merror("%s: ERROR: Invalid agent name %s (duplicated)", ARGV0, agentname);
+                                    snprintf(response, 2048, "ERROR: Invalid agent name: %s\n\n", agentname);
+                                    SSL_write(ssl, response, strlen(response));
+                                    snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
+                                    SSL_write(ssl, response, strlen(response));
+                                    sleep(1);
+                                    exit(0);
+                                }
+                            }
+                            agentname = fname;
+        
+                            /* Add the new agent */
+                            if (use_ip_address) {
+                                finalkey = OS_AddNewAgent(agentname, srcip, NULL);
+                            } else {
+                                finalkey = OS_AddNewAgent(agentname, NULL, NULL);
+                            }
+                            if (!finalkey) {
+                                merror("%s: ERROR: Unable to add agent: %s (internal error)", ARGV0, agentname);
+                                snprintf(response, 2048, "ERROR: Internal manager error adding agent: %s\n\n", agentname);
+                                SSL_write(ssl, response, strlen(response));
+                                snprintf(response, 2048, "ERROR: Unable to add agent.\n\n");
+                                SSL_write(ssl, response, strlen(response));
+                                sleep(1);
+                                exit(0);
+                            }
+        
+                            snprintf(response, 2048, "OSSEC K:'%s'\n\n", finalkey);
+                            verbose("%s: INFO: Agent key generated for %s (requested by %s)", ARGV0, agentname, srcip);
+                            ret = SSL_write(ssl, response, strlen(response));
+                            if (ret < 0) {
+                                merror("%s: ERROR: SSL write error (%d)", ARGV0, ret);
+                                merror("%s: ERROR: Agen key not saved for %s", ARGV0, agentname);
+                                ERR_print_errors_fp(stderr);
+                            } else {
+                                verbose("%s: INFO: Agent key created for %s (requested by %s)", ARGV0, agentname, srcip);
+                            }
+                        }
+        
+                        clean_exit(ctx, client_sock);
                     }
                 }
+            } /* if active socket */
+        } /* for() loop on available sockets */
 
-                clean_exit(ctx, client_sock);
-            }
-        }
-    }
+        /* check for while() escape flag */
+        if (esc == 1)
+            break;
+
+    } /* while(1) loop for messages */
 
     /* Shut down the socket */
     clean_exit(ctx, sock);

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -708,7 +708,7 @@ char *OS_DecodeSockaddr (struct sockaddr *sa) {
 
     rc = getnameinfo ((struct sockaddr *) sa, sizeof (sa), ipaddr,
                       sizeof (ipaddr), ipport, sizeof (ipport),
-                      NI_NUMERICHOST | AI_NUMERICSERV);
+                      NI_NUMERICHOST | NI_NUMERICSERV);
 
     if (rc) {
         sprintf (buf, "Error %d on getnameinfo: %s", rc, gai_strerror (rc));

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -17,8 +17,13 @@
 agent *agt;
 
 /* Prototypes */
-static int OS_Bindport(char *_port, unsigned int _proto, const char *_ip);
+static OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip);
 static int OS_Connect(char *_port, unsigned int protocol, const char *_ip);
+static int OS_DecodeAddrinfo (struct addrinfo *res);
+static char *OS_DecodeSockaddr (struct sockaddr *sa);
+static char *DecodeFamily (int val);
+static char *DecodeSocktype (int val);
+static char *DecodeProtocol (int val);
 
 /* Unix socket -- not for windows */
 #ifndef WIN32
@@ -40,92 +45,172 @@ static socklen_t us_l = sizeof(n_us);
 #endif /* WIN32*/
 
 
-/* Bind a specific port */
-int OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
+/* Bind all relevant ports */
+OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
 {
     int ossock = 0, s;
     struct addrinfo hints, *result, *rp;
+    OSNetInfo *ni;			/* return data */
 
+    /* Allocate the return data structure and initialize it. */
+    ni = malloc (sizeof (OSNetInfo));
+    memset(ni, 0, sizeof (OSNetInfo));
+    FD_ZERO (&(ni->fdset));
+    ni->fdmax  = 0;
+    ni->fdcnt  = 0;
+    ni->status = 0;
+    ni->retval = 0;
 
+    /* init hints for getaddrinfo() */
     memset(&hints, 0, sizeof(struct addrinfo));
-#ifdef AI_V4MAPPED
-    hints.ai_family = AF_INET6;    /* Allow IPv4 and IPv6 */
+
+   /*
+    * If you cannot bind both IPv4 and IPv6, the problem is likely due to the
+    * AF_INET6 family with the AI_V4MAPPED flag. Alter your Makefile to use the
+    * NOV4MAP define and it should work like a breeze. All of the *BSDs fall
+    * into this category even though AI_V4MAPPED exists in netdb.h (true for
+    * all modern OS's). This should work with all Linux versions too, but the
+    * original code for AF_INET6 was left for Linux because it works.
+    *
+    * d. stoddard - 4/19/2018
+    */
+
+#if defined(__linux__) && !defined(NOV4MAP)
+#if defined (AI_V4MAPPED)
+    hints.ai_family = AF_INET6;		/* Allow IPv4 and IPv6 */
     hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG | AI_V4MAPPED;
 #else
-    /* Certain *BSD OS (eg. OpenBSD) do not allow binding to a
-       single-socket for both IPv4 and IPv6 per RFC 3493.  This will 
-       allow one or the other based on _ip. */
-    hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
-    hints.ai_flags = AI_PASSIVE;
+    /* handle as normal IPv4 and IPv6 multi request */
+    hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
+    hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
+#endif /* AI_V4MAPPED */
+#else
+    /* FreeBSD, OpenBSD, NetBSD, and others */
+    hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
+    hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
 #endif
+
     hints.ai_protocol = _proto;
     if (_proto == IPPROTO_UDP) {
         hints.ai_socktype = SOCK_DGRAM;
     } else if (_proto == IPPROTO_TCP) {
         hints.ai_socktype = SOCK_STREAM;
     } else {
-        return(OS_INVALID);
+        ni->status = -1;
+        ni->retval = OS_INVALID;
+        return(ni);
     }
 
+    /* get linked list of adresses */
     s = getaddrinfo(_ip, _port, &hints, &result);
+
     /* Try to support legacy ipv4 only hosts */
     if((s == EAI_FAMILY) || (s == EAI_NONAME)) {
         hints.ai_family = AF_INET;
         s = getaddrinfo(_ip, _port, &hints, &result);
     }
+
     if (s != 0) {
         verbose("getaddrinfo: %s", gai_strerror(s));
-        return(OS_INVALID);
+        ni->status = -1;
+        ni->retval = OS_INVALID;
+        return(ni);
     }
 
-           /* getaddrinfo() returns a list of address structures.
-              Try each address until we successfully connect(2).
-              If socket(2) (or bind(2)) fails, we (close the socket
-              and) try the next address. */
+    /* log the list of connections available */
+    OS_DecodeAddrinfo (result);
+
+   /*
+    * getaddrinfo() returns a list of address structures.  We try each
+    * address and attempt to connect to it.  If a socket(2) or bind(2) fails,
+    * we close the socket and try the next address. We repeat this for every
+    * address getaddrinfo() returns in the addrinfo linked list.
+    */
 
     for (rp = result; rp != NULL; rp = rp->ai_next) {
         ossock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
         if (ossock == -1) {
+            verbose ("socket error: family %s type %s protocol %s: %s",
+                     DecodeFamily (rp->ai_family),
+                     DecodeSocktype (rp->ai_socktype),
+                     DecodeProtocol (rp->ai_protocol),
+                     strerror(errno));
             continue;
-        } 
+        }
+
         if (_proto == IPPROTO_TCP) {
             int flag = 1;
             if (setsockopt(ossock, SOL_SOCKET, SO_REUSEADDR,
                           (char *)&flag, sizeof(flag)) < 0) {
+                verbose ("setsockopt error: SO_REUSEADDR %d: %s",
+                         errno, strerror(errno));
                 OS_CloseSocket(ossock);
-                return(OS_SOCKTERR);
+                continue;
             }
-        } 
-        if (bind(ossock, rp->ai_addr, rp->ai_addrlen) == 0) {
-            break;                  /* Success */
+        }
+
+        if (bind(ossock, rp->ai_addr, rp->ai_addrlen) == -1) {
+           /*
+            * Don't issue an error message if the address and port is already
+            * bound.  This can happen when 0.0.0.0 or :: are bound in a
+            * previous iteration of this loop.
+            */
+            if (errno == EADDRINUSE) {
+                close (ossock);
+                continue;
+            }
+
+            /* tell them why this address failed */
+            verbose ("Bind failed on socket for %s: %s",
+                     OS_DecodeSockaddr (rp->ai_addr), strerror (errno));
+            close (ossock);
+            continue;
+        }
+
+        if (_proto == IPPROTO_TCP) {
+            if (listen(ossock, 32) < 0) {
+                verbose ("Request to listen() failed on socket for %s: %s",
+                          OS_DecodeSockaddr (rp->ai_addr), strerror (errno));
+                close (ossock);
+                continue;
+            }
+            verbose ("Request for TCP listen() succeeded.\n");
+        }
+
+        /* success - accumulate data for select call */
+        verbose ("Socket bound for %s\n", OS_DecodeSockaddr (rp->ai_addr));
+
+        /* save bound socket info for select() */
+        ni->fds[ni->fdcnt++] = ossock;  /* increment after use! */
+        FD_SET (ossock, &(ni->fdset));
+        if (ossock > ni->fdmax) {
+          ni->fdmax = ossock;
         }
     }
-    if (rp == NULL) {               /* No address succeeded */
+
+    /* check to see if at least one address succeeded */
+    if (ni->fdmax == 0) {
+        verbose ("Request to allocate and bind sockets failed.");
         OS_CloseSocket(ossock);
-        return (OS_SOCKTERR);
+        ni->status = -1;
+        ni->retval = OS_SOCKTERR;
+        return(ni);
     }
 
-    freeaddrinfo(result);           /* No longer needed */
-
-    if (_proto == IPPROTO_TCP) {
-        if (listen(ossock, 32) < 0) {
-            OS_CloseSocket(ossock);
-            return (OS_SOCKTERR);
-        }
-    }
-
-    return (ossock);
+    freeaddrinfo(result);		/* No longer needed */
+    ni->fdmax += 1;			/* prep for use with select() */
+    return (ni);
 }
 
 
 /* Bind a TCP port, using the OS_Bindport */
-int OS_Bindporttcp(char *_port, const char *_ip)
+OSNetInfo *OS_Bindporttcp(char *_port, const char *_ip)
 {
     return (OS_Bindport(_port, IPPROTO_TCP, _ip));
 }
 
 /* Bind a UDP port, using the OS_Bindport */
-int OS_Bindportudp(char *_port, const char *_ip)
+OSNetInfo *OS_Bindportudp(char *_port, const char *_ip)
 {
     return (OS_Bindport(_port, IPPROTO_UDP, _ip));
 }
@@ -538,7 +623,7 @@ char *OS_GetHost(const char *host, unsigned int attempts)
     return (NULL);
 }
 
-/* satop(struct sockaddr *sa, char *dst, socklen_t size) 
+/* satop(struct sockaddr *sa, char *dst, socklen_t size)
  * Convert a sockaddr to a printable address.
  */
 int satop(struct sockaddr *sa, char *dst, socklen_t size)
@@ -558,7 +643,7 @@ int satop(struct sockaddr *sa, char *dst, socklen_t size)
         sa4 = (struct sockaddr_in *) sa;
 #ifdef WIN32
         newlength = size;
-        WSAAddressToString((LPSOCKADDR) sa4, sizeof(struct sockaddr_in), 
+        WSAAddressToString((LPSOCKADDR) sa4, sizeof(struct sockaddr_in),
                            NULL, dst, (LPDWORD) &newlength);
 #else
         inet_ntop(af, (const void *) &(sa4->sin_addr), dst, size);
@@ -568,7 +653,7 @@ int satop(struct sockaddr *sa, char *dst, socklen_t size)
         sa6 = (struct sockaddr_in6 *) sa;
 #ifdef WIN32
         newlength = size;
-        WSAAddressToString((LPSOCKADDR) sa6, sizeof(struct sockaddr_in6), 
+        WSAAddressToString((LPSOCKADDR) sa6, sizeof(struct sockaddr_in6),
                            NULL, dst, (LPDWORD) &newlength);
 #else
         inet_ntop(af, (const void *) &(sa6->sin6_addr), dst, size);
@@ -578,9 +663,9 @@ int satop(struct sockaddr *sa, char *dst, socklen_t size)
             memmove(dst, dst+7, size-7);
         }
         return(0);
-    default:  
+    default:
         *dst = '\0';
-        return(-1);     
+        return(-1);
     }
 }
 
@@ -591,5 +676,127 @@ int OS_CloseSocket(int socket)
 #else
     return (close(socket));
 #endif /* WIN32 */
+}
+
+
+/*
+ * OS_DecodeAddrinfo() will decode the contents of an addrinfo structure and
+ * log the IP version, address, and port number for each item in the
+ * linked list of addrinfo structs.
+ */
+
+int OS_DecodeAddrinfo (struct addrinfo *res) {
+    struct addrinfo *p;			/* pointer to addrinfo structs */
+
+    for (p = res; p != NULL; p = p->ai_next)
+        verbose ("%s\n",OS_DecodeSockaddr (p->ai_addr));
+    return 0;
+}
+
+
+/*
+ * OS_DecodeSockaddr() will decode a socket address and return a string with
+ * the IP version, address, and port number.
+ */
+
+char *OS_DecodeSockaddr (struct sockaddr *sa) {
+    int rc;				/* return code */
+    char ipaddr[INET6_ADDRSTRLEN];	/* printed address */
+    char ipport[NI_MAXSERV];		/* printed port */
+    static char buf[256];		/* message buffer */
+
+    rc = getnameinfo ((struct sockaddr *) sa, sa->sa_len, ipaddr,
+                      sizeof (ipaddr), ipport, sizeof (ipport),
+                      NI_NUMERICHOST | AI_NUMERICSERV);
+
+    if (rc) {
+        sprintf (buf, "Error %d on getnameinfo: %s", rc, gai_strerror (rc));
+        return (buf);
+    }
+
+    sprintf (buf, "%s: %s on port %s\n",
+             DecodeFamily (sa->sa_family), ipaddr, ipport);
+    return buf;
+}
+
+
+/*
+ * DecodeFamily() is used to convert the IP family into a string for info
+ * and debugging purposes.
+ */
+
+char *DecodeFamily (int val) {
+    static char buf[32];		/* response */
+
+    switch (val) {
+        case AF_INET:
+            strcpy (buf,"IPv4");
+            break;
+        case AF_INET6:
+            strcpy (buf,"IPv6");
+            break;
+        default:
+            sprintf (buf, "Unknown Family %d", val);
+            break;
+    }
+
+    return (buf);
+}
+
+
+/*
+ * DecodeSocktype() is used to convert the IP socket type into a string for
+ * info and debugging purposes.
+ */
+
+char *DecodeSocktype (int val) {
+    static char buf[32];		/* response */
+
+    switch (val) {
+        case SOCK_STREAM:
+            strcpy (buf,"STREAM");
+            break;
+        case SOCK_DGRAM:
+            strcpy (buf,"DGRAM");
+            break;
+        case SOCK_RAW:
+            strcpy (buf,"RAW");
+            break;
+        default:
+            sprintf (buf, "Unknown Sock Type %d", val);
+            break;
+    }
+
+    return (buf);
+}
+
+
+/*
+ * DecodeProtocol() is used to convert the IP protocol into a string for info
+ * and debugging purposes.
+ */
+
+char *DecodeProtocol (int val) {
+    static char buf[32];		/* response */
+
+    switch (val) {
+        case IPPROTO_IP:
+            strcpy (buf,"IP");
+            break;
+        case IPPROTO_ICMP:
+            strcpy (buf,"ICMP");
+            break;
+        case IPPROTO_TCP:
+            strcpy (buf,"TCP");
+            break;
+        case IPPROTO_UDP:
+            strcpy (buf,"UDP");
+            break;
+        default:
+            sprintf (buf, "Unknown Protocol %d", val);
+            break;
+    }
+
+    return (buf);
 }
 

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -78,16 +78,16 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
 #if defined(__linux__) && !defined(NOV4MAP)
 #if defined (AI_V4MAPPED)
     hints.ai_family = AF_INET6;		/* Allow IPv4 and IPv6 */
-    hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG | AI_V4MAPPED;
+    hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG | AI_V4MAPPED;
 #else
     /* handle as normal IPv4 and IPv6 multi request */
     hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
-    hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
+    hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG;
 #endif /* AI_V4MAPPED */
 #else
     /* FreeBSD, OpenBSD, NetBSD, and others */
     hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
-    hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
+    hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG;
 #endif
 
     hints.ai_protocol = _proto;
@@ -107,6 +107,7 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
     /* Try to support legacy ipv4 only hosts */
     if((s == EAI_FAMILY) || (s == EAI_NONAME)) {
         hints.ai_family = AF_INET;
+        hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG;
         s = getaddrinfo(_ip, _port, &hints, &result);
     }
 
@@ -174,11 +175,11 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
                 close (ossock);
                 continue;
             }
-            verbose ("Request for TCP listen() succeeded.\n");
+            verbose ("Request for TCP listen() succeeded.");
         }
 
         /* success - accumulate data for select call */
-        verbose ("Socket bound for %s\n", OS_DecodeSockaddr (rp->ai_addr));
+        verbose ("Socket bound for %s", OS_DecodeSockaddr (rp->ai_addr));
 
         /* save bound socket info for select() */
         ni->fds[ni->fdcnt++] = ossock;  /* increment after use! */
@@ -689,7 +690,7 @@ int OS_DecodeAddrinfo (struct addrinfo *res) {
     struct addrinfo *p;			/* pointer to addrinfo structs */
 
     for (p = res; p != NULL; p = p->ai_next)
-        verbose ("%s\n",OS_DecodeSockaddr (p->ai_addr));
+        verbose ("%s",OS_DecodeSockaddr (p->ai_addr));
     return 0;
 }
 
@@ -705,7 +706,7 @@ char *OS_DecodeSockaddr (struct sockaddr *sa) {
     char ipport[NI_MAXSERV];		/* printed port */
     static char buf[256];		/* message buffer */
 
-    rc = getnameinfo ((struct sockaddr *) sa, sa->sa_len, ipaddr,
+    rc = getnameinfo ((struct sockaddr *) sa, sizeof (sa), ipaddr,
                       sizeof (ipaddr), ipport, sizeof (ipport),
                       NI_NUMERICHOST | AI_NUMERICSERV);
 
@@ -714,7 +715,7 @@ char *OS_DecodeSockaddr (struct sockaddr *sa) {
         return (buf);
     }
 
-    sprintf (buf, "%s: %s on port %s\n",
+    sprintf (buf, "%s: %s on port %s",
              DecodeFamily (sa->sa_family), ipaddr, ipport);
     return buf;
 }

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -706,7 +706,7 @@ char *OS_DecodeSockaddr (struct sockaddr *sa) {
     char ipport[NI_MAXSERV];		/* printed port */
     static char buf[256];		/* message buffer */
 
-#if defined(__linux__)
+#if defined(__linux__) || defined (WIN32)
     /* most Linux systems do not have sa_len in the sockaddr struct */
     rc = getnameinfo ((struct sockaddr *) sa, sizeof (sa), ipaddr,
                       sizeof (ipaddr), ipport, sizeof (ipport),

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -33,13 +33,31 @@ typedef uint8_t u_int8_t;
 typedef uint16_t u_int16_t;
 typedef uint32_t u_int32_t;
 #endif
-/* OS_Bindport*
+
+/*
+ * OSNetInfo is used to exchange a set of bound sockets for use with the
+ * select() function for monitoring incoming packets on multiple interfaces.
+ * This allows you to support IPv4 and IPv6 simultaneously.
+ */
+
+typedef struct _OSNetInfo {
+  fd_set fdset;                         /* set of sockets used by select ()*/
+  int fdmax;                            /* fd max socket for select() */
+  int fds[FD_SETSIZE];                  /* array of bound sockets for send() */
+  int fdcnt;                            /* number of sockets in array */
+  int status;                           /* return status (-1 is error) */
+  int retval;                           /* return value (additional info) */
+} OSNetInfo;
+
+/*
+ * OS_Bindport*
  * Bind a specific port (protocol and a ip).
  * If the IP is not set, it is going to use ADDR_ANY
- * Return the socket.
+ * Return a pointer to the OSNetInfo struct.
  */
-int OS_Bindporttcp(char *_port, const char *_ip);
-int OS_Bindportudp(char *_port, const char *_ip);
+
+OSNetInfo *OS_Bindporttcp(char *_port, const char *_ip);
+OSNetInfo *OS_Bindportudp(char *_port, const char *_ip);
 
 /* OS_BindUnixDomain
  * Bind to a specific file, using the "mode" permissions in

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -41,14 +41,16 @@ void HandleRemote(int position, int uid)
 
     /* Bind TCP */
     if (logr.proto[position] == IPPROTO_TCP) {
-        if ((logr.sock =
-                    OS_Bindporttcp(logr.port[position], logr.lip[position])) < 0) {
+        logr.sock    = 0;
+        logr.netinfo = OS_Bindporttcp(logr.port[position], logr.lip[position]);
+        if (logr.netinfo->status < 0) {
             ErrorExit(BIND_ERROR, ARGV0, logr.port[position]);
         }
     } else {
         /* Using UDP. Fast, unreliable... perfect */
-        if((logr.sock =
-                   OS_Bindportudp(logr.port[position], logr.lip[position])) < 0) {
+        logr.sock    = 0;
+        logr.netinfo = OS_Bindportudp(logr.port[position], logr.lip[position]);
+        if (logr.netinfo->status < 0) {
             ErrorExit(BIND_ERROR, ARGV0, logr.port[position]);
         }
     }

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -24,6 +24,9 @@ void HandleSecure()
     ssize_t recv_b;
     struct sockaddr_storage peer_info;
     socklen_t peer_size;
+    fd_set fdsave, fdwork;			/* select() work areas */
+    int fdmax;					/* max socket number + 1 */
+    int sock;					/* active socket */
 
     /* Send msg init */
     send_msg_init();
@@ -44,9 +47,10 @@ void HandleSecure()
         ErrorExit(THREAD_ERROR, ARGV0);
     }
 
-    /* Connect to the message queue
-     * Exit if it fails.
-     */
+   /*
+    * Connect to the message queue
+    * Exit if it fails.
+    */
     if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
         ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQUEUE);
     }
@@ -72,105 +76,134 @@ void HandleSecure()
     memset(srcmsg, '\0', OS_FLSIZE + 1);
     tmp_msg = NULL;
 
-    while (1) {
-        /* Receive message  */
-        recv_b = recvfrom(logr.sock, buffer, OS_MAXSTR, 0,
-                          (struct sockaddr *)&peer_info, &peer_size);
+    /* initialize select() save area */
+    fdsave = logr.netinfo->fdset;
+    fdmax  = logr.netinfo->fdmax;	/* value preset to max fd + 1 */
 
-        /* Nothing received */
-        if (recv_b <= 0) {
-            continue;
+    while (1) {
+        /* process connections through select() for multiple sockets */
+        fdwork = fdsave;
+        if (select (fdmax, &fdwork, NULL, NULL, NULL) < 0) {
+            ErrorExit("ERROR: Call to secure select() failed, errno %d - %s",
+                      errno, strerror (errno));
         }
 
-        /* Set the source IP */
-        satop((struct sockaddr *) &peer_info, srcip, IPSIZE);
-        srcip[IPSIZE] = '\0';
+        /* read through socket list for active socket */
+        for (sock = 0; sock <= fdmax; sock++) {
+            if (FD_ISSET (sock, &fdwork)) {
 
-        /* Get a valid agent id */
-        if (buffer[0] == '!') {
-            tmp_msg = buffer;
-            tmp_msg++;
+                /* Receive message  */
+                recv_b = recvfrom(sock, buffer, OS_MAXSTR, 0,
+                                  (struct sockaddr *)&peer_info, &peer_size);
 
-            /* We need to make sure that we have a valid id
-             * and that we reduce the recv buffer size
-             */
-            while (isdigit((int)*tmp_msg)) {
-                tmp_msg++;
-                recv_b--;
-            }
+                /* Nothing received */
+                if (recv_b <= 0) {
+                    continue;
+                }
 
-            if (*tmp_msg != '!') {
-                merror(ENCFORMAT_ERROR, __local_name, srcip);
-                continue;
-            }
+               /*
+                * send_msg() needs a socket, but we don't know which
+                * socket is active until we receive our first packet.
+                * This sets the socket for send_msg() once it is known.
+                */
 
-            *tmp_msg = '\0';
-            tmp_msg++;
-            recv_b -= 2;
+                if (logr.sock == 0)
+                  logr.sock = sock;
 
-            agentid = OS_IsAllowedDynamicID(&keys, buffer + 1, srcip);
-            if (agentid == -1) {
-                if (check_keyupdate()) {
+                /* Set the source IP */
+                satop((struct sockaddr *) &peer_info, srcip, IPSIZE);
+                srcip[IPSIZE] = '\0';
+
+                /* Get a valid agent id */
+                if (buffer[0] == '!') {
+                    tmp_msg = buffer;
+                    tmp_msg++;
+
+                   /*
+                    * We need to make sure that we have a valid id
+                    * and that we reduce the recv buffer size
+                    */
+                    while (isdigit((int)*tmp_msg)) {
+                        tmp_msg++;
+                        recv_b--;
+                    }
+
+                    if (*tmp_msg != '!') {
+                        merror(ENCFORMAT_ERROR, __local_name, srcip);
+                        continue;
+                    }
+
+                    *tmp_msg = '\0';
+                    tmp_msg++;
+                    recv_b -= 2;
+
                     agentid = OS_IsAllowedDynamicID(&keys, buffer + 1, srcip);
                     if (agentid == -1) {
-                        merror(ENC_IP_ERROR, ARGV0, buffer + 1, srcip);
-                        continue;
+                        if (check_keyupdate()) {
+                            agentid = OS_IsAllowedDynamicID(&keys, buffer + 1, srcip);
+                            if (agentid == -1) {
+                                merror(ENC_IP_ERROR, ARGV0, buffer + 1, srcip);
+                                continue;
+                            }
+                        } else {
+                            merror(ENC_IP_ERROR, ARGV0, buffer + 1, srcip);
+                            continue;
+                        }
                     }
                 } else {
-                    merror(ENC_IP_ERROR, ARGV0, buffer + 1, srcip);
-                    continue;
-                }
-            }
-        } else {
-            agentid = OS_IsAllowedIP(&keys, srcip);
-            if (agentid < 0) {
-                if (check_keyupdate()) {
                     agentid = OS_IsAllowedIP(&keys, srcip);
-                    if (agentid == -1) {
-                        merror(DENYIP_WARN, ARGV0, srcip);
-                        continue;
+                    if (agentid < 0) {
+                        if (check_keyupdate()) {
+                            agentid = OS_IsAllowedIP(&keys, srcip);
+                            if (agentid == -1) {
+                                merror(DENYIP_WARN, ARGV0, srcip);
+                                continue;
+                            }
+                        } else {
+                            merror(DENYIP_WARN, ARGV0, srcip);
+                            continue;
+                        }
                     }
-                } else {
-                    merror(DENYIP_WARN, ARGV0, srcip);
+                    tmp_msg = buffer;
+                }
+
+                /* Decrypt the message */
+                tmp_msg = ReadSecMSG(&keys, tmp_msg, cleartext_msg,
+                                     agentid, recv_b - 1);
+                if (tmp_msg == NULL) {
+                    /* If duplicated, a warning was already generated */
                     continue;
                 }
-            }
-            tmp_msg = buffer;
-        }
 
-        /* Decrypt the message */
-        tmp_msg = ReadSecMSG(&keys, tmp_msg, cleartext_msg,
-                             agentid, recv_b - 1);
-        if (tmp_msg == NULL) {
-            /* If duplicated, a warning was already generated */
-            continue;
-        }
+                /* Check if it is a control message */
+                if (IsValidHeader(tmp_msg)) {
+                    /* We need to save the peerinfo if it is a control msg */
+                    memcpy(&keys.keyentries[agentid]->peer_info,
+                           &peer_info, peer_size);
+                    keys.keyentries[agentid]->rcvd = time(0);
+                    save_controlmsg((unsigned)agentid, tmp_msg);
+                    continue;
+                }
 
-        /* Check if it is a control message */
-        if (IsValidHeader(tmp_msg)) {
-            /* We need to save the peerinfo if it is a control msg */
-            memcpy(&keys.keyentries[agentid]->peer_info, &peer_info, peer_size);
-            keys.keyentries[agentid]->rcvd = time(0);
+                /* Generate srcmsg */
+                snprintf(srcmsg, OS_FLSIZE, "(%s) %s",
+                         keys.keyentries[agentid]->name,
+                         keys.keyentries[agentid]->ip->ip);
 
-            save_controlmsg((unsigned)agentid, tmp_msg);
+               /*
+                * If we can't send the message, try to connect to the
+                * socket again. If it fails exit.
+                */
+                if (SendMSG(logr.m_queue, tmp_msg, srcmsg,
+                            SECURE_MQ) < 0) {
+                    merror(QUEUE_ERROR, ARGV0, DEFAULTQUEUE, strerror(errno));
 
-            continue;
-        }
-
-        /* Generate srcmsg */
-        snprintf(srcmsg, OS_FLSIZE, "(%s) %s", keys.keyentries[agentid]->name,
-                 keys.keyentries[agentid]->ip->ip);
-
-        /* If we can't send the message, try to connect to the
-         * socket again. If it not exit.
-         */
-        if (SendMSG(logr.m_queue, tmp_msg, srcmsg,
-                    SECURE_MQ) < 0) {
-            merror(QUEUE_ERROR, ARGV0, DEFAULTQUEUE, strerror(errno));
-
-            if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
-                ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQUEUE);
-            }
-        }
-    }
+                    if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
+                        ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQUEUE);
+                    }
+                }
+            } /* if socket active */
+        } /* for() loop on sockets */
+    } /* while(1) loop for messages */
 }
+

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -104,11 +104,10 @@ void HandleSecure()
                /*
                 * send_msg() needs a socket, but we don't know which
                 * socket is active until we receive our first packet.
-                * This sets the socket for send_msg() once it is known.
+                * This sets the socket for send_msg().
                 */
 
-                if (logr.sock == 0)
-                  logr.sock = sock;
+                logr.sock = sock;
 
                 /* Set the source IP */
                 satop((struct sockaddr *) &peer_info, srcip, IPSIZE);

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -81,14 +81,19 @@ void send_msg_init()
     pthread_mutex_init(&sendmsg_mutex, NULL);
 }
 
-/* Send message to an agent
+
+/*
+ * Send message to an agent
  * Returns -1 on error
  */
+
 int send_msg(unsigned int agentid, const char *msg)
 {
     size_t msg_size, sa_size;
     char crypt_msg[OS_MAXSTR + 1];
     struct sockaddr * dest_sa;
+    int i;
+    int ok = 0;
 
     /* If we don't have the agent id, ignore it */
     if (keys.keyentries[agentid]->rcvd < (time(0) - (2 * NOTIFY_TIME))) {
@@ -111,8 +116,35 @@ int send_msg(unsigned int agentid, const char *msg)
     dest_sa = (struct sockaddr *)&keys.keyentries[agentid]->peer_info;
     sa_size = (dest_sa->sa_family == AF_INET) ?
               sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
-    if (sendto(logr.sock, crypt_msg, msg_size, 0, dest_sa, sa_size) < 0) {
-        merror(SEND_ERROR, ARGV0, keys.keyentries[agentid]->id);
+
+   /*
+    * Because we handle multiple IP addresses, we won't know what interfaces
+    * are active for network communication until we receive something on one
+    * of them.  This is a work around in the event we need to send before
+    * we have identified the working interface in secure.c. (dgs - 2/26/18)
+    */
+
+    if (logr.sock == 0) {
+        /* not initialized */
+        for (i = 0; i < logr.netinfo->fdcnt; i++) {
+            if (sendto(logr.netinfo->fds[i], crypt_msg, msg_size, 0,
+                       dest_sa, sa_size) < 0) {
+                continue;
+            }
+
+            ok = 1;
+            break;
+        }
+
+        /* if we tried all the sockets and noe of them worked, send an error */
+        if (ok == 0) {       
+            merror(SEND_ERROR, ARGV0, keys.keyentries[agentid]->id);
+        }
+    } else {
+        /* working socket identified */
+        if (sendto(logr.sock, crypt_msg, msg_size, 0, dest_sa, sa_size) < 0) {
+            merror(SEND_ERROR, ARGV0, keys.keyentries[agentid]->id);
+        }
     }
 
     /* Unlock mutex */

--- a/src/remoted/sendmsg.c
+++ b/src/remoted/sendmsg.c
@@ -92,8 +92,6 @@ int send_msg(unsigned int agentid, const char *msg)
     size_t msg_size, sa_size;
     char crypt_msg[OS_MAXSTR + 1];
     struct sockaddr * dest_sa;
-    int i;
-    int ok = 0;
 
     /* If we don't have the agent id, ignore it */
     if (keys.keyentries[agentid]->rcvd < (time(0) - (2 * NOTIFY_TIME))) {
@@ -125,7 +123,9 @@ int send_msg(unsigned int agentid, const char *msg)
     */
 
     if (logr.sock == 0) {
-        /* not initialized */
+        int i, ok = 0;
+
+        /* socket not established - try current sockets */
         for (i = 0; i < logr.netinfo->fdcnt; i++) {
             if (sendto(logr.netinfo->fds[i], crypt_msg, msg_size, 0,
                        dest_sa, sa_size) < 0) {
@@ -141,7 +141,7 @@ int send_msg(unsigned int agentid, const char *msg)
             merror(SEND_ERROR, ARGV0, keys.keyentries[agentid]->id);
         }
     } else {
-        /* working socket identified */
+        /* working socket identified in secure.c */
         if (sendto(logr.sock, crypt_msg, msg_size, 0, dest_sa, sa_size) < 0) {
             merror(SEND_ERROR, ARGV0, keys.keyentries[agentid]->id);
         }


### PR DESCRIPTION
I have encountered a significant issue in OSSEC 2.9.3 and the current OSSEC beta (GitHub repository) release that affects the ability of OSSEC clients to be able to connect to FreeBSD servers. This issue also probably affects all current BSD derivatives and possibly some Linux systems as well. I have identified and resolved the issue in OSSEC by rewriting some of the networking code, however, before I describe the solution, I wanted to provide some background information on the problem first.

**Problem Symptoms**

The server is running FreeBSD 11.1 with all of the current updates. This is a standard OSSEC server installation with all standard options enabled and no bells and whistles (no MySQL and no MQ). After correcting for some BSD-specific issues for header files and libraries, OSSEC installs normally on the server with the install.sh script and the compilation completes without any fatal errors (GCC does generate a few warnings on analysisd/decoders/syscheck.c and analysisd/decoders/syscheck-test.c, but these are not show stoppers). The server has an assigned IP address of 192.168.1.80 (IPv4 private IP space) and all of the clients it associates with are on the local 192.168.1.0/24 network.

The OSSEC 2.9.3 client software is installed on each Windows workstation and valid client keys are obtained for each client system. Everything appears fine, except that there are no alerts logged on the server for any of the configured clients. In short, the problem manifests itself as an inability for the client systems to connect to the OSSEC server. In the ossec.log file on each client there are messages like this that repeat over and over:

```
2018/03/08 12:11:06 ossec-agentd: INFO: Trying to connect to server 192.168.1.80, port 1514. 2018/03/08 12:11:06 INFO: Connected to 192.168.1.80 at address 192.168.1.80:1514, port 1514 2018/03/08 12:11:27 ossec-agentd(4101): WARN: Waiting for server reply (not started). Tried: '192.168.1.80'.

2018/03/08 12:12:41 ossec-agentd: INFO: Trying to connect to server 192.168.1.80, port 1514. 2018/03/08 12:12:41 INFO: Connected to 192.168.1.80 at address 192.168.1.80:1514, port 1514 2018/03/08 12:13:02 ossec-agentd(4101): WARN: Waiting for server reply (not started). Tried: '192.168.1.80'.
```

Because the clients use UDP, and UDP is a connectionless protocol, there is no protocol handshake to ensure a connection has actually been established like there would be with TCP. As long as the sendto() function returns a positive integer (the number of bytes sent), the call is deemed successful. This is true even when packets are not received on the destination host. To compensate for this, the server is supposed to return a control message to indicate the packet was received. Because the client never receives this confirmation, a warning is generated in the client log "Waiting for server reply (not started)".

On the server, remoted starts fine. It displays the maximum number of agents allowed (2048) and logs the fact that it successfully read the authentication keys file. However, the server logs hint that there is an issue when remoted starts because each client in the client.keys file results in a message stating "Assigning counter for agent Workstation01: '0:0'", or "Assigning sender counter: 0:0". These messages are generated when a client is defined in the etc/client.keys file, but no initial connection has ever occurred. This is normal for a first time start of OSSEC, but if this happens every time you restart OSSEC for every client defined in the system, your clients are not communicating.

To identify whether remoted was listening on UDP port 1514, I used the "netstat -an" command and the FreeBSD "sockstat" command (sockstat is like "lsof" for sockets). The only address bound to port 1514 was an IPv6 address, not the IPv4 address. The server uses only a single IPv4 address for network communication and no IPv6 addresses. However, it turns out that FreeBSD (and many other systems) create a link-local IPv6 address based on the MAC address of each interface when IPv6 is not specifically configured for the interface. This is specified in RFC 2462.

The standard solution for this would be to specify an IP address for the "secure" connection in the remote configuration using the <local_ip> option. However, when that is used, OSSEC ignores it and the system continues to bind to the IPv6 link-local address. While I could have experimented with disabling IPv6 in the operating system, this could have an adverse impact on other applications running on the server.

Normally, the system should simply query all available addresses on the system using getaddrinfo(), create a socket for each address, and bind the address to the socket. If the protocol is TCP, then you also need to use listen() to establish a queue. Then select() can be used to handle the dispatch of the individual sockets as messages arrive. I have a lot of experience with writing network interfaces in C, so I decided I would take a look at what was going on inside OSSEC that was creating this issue for me.

**Initial Analysis**

The OSSEC remoted process is responsible for handling the connections between the clients and the server. All of this code, except for the actual networking code, is found in the src/remoted directory. The initial connections for the UDP secure server and the syslog server are initiated in the HandleRemote() function inside remoted.c through calls to OS_Bindportudp() or OS_Bindporttcp() which are found in os_net/os_net.c. What is immediately obvious is that only one socket is returned as an integer value, instead of a group of sockets (one for each interface and protocol family).

The actual processing of incoming messages is divided between secure.c for secure UDP connections, syslog.c for syslog UDP connections, and syslogtcp.c for syslog TCP connections. Most of the outgoing connections are handled by send_msg.c (with some exceptions). Because there is only one socket used per communication strategy (secure UDP, syslog UDP, and syslog TCP), all of the routines use a while(1) loop with blocking reads to process incoming messages. To handle multiple sockets without dragging the CPU into the mud, these would have to be modified to use select().

The next thing I looked at was the code that was doing the network calls, which is found in the file os_net/os_net.c.  Both the OS_Bindportudp() and OS_Bindporttcp() calls referred to a function called OS_Bindport() to handle all of the network initialization code including querying the available addresses, creating the socket, binding the address, invoking listen() for the queue (TCP only), and returning the active socket to the caller.

The code in os_net/os_net.c clearly showed my dilemma; the call to getaddrinfo() was setup to use AF_INET6 for the address family and AI_V4MAPPED, AI_PASSIVE, and AI_ADDRCONFIG for flags. Under this specification, IPv6 is preferred over IPv4, and if no IPv6 addresses exist and IPv4 addresses do exist, the IPv4 address is to be returned as a mapped IPv4 address using IPv6. A better solution is to use PF_UNSPEC for the address family with AI_PASSIVE and AI_ADDRCONFIG to pick up all addressed on configured interfaces.

The original author of this module recognized this as a problem early on, but s/he assumed that if they had AI_V4MAPPED defined in netdb.h, then the system would handle it properly. However, if IPv4 is preferred and there are any IPv6 addresses configured on the system, AI_V4MAPPED will not yield any IPv4 addresses. There is a good article by IBM on this that you can read here:

https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.3.0/com.ibm.zos.v2r3.hale001/ipv6d0131000748.htm

This is further compounded because OSSEC is returning only a single socket bound to a single address making the process of supporting both IPv4 and IPv6 at the same time is impossible. The only correct solution is to modify OSSEC to handle multiple IP addresses under both IPv4 and IPv6 simultaneously.

**The Solution**

The overall solution to this problem was to return all of the addresses that meet the selection criteria and use the select() function to return sockets that are ready for reading. While this change affected a number of modules in the OSSEC system, the change was relatively straight forward to implement. A list of modules affected is provided at the end of this document.

Under the current version of OSSEC, a function named OS_Bindport() is used to locate the first address that is returned from getaddrinfo(). Then a socket for the appropriate connection type is created (SOCK_DGRAM for UDP or SOCK_STREAM for TCP), and the address is bound to the socket. If the connection is a TCP connection, a queue is established for the bound socket using listen(). Then the integer value socket is returned. If the socket value is -1, an error is assumed and various error actions are taken by the caller.

Under the modified version, OS_Bindport() was modified in a number of ways. First, instead of returning an integer value representing a bound socket to the caller, the routine now returns a pointer to an OSNetInfo structure. The OSNetInfo structure is defined in os_net/os_net.h as follows:

```
typedef struct _OSNetInfo {
  fd_set fdset;                         /* set of sockets used by select ()*/
  int fdmax;                            /* fd max socket for select() */
  int fds[FD_SETSIZE];                  /* array of bound sockets for send() */
  int fdcnt;                            /* number of sockets in array */
  int status;                           /* return status (-1 is error) */
  int retval;                           /* return value (additional info) */
} OSNetInfo;
```

In order to multiplex multiple sockets efficiently, we need to use the select() function. The select() function operates on a struct called fd_set that is built on the successful acquisition of a socket with a bound address. Each successful acquisition is added to the set using the FD_SET macro. We also track the highest value socket number returned in fdmax. When all processing is completed, fdmax is incremented by 1 so it can be used directly with the select() function in other modules. We also track the individual bound sockets in an integer table called fds, and a count of the number of sockets in the table using fdcnt.

Because the original implementation relied upon a return value of -1 to indicate an error, we include an element in the struct called status that performs the same function. If status is -1, then an error has occurred. Upon a successful return, the status element will be 0. If status is -1, the return value element retval will contain the error number associated with the error status. The OSNetInfo struct made the process of modifying the OSSEC networking code relatively simple because it preserved all of the functionality that was inherent with the original code.

In addition to the OSNetInfo structure as a return value, the second major change to os_net/os_net.c was the definition of hints to the getaddrinfo() function. The getaddrinfo() function was created by the POSIX standards committee to provide support both IPv4 and IPv6 simultaneously. The getaddrinfo() function modifies a struct that returns a pointer to a linked list of addresses that match the selection criteria passed to getaddrinfo() through the hints parameter struct.

Under the original OSSEC code, if the operating system platform had AI_V4MAPPED defined in <netdb.h> (the vast majority of modern OS's support this), then the hints structure passed to getaddrinfo() used AF_INET6 for the protocol family. This essentially guaranteed that only IPv6 addresses would be returned if they were defined on the system. Even if there are no IPv6 addresses configured on the system, the AF_INET6 protocol family with the AI_V4MAPPED flag will return a mapped IPv4 address in IPv6 format.

For current *BSD systems, if an IPv6 address is not defined on an interface, the system will create a link-local IPv6 address based on the MAC address of each interface. IPv6 link-local addresses are essentially useless for external communication, so the net result is that *BSD systems (and others) are not able to communicate using IPv4.

By modifying this to use AF_UNSPEC instead of AF_INET6, eliminating the AI_V4MAPPED flag, and utilizing all of the addresses returned by the call to getaddrinfo(), we have the ability to communicate through all of the interfaces defined on the system using both IPv4 nd IPv6. Nonetheless, there are a number of Linux systems that are working fine for OSSEC with the AF_INET6 family and the AI_V4MAPPED flag. As such, an "#if defined" definition was placed in the code to support the original behavior on Linux systems, with the PF_UNSPEC behavior defined for non-Linux systems. In the event you do want to use the PF_UNSPEC code with a Linux system (I suspect this will become the norm as more versions of Linux adopt RFC 2462 and the link-local address), all you need to do is to uncomment the line in the Makefile that defines NOV4MAP and the system will use AF_UNSPEC instead of AF_INET6.

Once the call is made to getaddrinfo(), we utilize a loop to process each of the addresses returned in the linked list of addresses. Each socket that is bound successfully is added to the fd_set for subsequent select() processing, and also added to an array of integers containing bound sockets. The only other substantive change that was made to this module is that we set a socket option for the SO_REUSEADDR flag. In the event OSSEC is stopped and restarted again, the use of the SO_REUSEADDR socket option allows OSSEC to restart immediately without having to wait for a lingering socket to close. It also improves performance for short duration transactions.

The other changes in the os_net/os_net.c module include changing the return parameter from integer to a pointer to an OSNetInfo struct for OS_Bindportudp() and OS_Bindporttcp(), and a number of helper functions were added to the bottom of the module to provide additional information as the addresses are retrieved, sockets created, and addresses are bound to sockets.

Once the changes were made to os_net/os_net.c, the remoted struct in config/remote-config.h  was modified to add a pointer called netinfo to the remoted struct using a typedef of OSNetInfo (directly below where the sock element is defined), and remoted/remoted.c was modified to accept the new OSNetInfo pointer and store it in the netinfo element in the logr configuration struct.

Next, I modified the routines that use the sockets to use the logr.netinfo element instead of the logr.sock element that was originally used for reads. Blocking reads were replaced with select() to multiplex the sockets that became available for reading. This change affected secure.c, syslog.c, and syslogtcp.c in the remoted subdirectory, and main-server.c in the os_auth subdirectory.

The remoted/sendmsg.c module was modified to use multiple sockets for sending. In the event a message was received on one of the sockets, that socket was used for sending the packet out. In the event no packet had been received, the routine was modified to loop through the list of available sockets to ensure the packet is sent.

The Makefile was also modified to added a define for NOV4MAP, which is commented out by default. When this is defined, Linux systems can build remoted with AF_UNSPEC instead of AF_INET6 and the AI_V4MAPPED attribute that was described earlier. As more operating systems adopt the link-local specification to establish an IPv6 address based on the MAC address, this could help Linux users with being able to support IPv4 on their systems.

There are two other changes I made that are not related to the IP address issue but relate to successfully compiling and installing OSSEC on FreeBSD.  Because I had to modify the Makefile for the NOV4MAP define, it made sense to include these changes as part of this pull request. Both of these changes are to make files that are provided with the distribution.

The first change is to the Makefile in the top src directory. BSD systems use the /usr/local directory for managing files and programs that are not part of the standard operating system distribution. MySQL, Postgres, MQ, readline, and other applications are extensions that get installed under /usr/local. As such, it is necessary to add /usr/local/include directory for C header files and /usr/local/lib for object libraries. This already existed in Makefile for OpenBSD, but not for FreeBSD or NetBSD.

The second Makefile change I made was to the LUA Makefile for BSD distributions. Like the Makefile in the src directory described above, the LUA build needs to have the same definitions for header files and libraries. The file I modified under the src directory is external/lua/src/Makefile. The modification added parameters for "-I/usr/local/include" and "-L/usr/local/lib". With these changes, FreeBSD and other BSD systems will compile without problems using gmake and gcc.

**Header Files Modified**

os_net/os_net.h - Defined a new typedef struct called OSNetInfo that is used to return a list of bound sockets back to the caller, and changed the return values defined for OS_Bindporttcp() and OS_Bindportudp() to use a pointer to the OSNetInfo struct instead of the integer value they used to return. The pointer to the OSNetInfo struct is stored in the remoted struct that is defined as "logr" in the code. The pointer to the OSNetInfo pointer is named netinfo.

config/remote-config.h - Added a #include for "os_net/os_net.h" to ensure the appropriate network function headers were defined for select() and added a pointer to an OSNetInfo struct named netinfo to the remoted struct. The netinfo pointer serves the same purpose as the old sock element, except that it handles multiple sockets instead of just a single socket. The remoted struct, which is usually referred to as "logr" in the remoted code, is used to pass a number of configuration elements between the remoted modules.

**Source Modules Modified**

os_net/os_net.c - Modified the module to return a struct called OSNetInfo that contains the bound sockets for each of the addresses in a format ready for use by select(), and an array of sockets that can be referenced for individual socket usage. The OSNetInfo struct is described earlier in this document. Also added code to use PF_UNSPEC for all interfaces except those that are for Linux and also have AI_V4MAPPED defined in <netdb.h>. Also added a number of helper functions to display addresses and other status information in the ossec.log file using verbose().

remoted/remoted.c - Modified the module to use the new OSNetInfo struct for return values from calls to OS_Bindporttcp() and OS_Bindportudp().

remoted/secure.c - Modified secure.c to utilize OSNetInfo data with multiple bound sockets via logr.netinfo instead of the original single bound socket with logr.sock. Also changed the message receipt loop to use select() to multiplex the sockets, instead of blocking on a read for a single socket.

remoted/syslog.c - Modified syslog.c to support UDP messages the same way we modified secure.c, including using the OSNetInfo struct for multiple sockets and the select() call to support multiplexing.

remoted/syslogtcp.c - Modified syslogtcp.c to support TCP messages the same way we modified secure.c and syslog.c, including using the OSNetInfo struct for multiple sockets and the select() call to support multiplexing.

remoted/sendmsg.c - Modified sendmsg.c to use the bound socket array in the netinfo structure. If we have previously identified a valid socket, we use that socket to send on. Otherwise, we cycle through the array of valid bound sockets until we get a successful completion on the sendto() call. This approach appears to work well.

os_auth/main-server.c - This module was an outlier, but because it called OS_Bindporttcp() it had to be modified to support the new multi-address approach. Modified main-server.c to use new OSNetInfo struct for data returned by OS_Bindporttcp and implemented the select() call to multiplex the group of sockets.

**Makefile Modifications**

Makefile - Found in the src directory at the top of the directory tree, I added /usr/local/include to CFLAGS and /usr/local/lib OSSEC_LDFLAGS to support successful compilation on FreeBSD and NetBSD. Also added the define for NOV4MAP that is commented out. When NOV4MAP is defined, Linux distributions will use AF_UNSPEC to bind sockets instead of AF_INET6 with the AI_V4MAPPED flag.

external/lua/src/Makefile - LUA compilation fails with the current Makefile because the /usr/local/include directory is not specified for headers, and the /usr/local/lib is not specified for object libraries. I added parameters to the definitions for bsd and freebsd in the Makefile to make sure those directories were included. This allows the LUA compile process to complete without errors.

**Modification Summary and Pull Request**

I had originally performed this modification for the OSSEC 2.9.3 release and tested it thoroughly on FreeBSD 11.1 for several weeks. I then ported these changes into the current code branch of OSSEC that I retrieved from GitHub on May 1, 2018. This required my changes to be re-ported into newer versions of os_auth/main-server.c, os_net/os_net.c, and os_net/os_net.h. I also had to re-port changes into the two Makefiles I identified earlier. I only have a day of use on this, but it seemd to be running ithout issues.

If anyone is interested in the changes that work for the 2.9.3 release, you can download the modified OSSEC 2.9.3 release from https://networkalarmcorp.com/dnld/ossec-hids-2.9.3.1.tgz. I should have the 2.9.3 code up on my server by Thursday.

I have submitted a pull request for this modification to be incorporated into the OSSEC code base. If anyone has any questions or suggestions related to this modification, I am happy to discuss them. I hope this modification helps the OSSEC community at large.

Dave Stoddard
Network Alarm Corporation
https://networkalarmcorp.com
https://redgravity.net
Office: 301-850-0668 x101
Email: dgs at networkalarmcorp dot com