### PR TITLE
Fix bashism in firewall-drop.sh

### DIFF
--- a/active-response/firewall-drop.sh
+++ b/active-response/firewall-drop.sh
@@ -192,7 +192,7 @@ if [ "X${UNAME}" = "XLinux" ]; then
                 IPV6KEY="0"
         fi
                 
-        if [ "$IPV4KEY" == "0" ] && [ "$IPV6KEY" == "0" ]
+        if [ "$IPV4KEY" = "0" ] && [ "$IPV6KEY" = "0" ]
         then
                 break
         fi


### PR DESCRIPTION
The PR in #1099 introduced a bash-ism in `firewall-drop.sh` which causes that command's use in active-response to fail to execute on systems where `/bin/sh` is not bash (e.g Debian, where it's a symlink to /bin/dash).

Bash understands `==` in a conditional, but not sh or dash. The error seen is:

```
wolverine:/var/ossec/bin# /var/ossec/active-response/bin/firewall-drop.sh add - 134.255.234.77 1542085014.1196524 31151
/var/ossec/active-response/bin/firewall-drop.sh: 195: [: 0: unexpected operator
```

This PR changes it to `=` which is understood by both bash and dash.