### PR TITLE
Add some bits to support Alpine Linux

### DIFF
--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -50,15 +50,22 @@ else
         USERADD="/usr/sbin/useradd"
         OSMYSHELL="/sbin/nologin"
     else
-	# All current linux distributions should support system accounts for
-	# users/groups. If not, leave the GROUPADD/USERADD as it was before
-	# this change
-	sys_acct_chk () {
-	    $1 --help 2>&1 | grep -e " *-r.*system account" >/dev/null 2>&1 && echo "$1 -r" || echo "$1"
-	  }
-	GROUPADD=$(sys_acct_chk "/usr/sbin/groupadd -f")
-	USERADD=$(sys_acct_chk "/usr/sbin/useradd")
-        OSMYSHELL="/sbin/nologin"
+        # Alpine linux has adduser/addgroup
+        if [ -e "/etc/alpine-release" ]; then
+            GROUPADD="/usr/sbin/addgroup"
+            USERADD="/usr/sbin/adduser"
+            OSMYSHELL="/sbin/nologin"
+        else
+	    # All current linux distributions should support system accounts for
+	    # users/groups. If not, leave the GROUPADD/USERADD as it was before
+	    # this change
+	    sys_acct_chk () {
+	        $1 --help 2>&1 | grep -e " *-r.*system account" >/dev/null 2>&1 && echo "$1 -r" || echo "$1"
+	    }
+	    GROUPADD=$(sys_acct_chk "/usr/sbin/groupadd -f")
+	    USERADD=$(sys_acct_chk "/usr/sbin/useradd")
+            OSMYSHELL="/sbin/nologin"
+        fi
     fi
 
     if [ -x /usr/bin/getent ]; then
@@ -84,14 +91,18 @@ else
         if [ -x /usr/bin/getent ]; then 
             if [ `getent passwd ${U} | wc -l` -lt 1 ]; then
 	            if [ "$UNAME" = "OpenBSD" ] || [ "$UNAME" = "SunOS" ]; then
-                    ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
+                        ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
+                    if [ -e "/etc/alpine-release" ]; then
+                        ${USERADD} -G ${GROUP} -s ${OSMYSHELL} -h ${DIR} -S ${U}
 	            else
 	                ${USERADD} "${U}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"
 	            fi
             fi
         elif [ ! `grep "^${U}" /etc/passwd > /dev/null 2>&1` ]; then
 	        if [ "$UNAME" = "OpenBSD" ] || [ "$UNAME" = "SunOS" ]; then
-                ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
+                    ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
+                elif [ -e "/etc/alpine-release ]; then
+                    ${USERADD} -G ${GROUP} -s ${OSMYSHELL} -h ${DIR} -S ${U}
 	        else
 	            ${USERADD} "${U}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"
 	        fi

--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -92,7 +92,7 @@ else
             if [ `getent passwd ${U} | wc -l` -lt 1 ]; then
 	            if [ "$UNAME" = "OpenBSD" ] || [ "$UNAME" = "SunOS" ]; then
                         ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
-                    if [ -e "/etc/alpine-release" ]; then
+                    elif [ -e "/etc/alpine-release" ]; then
                         ${USERADD} -G ${GROUP} -s ${OSMYSHELL} -h ${DIR} -S ${U}
 	            else
 	                ${USERADD} "${U}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"

--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -101,7 +101,7 @@ else
         elif [ ! `grep "^${U}" /etc/passwd > /dev/null 2>&1` ]; then
 	        if [ "$UNAME" = "OpenBSD" ] || [ "$UNAME" = "SunOS" ]; then
                     ${USERADD} -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}" "${U}"
-                elif [ -e "/etc/alpine-release ]; then
+                elif [ -e "/etc/alpine-release" ]; then
                     ${USERADD} -G ${GROUP} -s ${OSMYSHELL} -h ${DIR} -S ${U}
 	        else
 	            ${USERADD} "${U}" -d "${DIR}" -s ${OSMYSHELL} -g "${GROUP}"

--- a/src/init/init.sh
+++ b/src/init/init.sh
@@ -130,6 +130,14 @@ runInit()
             chown root:ossec /etc/init.d/ossec
             update-rc.d ossec defaults > /dev/null 2>&1
             return 0;
+        elif [ -e "/etc/alpine-release" ]; then
+            echo " - ${systemis} Alpine Linux."
+            echo " - ${modifiedinit}"
+            cp -pr ./src/init/ossec-hids-alpine.init /etc/init.d/ossec
+            chmod +x /etc/init.d/ossec
+            chmod go-w /etc/init.d/ossec
+            chown root:ossec /etc/init.d/ossec
+            return 0;
         else
             echo " - ${noboot}"
         fi

--- a/src/init/ossec-hids-alpine.init
+++ b/src/init/ossec-hids-alpine.init
@@ -1,0 +1,57 @@
+#!/sbin/openrc-run
+DIRECTORY="/var/ossec"
+OSSEC_CONTROL="${DIRECTORY}/bin/ossec-control"
+
+depend() {
+	need net
+	use logger
+}
+
+configtest() {
+	ebegin "Checking OSSEC Configuration"
+	checkconfig
+	eend $?
+}
+
+checkconfig() {
+	CONFIGFILE="${CONFIGFILE:-${DIRECTORY}/etc/ossec.conf}"
+	if [ ! -r "${CONFIGFILE}" ]; then
+		eerror "Unable to read configuration file: ${CONFIGFILE}"
+		return 1
+	fi
+
+	# Maybe put some kind of config file syntax checking in here?  XML is a little different
+	# so maybe not.	
+	return $ret
+}
+
+start() {
+	checkconfig || return 1
+	ebegin "Starting ossec-hids"
+	${OSSEC_CONTROL} start > /dev/null 2>&1
+	eend $?
+}
+
+stop() {
+	checkconfig || return 1
+	ebegin "Stopping ossec-hids"
+	${OSSEC_CONTROL} stop > /dev/null 2>&1
+	eend $?
+}
+
+restart() {
+	if ! service_started "${myservice}" ; then
+		eerror "OSSEC is not running! Please start it before trying to reload it."
+	else
+		checkconfig || return 1
+		ebegin "Reloading ossec"
+		svc_stop ${OSSEC_CONTROL}
+		svc_start ${OSSEC_CONTROL}
+		eend $?
+	fi
+}
+
+status() {
+	checkconfig || return 1
+	${OSSEC_CONTROL} status
+}


### PR DESCRIPTION
`setup-alpine` is so nice I decided I had to add some support for it.
`ossec-hids-alpine.init` taken from their package repository. Possibly written by Francesco Colista.

Lightly tested on alpine, but nothing else yet.