### PR TITLE
Fix and clean up output for Slack integration

### DIFF
--- a/active-response/ossec-slack.sh
+++ b/active-response/ossec-slack.sh
@@ -26,11 +26,14 @@ echo "`date` $0 $1 $2 $3 $4 $5 $6 $7 $8" >> ${PWD}/../logs/active-responses.log
 ALERTTITLE=`grep -A 1 "$ALERTID" ${PWD}/../logs/alerts/alerts.log | tail -1`
 ALERTTEXT=`grep -A 10 "$ALERTID" ${PWD}/../logs/alerts/alerts.log | grep -v "Src IP: " | grep -v "User: " | grep "Rule: " -A 4 | sed '/^$/Q' | cut -c -139 | sed 's/\"//g'`
 
-LEVEL=`echo ${ALERTTEXT} | grep "(level [0-9]*)" | sed 's/^.*(level \([0-9]*\)).*$/\1/'`
+LEVEL=`echo "${ALERTTEXT}" | head -1 | grep "(level [0-9]*)" | sed 's/^.*(level \([0-9]*\)).*$/\1/'`
 COLOR="#D3D3D3"
-[ "${LEVEL}" -ge 4 ] && COLOR="#FFCC00"
-[ "${LEVEL}" -ge 7 ] && COLOR="#FF9966"
-[ "${LEVEL}" -ge 12 ] && COLOR="#CC3300"
+if [ "${LEVEL}" ]
+then
+  [ "${LEVEL}" -ge 4 ] && COLOR="#FFCC00"
+  [ "${LEVEL}" -ge 7 ] && COLOR="#FF9966"
+  [ "${LEVEL}" -ge 12 ] && COLOR="#CC3300"
+fi
 
 PAYLOAD='{"channel": "'"$CHANNEL"'", "username": "'"$SLACKUSER"'", "attachments": [ {"fallback": "'"$( printf "${ALERTTITLE}\n${ALERTTEXT}" )"'", "title": "'"${ALERTTITLE}"'", "text": "'"${ALERTTEXT}"'", "color": "'"${COLOR}"'"} ]}'
 

--- a/active-response/ossec-slack.sh
+++ b/active-response/ossec-slack.sh
@@ -17,15 +17,13 @@ fi
 ALERTID=$4
 RULEID=$5
 LOCAL=`dirname $0`;
-ALERTTIME=`echo "$ALERTID" | cut -d  "." -f 1`
-ALERTLAST=`echo "$ALERTID" | cut -d  "." -f 2`
 
 # Logging
 cd $LOCAL
 cd ../
 PWD=`pwd`
-echo "`date` $0 $1 $2 $3 $4 $5 $6 $7 $8" >> ${PWD}/../../logs/active-responses.log
-ALERTFULL=`grep -A 10 "$ALERTTIME" ${PWD}/../../logs/alerts/alerts.log | grep -v "\.$ALERTLAST: " -A 10 | grep -v "Src IP: " | grep -v "User: " |grep "Rule: " -A 4 | cut -c -139 | sed 's/\"//g'`
+echo "`date` $0 $1 $2 $3 $4 $5 $6 $7 $8" >> ${PWD}/../logs/active-responses.log
+ALERTFULL=`grep -A 10 "$ALERTID" ${PWD}/../logs/alerts/alerts.log | grep -v "Src IP: " | grep -v "User: " | grep "Rule: " -A 4 -B 1 | sed '/^$/Q' | cut -c -139 | sed 's/\"//g' | sed '1 s/\(.*\)/*\1*/'`
 
 PAYLOAD='{"channel": "'"$CHANNEL"'", "username": "'"$SLACKUSER"'", "text": "'"${ALERTFULL}"'"}'
 
@@ -33,13 +31,13 @@ ls "`which curl`" > /dev/null 2>&1
 if [ ! $? = 0 ]; then
     ls "`which wget`" > /dev/null 2>&1
     if [ $? = 0 ]; then
-        wget --keep-session-cookies --post-data="${PAYLOAD}" ${SITE} 2>>${PWD}/../../logs/active-responses.log
+        wget --keep-session-cookies --post-data="${PAYLOAD}" ${SITE} 2>>${PWD}/../logs/active-responses.log
         exit 0;
     fi
 else
-    curl -s -X POST --data-urlencode "payload=${PAYLOAD}" ${SITE} 2>>${PWD}/../../logs/active-responses.log
+    curl -s -X POST --data-urlencode "payload=${PAYLOAD}" ${SITE} 2>>${PWD}/../logs/active-responses.log
     exit 0;
 fi
 
-echo "`date` $0: Unable to find curl or wget." >> ${PWD}/../../logs/active-responses.log
+echo "`date` $0: Unable to find curl or wget." >> ${PWD}/../logs/active-responses.log
 exit 1;

--- a/active-response/ossec-slack.sh
+++ b/active-response/ossec-slack.sh
@@ -23,9 +23,16 @@ cd $LOCAL
 cd ../
 PWD=`pwd`
 echo "`date` $0 $1 $2 $3 $4 $5 $6 $7 $8" >> ${PWD}/../logs/active-responses.log
-ALERTFULL=`grep -A 10 "$ALERTID" ${PWD}/../logs/alerts/alerts.log | grep -v "Src IP: " | grep -v "User: " | grep "Rule: " -A 4 -B 1 | sed '/^$/Q' | cut -c -139 | sed 's/\"//g' | sed '1 s/\(.*\)/*\1*/'`
+ALERTTITLE=`grep -A 1 "$ALERTID" ${PWD}/../logs/alerts/alerts.log | tail -1`
+ALERTTEXT=`grep -A 10 "$ALERTID" ${PWD}/../logs/alerts/alerts.log | grep -v "Src IP: " | grep -v "User: " | grep "Rule: " -A 4 | sed '/^$/Q' | cut -c -139 | sed 's/\"//g'`
 
-PAYLOAD='{"channel": "'"$CHANNEL"'", "username": "'"$SLACKUSER"'", "text": "'"${ALERTFULL}"'"}'
+LEVEL=`echo ${ALERTTEXT} | grep "(level [0-9]*)" | sed 's/^.*(level \([0-9]*\)).*$/\1/'`
+COLOR="#D3D3D3"
+[ "${LEVEL}" -ge 4 ] && COLOR="#FFCC00"
+[ "${LEVEL}" -ge 7 ] && COLOR="#FF9966"
+[ "${LEVEL}" -ge 12 ] && COLOR="#CC3300"
+
+PAYLOAD='{"channel": "'"$CHANNEL"'", "username": "'"$SLACKUSER"'", "attachments": [ {"fallback": "'"$( printf "${ALERTTITLE}\n${ALERTTEXT}" )"'", "title": "'"${ALERTTITLE}"'", "text": "'"${ALERTTEXT}"'", "color": "'"${COLOR}"'"} ]}'
 
 ls "`which curl`" > /dev/null 2>&1
 if [ ! $? = 0 ]; then


### PR DESCRIPTION
This reverts https://github.com/ossec/ossec-hids/pull/1422 which seemed to break the integration (at least in 3.0.0).

This also uses the full `$ALERTID` to find the alert as otherwise it may find the wrong alert in the log.

This also cleans up the output to make it more readable in Slack, including adding colours for alert level ranges.

![ossec-slack](https://user-images.githubusercontent.com/15616768/44846345-fbaeea00-ac47-11e8-9cb4-494527baf5d7.png)
