### PR TITLE
Hard coded user/group changed to appropriate variables

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -434,7 +434,7 @@ endif
 endif
 
 	install -d -m 0770 -o root -g ${OSSEC_GROUP} ${PREFIX}/etc/shared
-	install -m 0640 -o ossec -g ${OSSEC_GROUP} rootcheck/db/*.txt ${PREFIX}/etc/shared/
+	install -m 0640 -o ${OSSEC_USER} -g ${OSSEC_GROUP} rootcheck/db/*.txt ${PREFIX}/etc/shared/
 
 	install -d -m 0550 -o root -g ${OSSEC_GROUP} ${PREFIX}/active-response
 	install -d -m 0550 -o root -g ${OSSEC_GROUP} ${PREFIX}/active-response/bin

--- a/src/init/adduser.sh
+++ b/src/init/adduser.sh
@@ -69,7 +69,7 @@ else
     fi
 
     if [ -x /usr/bin/getent ]; then
-        if [ `getent group ossec | wc -l` -lt 1 ]; then
+        if [ `getent group "${GROUP}" | wc -l` -lt 1 ]; then
             ${GROUPADD} "${GROUP}"
         fi
     elif ! grep "^${GROUP}" /etc/group > /dev/null 2>&1; then


### PR DESCRIPTION
From @mobstef in issue #1476:
```
In 3.0.0 two new bugs appeared:

hardcoded "ossec" group in "src/init/adduser.sh"
hardcoded "ossec" user in "src/Makefile"
```
Patches submitted and applied