### PR TITLE
When trying to bind to a local address, present the error on failure.

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -302,8 +302,8 @@ int OS_Connect(char *_port, unsigned int protocol, const char *_ip)
         if (agt) {
             if (agt->lip) {
                 if (bind(ossock, local_ai->ai_addr, local_ai->ai_addrlen)) {
-                    verbose("Unable to bind to local address %s.  Ignoring...",
-                            agt->lip);
+                    verbose("Unable to bind to local address %s.  Ignoring. (%s)",
+                            agt->lip, strerror(errno));
                 }
                 else verbose("Connecting from local address %s", agt->lip);
             }


### PR DESCRIPTION
Our generic error messages don't provide enough detail, the errno stuff might help.
I can change the style, if anyone cares about it.