### PR TITLE
Add FreeBSD's php.ini location to rootcheck db

### DIFF
--- a/src/rootcheck/db/system_audit_rcl.txt
+++ b/src/rootcheck/db/system_audit_rcl.txt
@@ -25,7 +25,7 @@
 # Multiple patterns can be specified by using " && " between them.
 # (All of them must match for it to return true).
 
-$php.ini=/etc/php.ini,/var/www/conf/php.ini,/etc/php5/apache2/php.ini;
+$php.ini=/etc/php.ini,/var/www/conf/php.ini,/etc/php5/apache2/php.ini,/usr/local/etc/php.ini;
 $web_dirs=/var/www,/var/htdocs,/home/httpd,/usr/local/apache,/usr/local/apache2,/usr/local/www;
 
 # PHP checks


### PR DESCRIPTION
From @mobstef in issue #1478:
```
I am the OSSEC FreeBSD port maintainer.
I have noticed missing path for "/usr/local/etc/php.ini" in "src/rootcheck/db/system_audit_rcl.txt".
Please add it.
```
Patch included, and applied