### PR TITLE
Quick rule to ignore dropbear not being able to listen on a port

### DIFF
--- a/contrib/ossec-testing/tests/dropbear.ini
+++ b/contrib/ossec-testing/tests/dropbear.ini
@@ -1,0 +1,7 @@
+[already listening]
+log 1 pass = Jun 25 14:04:30 10.0.0.1 dropbear[30746]: Failed listening on '7001': Error listening: Address already in use
+
+rule = 51011
+alert = 1
+decoder = dropbear
+

--- a/etc/rules/dropbear_rules.xml
+++ b/etc/rules/dropbear_rules.xml
@@ -92,6 +92,13 @@
     <description>User successfully logged in using a public key.</description>
     <group>authentication_success,</group>
   </rule>
+
+  <rule id="51011" level="1">
+    <decoded_as>dropbear</decoded_as>
+    <if_sid>1002</if_sid>
+    <match>Error listening: Address already in use</match>
+    <description>Dropbear cannot listen on port.</description>
+  </rule>      
  
    
 </group> <!-- SYSLOG,LOCAL -->


### PR DESCRIPTION
Add a rule to basically ignore dropbear trying to run on itself and not being able to listen on the configured port.