### PR TITLE
Make sure there's room for the full alert id in json alerts

### DIFF
--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -32,11 +32,11 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
 
     if ( lf->time ) {
 
-        char alert_id[19];
+        char alert_id[23];
         double timestamp_ms;
         timestamp_ms = ((double)lf->time)*1000;
-        alert_id[18] = '\0';
-        if((snprintf(alert_id, 18, "%ld.%ld", (long int)lf->time, __crt_ftell)) < 0) {
+        alert_id[22] = '\0';
+        if((snprintf(alert_id, 22, "%ld.%ld", (long int)lf->time, __crt_ftell)) < 0) {
             merror("snprintf failed");
         }
 


### PR DESCRIPTION
From gandalfn in wazuh pull request #1052:
```
> When writing rule id in json alerts file, the id is truncated and can be non unique, on intensive alerts generation.
> This is due snprintf buffer size which is too small to store id. Indeed id is composed of two long int (timestamp and log offset) then the size can be to 21 characters (10 digits for both timestamp and offset + the dot)
> The fix set id buffer to the correct size, and snprintf max size.

https://github.com/wazuh/wazuh/pull/1052

I'm not positive this affects us, but it probably doesn't hurt.