### PR TITLE
additional sshd decoders

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -217,7 +217,7 @@
 <decoder name="ssh-invalid-user">
   <parent>sshd</parent>
   <prematch>^Invalid user|^Illegal user</prematch>
-  <regex offset="after_prematch"> from (\S+)$</regex>
+  <regex offset="after_prematch"> from (\S+)</regex>
   <order>srcip</order>
 </decoder>
 
@@ -225,6 +225,41 @@
   <parent>sshd</parent>
   <prematch>^scanned from</prematch>
   <regex offset="after_prematch"> (\S+) </regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="ssh-received">
+  <parent>sshd</parent>
+  <prematch>^Received disconnect </prematch>
+  <regex offset="after_prematch">^from (\S+): |^from (\S+) </regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="ssh-disconnected">
+  <parent>sshd</parent>
+  <prematch>^Disconnected from invalid user</prematch>
+  <regex offset="after_prematch">\S+ (\S+) </regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="ssh-connection">
+  <parent>sshd</parent>
+  <prematch>^Connection closed by </prematch>
+  <regex offset="after_prematch">user (\S+) (\S+) </regex>
+  <order>user, srcip</order>
+</decoder>
+
+<decoder name="ssh-negotiate">
+  <parent>sshd</parent>
+  <prematch>^Unable to negotiate with </prematch>
+  <regex offset="after_prematch">^(\S+) port (\d+)</regex>
+  <order>srcip, srcport</order>
+</decoder>
+
+<decoder name="ssh-protocol">
+  <parent>sshd</parent>
+  <prematch>^Protocol major versions differ for </prematch>
+  <regex offset="after_prematch">^(\S+)</regex>
   <order>srcip</order>
 </decoder>
 


### PR DESCRIPTION
Add a few decoders for sshd. I'm not sure if the log messages changed recently, but I saw they weren't being decoded very well. I'm too tired to do it now, but reviewing the sshd decoders should be a task sometime. 
Sample logs that should be decoded better:
```
Jul 28 23:22:18 junction sshd[15131]: Invalid user role1 from 192.144.139.214 port 4100
Jul 28 23:22:18 junction sshd[15131]: Received disconnect from 192.144.139.214 port 41006:11: Normal Shutdown, Thank you for playing [preauth]
Jun 22 12:01:13 junction sshd[11283]: Received disconnect from 212.14.228.46: 11: Bye Bye
Jul 28 23:22:18 junction sshd[15131]: Disconnected from invalid user role1 192.144.139.214 port 41006 [preauth]
Jul 28 23:35:04 junction sshd[38935]: Received disconnect from 185.8.49.228 port 37890:11: Bye Bye [preauth]
Jul 29 00:21:57 junction sshd[72341]: User root from 180.101.185.159 not allowed because not listed in AllowUsers
Jul 29 00:21:58 junction sshd[72341]: Connection closed by invalid user root 180.101.185.159 port 45952 [preauth]
Jul 29 00:39:25 junction sshd[52330]: Did not receive identification string from 192.168.18.8 port 36566
Jul 29 00:43:14 junction sshd[5957]: Unable to negotiate with 192.168.18.8 port 35250: no matching host key type found. Their offer: ssh-dss [preauth]
Jul 29 00:43:14 junction sshd[79098]: Protocol major versions differ for 192.168.18.8 port 34704: SSH-2.0-OpenSSH_7.8 vs. SSH-1.5-Nmap-SSH1-Hostkey
```