### PR TITLE
host-deny.sh: Move duplicate entry check into the add action

### DIFF
--- a/active-response/host-deny.sh
+++ b/active-response/host-deny.sh
@@ -93,19 +93,11 @@ if [ ! $? = 0 ]; then
 fi
 
 
-# Looking for duplication
-IPKEY=$(grep -w "${IP}" /etc/hosts.deny)
-if [ ! -z "$IPKEY" ]
-then
-    IPKEY="1"
-else
-    IPKEY="0"
-fi
-
-
 # Adding the ip to hosts.deny
 if [ "x${ACTION}" = "xadd" ]; then
-    if [ "$IPKEY" -eq "1" ]; then
+    # Looking for duplication
+    IPKEY=$(grep -w "${IP}" /etc/hosts.deny)
+    if [ ! -z "$IPKEY" ]; then
         echo "IP ${IP} already exists on host.deny..." >> ${PWD}/../logs/active-responses.log
         exit 1
     fi


### PR DESCRIPTION
Last change from my side to this file for now:

Moving the duplicate entry check into the "add" action (the only place where the result of IPKEY was used) to avoid some grep calls for the "delete" action.

If it is really desired to also report duplicated entries within the "delete" action a separate grep for entries > 1 should be implemented in a separate PR.