### PR TITLE
Remove the subject selection options. 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,6 @@ else
 endif
 
 ONEWAY?=no
-CLEANFULL?=no
 
 export MYLDFLAGS= "${LDFLAGS}"
 export MYCFLAGS= "${CFLAGS}"
@@ -132,10 +131,6 @@ ifdef DEBUG
 else
 	OSSEC_CFLAGS+=-O2
 endif #DEBUG
-
-ifneq (,$(filter ${CLEANFULL},yes y Y 1))
-	DEFINES+=-DCLEANFULL
-endif
 
 ifneq (,$(filter ${ONEWAY},yes y Y 1))
 	DEFINES+=-DONEWAY_ENABLED
@@ -552,7 +547,6 @@ settings:
 	@echo "    REUSE_ID:         ${REUSE_ID}"
 	@echo "    DATABASE:         ${DATABASE}"
 	@echo "    ONEWAY:           ${ONEWAY}"
-	@echo "    CLEANFULL:        ${CLEANFULL}"
 	@echo "User settings:"
 	@echo "    OSSEC_GROUP:      ${OSSEC_GROUP}"
 	@echo "    OSSEC_USER:       ${OSSEC_USER}"

--- a/src/os_maild/maild.h
+++ b/src/os_maild/maild.h
@@ -22,13 +22,8 @@
 #define BODY_SIZE           OS_MAXSTR + OS_SIZE_1024
 
 #define SMS_SUBJECT         "OSSEC %d - %d - %s"
-#define MAIL_SUBJECT        "OSSEC Notification - %s - Alert level %d"
-#define MAIL_SUBJECT_FULL   "OSSEC Alert - %s - Level %d - %s"
-
 /* Full subject without ossec in the name */
-#ifdef CLEANFULL
 #define MAIL_SUBJECT_FULL2   "%d - %s - %s"
-#endif
 
 #ifdef LIBGEOIP_ENABLED
 #define MAIL_BODY           "\r\nOSSEC HIDS Notification.\r\n" \

--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -134,26 +134,11 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p,
         *subject_host = '\0';
     }
 
-    /* We have two subject options - full and normal */
-    if (Mail->subject_full == 0) {
-        /* Option for a clean full subject (without ossec in the name) */
-#ifdef CLEANFULL
-        snprintf(mail->subject, SUBJECT_SIZE - 1, MAIL_SUBJECT_FULL2,
-                 al_data->level,
-                 al_data->comment,
-                 al_data->location);
-#else
-        snprintf(mail->subject, SUBJECT_SIZE - 1, MAIL_SUBJECT_FULL,
-                 al_data->location,
-                 al_data->level,
-                 al_data->comment);
-#endif
-    } else {
-        snprintf(mail->subject, SUBJECT_SIZE - 1, MAIL_SUBJECT,
-                 al_data->location,
-                 al_data->level);
-    }
-
+    /* Option for a clean full subject (without ossec in the name) */
+    snprintf(mail->subject, SUBJECT_SIZE - 1, MAIL_SUBJECT_FULL2,
+            al_data->level,
+            al_data->comment,
+            al_data->location);
 
     /* Fix subject back */
     if (subject_host) {


### PR DESCRIPTION
It feels like it should be simple, but no one can agree on if it's working or not. 
So let's just get rid of it. I chose the short subject option as the default.
I left in the `internal_options.conf` stuff, because removing it might just break installations.
If I get around to it, I'll test that out and see what happens.

References: Issue #1370, Pull Request: #1377 