### PR TITLE
Syscheck support for realtime new files / directory detection

### DIFF
--- a/etc/rules/ossec_rules.xml
+++ b/etc/rules/ossec_rules.xml
@@ -197,7 +197,7 @@
     <group>syscheck,</group>
   </rule>
   
-  <rule id="554" level="0">
+  <rule id="554" level="5">
     <category>ossec</category>
     <decoded_as>syscheck_new_entry</decoded_as>
     <description>File added to the system.</description>

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -588,7 +588,9 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
     fflush(fp);
 
     /* Alert if configured to notify on new files */
-    if ((Config.syscheck_alert_new == 1) && (DB_IsCompleted(agent_id))) {
+    /* TODO: debugging this - Scott */
+    /* if ((Config.syscheck_alert_new == 1) && (DB_IsCompleted(agent_id))) { */
+    if (Config.syscheck_alert_new == 1)  {
         sdb.syscheck_dec->id = sdb.idn;
 
         /* New file message */

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -19,7 +19,6 @@
 
 /* Prototypes */
 static int read_file(const char *dir_name, int opts, OSMatch *restriction)  __attribute__((nonnull(1)));
-static int read_dir(const char *dir_name, int opts, OSMatch *restriction) __attribute__((nonnull(1)));
 
 /* Global variables */
 static int __counter = 0;
@@ -299,7 +298,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
     return (0);
 }
 
-static int read_dir(const char *dir_name, int opts, OSMatch *restriction)
+int read_dir(const char *dir_name, int opts, OSMatch *restriction)
 {
     size_t dir_size;
     char f_name[PATH_MAX + 2];

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -135,6 +135,15 @@ void start_daemon()
     if (syscheck.scan_on_start) {
         sleep(syscheck.tsleep * 15);
         send_sk_db();
+
+#ifdef WIN32
+        /* Check for registry changes on Windows */
+        os_winreg_check();
+#endif
+        /* Send database completed message */
+        send_syscheck_msg(HC_SK_DB_COMPLETED);
+        debug2("%s: DEBUG: Sending database completed message.", ARGV0);
+
     } else {
         prev_time_rk = time(0);
     }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -82,7 +82,33 @@ int realtime_checksumfile(const char *file_name)
             return (1);
         }
         return (0);
+    } else {
+        /* New file */
+        char *c;
+        int i;
+        buf = strdup(file_name);
+
+        /* Find container directory */
+
+        while (c = strrchr(buf, '/'), c && c != buf) {
+            *c = '\0';
+
+            for (i = 0; syscheck.dir[i]; i++) {
+                if (strcmp(syscheck.dir[i], buf) == 0) {
+                    debug1("%s: DEBUG: Scanning new file '%s' with options for directory '%s'.", ARGV0, file_name, buf);
+                    read_dir(file_name, syscheck.opts[i], syscheck.filerestrict[i]);
+                    break;
+                }
+            }
+
+            if (syscheck.dir[i]) {
+                break;
+            }
+        }
+
+        free(buf);
     }
+
     return (0);
 }
 

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -36,6 +36,10 @@ int create_db(void);
 /* Check database for changes */
 int run_dbcheck(void);
 
+/* Scan directory */
+int read_dir(const char *dir_name, int opts, OSMatch *restriction);
+
+
 /* Check the registry for changes */
 void os_winreg_check(void);
 


### PR DESCRIPTION
This requires the following to be set in <syscheck>

        <alert_new_files>yes</alert_new_files>
        <scan_on_start>yes</scan_on_start>

and for a filesystem:
    <directories check_all="yes" realtime="yes" report_changes="yes">/etc</directories>

Note: report_changes is optional, but also super cool.