### PR TITLE
Remove unnecessary echo for duplicated entry

### DIFF
--- a/active-response/host-deny.sh
+++ b/active-response/host-deny.sh
@@ -83,23 +83,23 @@ if [ "x${IP}" = "x" ]; then
    echo "$0: Missing argument <action> <user> (ip)"
    exit 1;
 fi
-#
-#       Looking for duplication
-#
-IPKEY=$(grep -w "${IP}" /etc/hosts.deny)
-if [ ! -z "$IPKEY" ]
-then
-    echo "`date` Duplicate ip/hostname entry: ${IP}" >> ${PWD}/../logs/active-responses.log
-	IPKEY="1"
-else
-	IPKEY="0"
-fi
+
 
 # Checking for invalid entries (lacking "." or ":", etc)
 echo "${IP}" | egrep "\.|\:" > /dev/null 2>&1
 if [ ! $? = 0 ]; then
     echo "`date` Invalid ip/hostname entry: ${IP}" >> ${PWD}/../logs/active-responses.log
     exit 1;
+fi
+
+
+# Looking for duplication
+IPKEY=$(grep -w "${IP}" /etc/hosts.deny)
+if [ ! -z "$IPKEY" ]
+then
+    IPKEY="1"
+else
+    IPKEY="0"
 fi
 
 


### PR DESCRIPTION
This logging for duplicated entries is already covered by an echo some lines below for the "add" case:

https://github.com/ossec/ossec-hids/blob/0125b4fa54e28eb382fba5970f862cb694a60d39/active-response/host-deny.sh#L109

Keeping this echo will cause a log entry for the "delete" case which is completely unnecessary because it is clear that an entry already exists in the hosts.deny.

Also moved the check for duplicated entries after the IP syntax verification as we only need to check for duplicated entries if we have verified that we really got an IP.

Furthermore replaced the tabs with spaces and stripped down the comment.