### PR TITLE
Corrected Check

### DIFF
--- a/src/rootcheck/db/cis_win2012r2_domainL2_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_domainL2_rcl.txt
@@ -187,8 +187,10 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnabl
 #
 #18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
 [CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting -> DoReport -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting -> !DoReport;
 #
 #
 #18.8.24.1 Ensure 'Disallow copying of user input methods to the system account for sign-in' is set to 'Enabled'

--- a/src/rootcheck/db/cis_win2012r2_memberL2_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_memberL2_rcl.txt
@@ -210,8 +210,10 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnabl
 #
 #18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
 [CIS - Microsoft Windows Server 2012 R2 - 18.8.20.1.14: Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting -> DoReport -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting -> !DoReport;
 #
 #
  -> !1;

--- a/src/rootcheck/db/cis_win2016_domainL2_rcl.txt
+++ b/src/rootcheck/db/cis_win2016_domainL2_rcl.txt
@@ -193,8 +193,10 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnabl
 #
 #18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
 [CIS - Microsoft Windows Server 2016 - 18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/515]
-r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting -> DoReport -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting -> !DoReport;
 #
 #
 #18.8.23.1 Ensure 'Support device authentication using certificate' is set to 'Enabled: Automatic'

--- a/src/rootcheck/db/cis_win2016_memberL2_rcl.txt
+++ b/src/rootcheck/db/cis_win2016_memberL2_rcl.txt
@@ -206,8 +206,10 @@ r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\SQMClient\Windows -> !CEIPEnabl
 #
 #18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'
 [CIS - Microsoft Windows Server 2016 - 18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'] [any] [https://workbench.cisecurity.org/benchmarks/515]
-r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> Disabled -> !0;
 r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting -> !Disabled;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting -> DoReport -> !1;
+r:HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting -> !DoReport;
 #
 #
 #18.8.23.1 Ensure 'Support device authentication using certificate' is set to 'Enabled: Automatic'


### PR DESCRIPTION
Corrected Check (18.8.20.1.14 Ensure 'Turn off Windows Error Reporting' is set to 'Enabled').
I corrected the testing for a wrong value. A second registry-key has to be checked. It is now added.