### PR TITLE
Modify status() to not return 1 when maild is not running

### DIFF
--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -157,6 +157,14 @@ status()
 {
     RETVAL=0
     for i in ${DAEMONS}; do
+        ## If ossec-maild is disabled, don't try to start it.
+        if [ X"$i" = "Xossec-maild" ]; then
+            grep "<email_notification>no<" ${DIR}/etc/ossec.conf >/dev/null 2>&1
+            if [ $? = 0 ]; then
+                continue
+            fi
+        fi
+
         pstatus ${i};
         if [ $? = 0 ]; then
             echo "${i} not running..."


### PR DESCRIPTION
because it's configured to not run. Copied from start().
From issue #1499 reported by @jsilverman-blispay