### PR TITLE
psad signature match level 6

### DIFF
--- a/etc/rules/psad_rules.xml
+++ b/etc/rules/psad_rules.xml
@@ -43,7 +43,7 @@
     <description>many PSAD level 3 warnings from same source (slow scan)</description>
   </rule>
   <!-- PSAD Signature Match -->
- <rule id="110226" level="10">
+ <rule id="110226" level="6">
     <if_sid>110201</if_sid>
     <match>signature match: </match>
     <description>PSAD signature match</description>


### PR DESCRIPTION
psad signatures has DL: 2 https://github.com/mrash/psad/blob/master/signatures
set level="6" to avoid constant ossec alerts