### PR TITLE
BUGFIX: remove default value for authpass

### DIFF
--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -246,11 +246,6 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-
-    if(authpass == NULL) {
-        authpass = AUTHDPASS_PATH;
-    }
-
     /* Checking if there is a custom password file */
     if (authpass != NULL && authenticate > 0) {
         FILE *fp;


### PR DESCRIPTION
authpass is originally set as NULL
If user does not specify option "-P" but then incsecure mode is used.
However the authpass is set to some default value by mistake which
forces user to always use password