### PR TITLE
install.sh - case for s-nail patch can't be applied if `mail` is not installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -230,7 +230,7 @@ UseRootcheck()
         echo "    <system_audit>$INSTALLDIR/etc/shared/cis_rhel5_linux_rcl.txt</system_audit>" >> $NEWCONFIG
         echo "  </rootcheck>" >> $NEWCONFIG
 	# Patch for systems that use s-nail instead of GNU Mailutils (such as Arch Linux).
-	if strings /usr/bin/mail | grep "x-shsh bash" 1> /dev/null; then
+	if [ -r /usr/bin/mail ] && strings /usr/bin/mail | grep "x-shsh bash" 1> /dev/null; then
 	  sed -i 's/mail        !bash|/mail        !/' ./src/rootcheck/db/rootkit_trojans.txt
 	fi
     else


### PR DESCRIPTION
See https://github.com/ossec/ossec-hids/issues/1525#issue-360203486 for more information.