### PR TITLE
Fix the log location in the ossec-slack AR script.

### DIFF
--- a/active-response/ossec-slack.sh
+++ b/active-response/ossec-slack.sh
@@ -24,8 +24,8 @@ ALERTLAST=`echo "$ALERTID" | cut -d  "." -f 2`
 cd $LOCAL
 cd ../
 PWD=`pwd`
-echo "`date` $0 $1 $2 $3 $4 $5 $6 $7 $8" >> ${PWD}/../logs/active-responses.log
-ALERTFULL=`grep -A 10 "$ALERTTIME" ${PWD}/../logs/alerts/alerts.log | grep -v "\.$ALERTLAST: " -A 10 | grep -v "Src IP: " | grep -v "User: " |grep "Rule: " -A 4 | cut -c -139 | sed 's/\"//g'`
+echo "`date` $0 $1 $2 $3 $4 $5 $6 $7 $8" >> ${PWD}/../../logs/active-responses.log
+ALERTFULL=`grep -A 10 "$ALERTTIME" ${PWD}/../../logs/alerts/alerts.log | grep -v "\.$ALERTLAST: " -A 10 | grep -v "Src IP: " | grep -v "User: " |grep "Rule: " -A 4 | cut -c -139 | sed 's/\"//g'`
 
 PAYLOAD='{"channel": "'"$CHANNEL"'", "username": "'"$SLACKUSER"'", "text": "'"${ALERTFULL}"'"}'
 
@@ -33,13 +33,13 @@ ls "`which curl`" > /dev/null 2>&1
 if [ ! $? = 0 ]; then
     ls "`which wget`" > /dev/null 2>&1
     if [ $? = 0 ]; then
-        wget --keep-session-cookies --post-data="${PAYLOAD}" ${SITE} 2>>${PWD}/../logs/active-responses.log
+        wget --keep-session-cookies --post-data="${PAYLOAD}" ${SITE} 2>>${PWD}/../../logs/active-responses.log
         exit 0;
     fi
 else
-    curl -s -X POST --data-urlencode "payload=${PAYLOAD}" ${SITE} 2>>${PWD}/../logs/active-responses.log
+    curl -s -X POST --data-urlencode "payload=${PAYLOAD}" ${SITE} 2>>${PWD}/../../logs/active-responses.log
     exit 0;
 fi
 
-echo "`date` $0: Unable to find curl or wget." >> ${PWD}/../logs/active-responses.log
+echo "`date` $0: Unable to find curl or wget." >> ${PWD}/../../logs/active-responses.log
 exit 1;


### PR DESCRIPTION
The script looks for `${PWD}/../logs`, but that does not exist.
It should look for `${PWD}/../logs` instead since it is being runfrom ossec/active-response/bin.

Reported by amh5366 in issue #1421 