### PR TITLE
Adjust the tests for sysmon rules

### DIFF
--- a/contrib/ossec-testing/tests/sysmon.ini
+++ b/contrib/ossec-testing/tests/sysmon.ini
@@ -1,12 +1,12 @@
 [Sysmon EventID#1 - Suspicious svchost process]
 log 1 pass = 2014 Dec 20 14:29:48 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 2:29 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\Windows\system32\NOTEPAD.EXE" C:\Users\Administrator\Desktop\ossec.log  User: WIN-U93G48C7BOP\Administrator  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\Explorer.EXE  ParentCommandLine: C:\Windows\Explorer.EXE
-rule = 184666
+rule = 18501
 alert = 12
 decoder = Sysmon-EventID#1
 
 [Sysmon EventID#1 - non-Suspicious svchost process]
 log 1 pass = 2014 Dec 20 12:15:13 (HME-TEST-01) 10.0.15.14->WinEvtLog 2014 Dec 20 09:29:47 WinEvtLog: Microsoft-Windows-Sysmon/Operational: INFORMATION(1): Microsoft-Windows-Sysmon: SYSTEM: NT AUTHORITY: WIN-U93G48C7BOP: Process Create:  UtcTime: 12/20/2014 12:15 PM  ProcessGuid: {00000000-87DB-5495-0000-001045F25A00}  ProcessId: 3048  Image: C:\Windows\system32\svchost.exe  CommandLine: "C:\windows\system32\svchost.exe -k defragsvc"  User: NT AUTHORITY\SYSTEM  LogonGuid: {00000000-84B8-5494-0000-0020CB330200}  LogonId: 0x233CB  TerminalSessionId: 1  IntegrityLevel: High  HashType: SHA1  Hash: 9FEF303BEDF8430403915951564E0D9888F6F365  ParentProcessGuid: {00000000-84B9-5494-0000-0010BE4A0200}  ParentProcessId: 848  ParentImage: C:\Windows\System32\services.exe  ParentCommandLine: C:\Windows\System32\services.exe
-rule = 184667
+rule = 18502
 alert = 0
 decoder = Sysmon-EventID#1
 


### PR DESCRIPTION
Rule IDs have changed since the previous ones were 100000+.
The tests need updating to take advantage of the new IDs.
See PR #1547 