### PR TITLE
Add an "su" decoder to properly decode a previously unseen log message

### DIFF
--- a/contrib/ossec-testing/tests/su.ini
+++ b/contrib/ossec-testing/tests/su.ini
@@ -1,5 +1,6 @@
 [su: failed ]
 log 1 pass = Apr 27 15:22:23 niban su[2921936]: failed: ttyq4 changing from ldap to root
+log 2 pass = Jun 20 17:19:59 dactyl su: FAILED SU (to root) mmoorcro on pts/0
 rule = 5302
 alert = 9
 decoder = su
@@ -23,3 +24,4 @@ log 1 pass = Apr 22 17:51:51 enigma su: dcid to root on /dev/ttyp1
 rule = 5305
 alert = 4
 decoder = su
+

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -522,6 +522,13 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <fts>name, srcuser, location</fts>
 </decoder>
 
+<decoder name="su-failed">
+  <parent>su</parent>
+  <prematch>^FAILED SU </prematch>
+  <regex offset="after_prematch">^\(to (\S+) (\S+) on</regex>
+  <order>dstuser, srcuser</order>
+</decoder>
+
 <decoder name="su-detail2">
   <parent>su</parent>
   <prematch> </prematch>


### PR DESCRIPTION
Mark M on the user list found an su log message that was not parsing properly. I added a decoder to decode these messages and added his log to the su tests. No failures so far.

New log message:
```
Jun 20 17:19:59 dactyl su: FAILED SU (to root) mmoorcro on pts/0
```