### PR TITLE
Replace hard coded directories with the appropriate variables

### DIFF
--- a/active-response/host-deny.sh
+++ b/active-response/host-deny.sh
@@ -126,10 +126,10 @@ if [ "x${ACTION}" = "xadd" ]; then
 # Deleting from hosts.deny
 elif [ "x${ACTION}" = "xdelete" ]; then
    lock;
-   TMP_FILE=`mktemp /var/ossec/ossec-hosts.XXXXXXXXXX`
+   TMP_FILE=`mktemp ${PWD}/ossec-hosts.XXXXXXXXXX`
    if [ "X${TMP_FILE}" = "X" ]; then
      # Cheap fake tmpfile, but should be harder then no random data
-     TMP_FILE="/var/ossec/ossec-hosts.`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -1 `"
+     TMP_FILE="${PWD}/ossec-hosts.`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -1 `"
    fi
    echo "${IP}" | grep "\:" > /dev/null 2>&1
    if [ $? = 0 ]; then


### PR DESCRIPTION
From @mobstef in issue #1477:
```
I am the OSSEC FreeBSD port maintainer.
For a long time there is a bug in "active-response/host-deny.sh" where OSSEC installation directory is hardcoded to "/var/ossec". I have replaced it with "${PWD}" as seen in other active response scripts. Note however, that this will default to "/var/ossec/active-response" instead.
```

A patch was included, but I made the changes by hand.