### PR TITLE
Fix an issue in the nodiff option which could ignore files it isn't supposed to

### DIFF
--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -48,7 +48,7 @@ int is_nodiff(const char *filename){
         int i;
         for (i = 0; syscheck.nodiff[i] != NULL; i++){
             if (strncasecmp(syscheck.nodiff[i], filename,
-                            strlen(filename)) == 0) {
+                            strlen(syscheck.nodiff[i])) == 0) {
                 return (TRUE);
             }
         }


### PR DESCRIPTION
The nodiff check uses strncasecmp to compare filename to syscheck.nodiff[i].

strncasecmp requires a length, which it previously used the length of the
filename. If /etc/file123 is in a nodiff, /etc/file won't be checked because
the first 9 chars are the same. If we used the length of /etc/file123 instead
/etc/file should be checked because the comparison fails.
From bah07 in Wazuh pull request #1046:
https://github.com/wazuh/wazuh/pull/1046