### PR TITLE
Remove unnecessary echo for duplicated entry

### DIFF
--- a/active-response/host-deny.sh
+++ b/active-response/host-deny.sh
@@ -89,7 +89,6 @@ fi
 IPKEY=$(grep -w "${IP}" /etc/hosts.deny)
 if [ ! -z "$IPKEY" ]
 then
-    echo "`date` Duplicate ip/hostname entry: ${IP}" >> ${PWD}/../logs/active-responses.log
 	IPKEY="1"
 else
 	IPKEY="0"


### PR DESCRIPTION
This logging for duplicated entries is already covered by an echo some lines below for the "add" case:

https://github.com/ossec/ossec-hids/blob/0125b4fa54e28eb382fba5970f862cb694a60d39/active-response/host-deny.sh#L109

Keeping this echo will cause a log entry for the "delete" case which is completely unnecessary because it is clear that an entry already exists in the hosts.deny.