### PR TITLE
Add more fields to JSON output.

### DIFF
--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -33,6 +33,9 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->generated_rule->sigid) {
         cJSON_AddNumberToObject(rule, "sidid", lf->generated_rule->sigid);
     }
+    if (lf->generated_rule->group) {
+        cJSON_AddStringToObject(rule, "group", lf->generated_rule->group);
+    }
     if (lf->generated_rule->cve) {
         cJSON_AddStringToObject(rule, "cve", lf->generated_rule->cve);
     }
@@ -40,9 +43,18 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
         cJSON_AddStringToObject(rule, "info", lf->generated_rule->info);
     }
 
+    if( lf->decoder_info->name ) {
+        cJSON_AddStringToObject(root, "decoder", lf->decoder_info->name);
+    }
+    if( lf->decoder_info->parent ) {
+        cJSON_AddStringToObject(root, "decoder_parent", lf->decoder_info->parent);
+    }
 
     if (lf->action) {
         cJSON_AddStringToObject(root, "action", lf->action);
+    }
+    if (lf->protocol) {
+        cJSON_AddStringToObject(root, "protocol", lf->protocol);
     }
     if (lf->srcip) {
         cJSON_AddStringToObject(root, "srcip", lf->srcip);
@@ -93,6 +105,24 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
             cJSON_AddNumberToObject(file_diff, "perm_before", lf->perm_before);
             cJSON_AddNumberToObject(file_diff, "perm_after", lf->perm_after);
         }
+    }
+    if ( lf->data ) {
+        cJSON_AddStringToObject(root, "data", lf->data);
+    }
+    if ( lf->url ) {
+        cJSON_AddStringToObject(root, "url", lf->url);
+    }
+    if ( lf->systemname ) {
+        cJSON_AddStringToObject(root, "system_name", lf->systemname);
+    }
+    if ( lf->status ) {
+        cJSON_AddStringToObject(root, "status", lf->status);
+    }
+    if ( lf->hostname ) {
+        cJSON_AddStringToObject(root, "hostname", lf->hostname);
+    }
+    if ( lf->program_name ) {
+        cJSON_AddStringToObject(root, "program_name", lf->program_name);
     }
     out = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);


### PR DESCRIPTION
We already have parsed these elements and used them in the rules, so why
not pass them along to JSON consumers.  This gives users more
flexibility to analyze their alerts in a system like ElasticSearch
without having to reparse or remap this data.  This will hopefully
deduplicate slower Logstash type configs.