### PR TITLE
Added rules/decoder for mhn

### DIFF
--- a/doc/rule_ids.txt
+++ b/doc/rule_ids.txt
@@ -95,8 +95,9 @@
 53700 - 53749 PSAD rules
 53750 - 53799 unbound rules
 53800 - 53825 Kaspersky Endpoint Security 10 for Linux rules
-56000 - 56200 FreeBSD rules
 53826 - 53829 MHN - Dionaea
 53830 - 53840 MHN - Cowrie
+56000 - 56200 FreeBSD rules
+
 100000 - 109999 User defined rules
 

--- a/doc/rule_ids.txt
+++ b/doc/rule_ids.txt
@@ -96,6 +96,7 @@
 53750 - 53799 unbound rules
 53800 - 53825 Kaspersky Endpoint Security 10 for Linux rules
 56000 - 56200 FreeBSD rules
-
+53826 - 53829 MHN - Dionaea
+53830 - 53840 MHN - Cowrie
 100000 - 109999 User defined rules
 

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -3320,4 +3320,44 @@ s=2 SFwdQ=0 SDupQ=0 SErr=0 RQ=2 RIQ=0 RFwdQ=0 RDupQ=0 RTCP=0 SFwdR=0 SFail=0 SFE
   <order>action, id, extra_data, status, srcuser</order>
 </decoder>
 
+<!-- MHN - Json log decoder - Dionaea -->
+<!-- include /var/log/mhn/mhn-json.log to ossec.conf -->
+<!-- {"direction": "inbound", "protocol": "ip", "ids_type": "network", "timestamp": "2018-09-14T11:02:54.215411", "dionaea_action": "reject", "type": "dionaea.connections", "app": "dionaea", "src_ip": "16.10.10.10", "vendor_product": "Dionaea", "dest_port": 365, "signature": "Connection to Honeypot", "src_port": 45302, "dest_ip": "16.10.10.11", "sensor": "5e7031cf-b74d-22f9-57e0-254166752457", "transport": "tcp", "severity": "high"} -->
+<decoder name="dionaea">
+  <prematch>dionaea.connections</prematch>
+  <regex>^\p\pdirection\p: \p(\S+)\p, \pprotocol\p: \p(\S+)\p, \pids_type\p: \p\S+\p, \ptimestamp\p: \p\d\d\d\d-\d\d-\d\d\w\d\d:\d\d:\d\d\.\d+\p, \pdionaea_action\p: \p(\S+)\p, \ptype\p: \pdionaea.connections\p, \papp\p: \pdionaea\p, \psrc_ip\p: \p(\d+.\d+.\d+.\d+)\p, \pvendor_product\p: \pDionaea\p, \pdest_port\p: (\d+), \psignature\p: \p\.+\p, \psrc_port\p: (\d+), \pdest_ip\p: \p(\d+.\d+.\d+.\d+)\p, \psensor\p: \S+, \ptransport\p: \p\S+\p, \pseverity\p: \p\S+\p\p</regex>
+  <order>extra_data, protocol, action, srcip, dstport, srcport, dstip</order>
+</decoder>
+
+<!-- MHN - Json log decoder - Cowrie -->
+<!-- include /var/log/mhn/mhn-json.log to ossec.conf -->
+<!-- {"direction": "inbound", "protocol": "ip", "ids_type": "network", "ssh_username": "admin", "app": "cowrie", "transport": "tcp", "dest_port": 22, "src_port": 45302, "severity": "high", "timestamp": "2018-10-23T11:22:36.597864", "vendor_product": "Cowrie", "sensor": "5e7031cf-b74d-22f9-57e0-254166752457", "src_ip": "16.10.10.10", "ssh_password": "password", "signature": "SSH login attempted on cowrie honeypot", "ssh_version": "'SSH-2.0-Sun_SSH_1.1.4'", "type": "cowrie.sessions", "dest_ip": "16.10.10.11"} -->
+<!-- {"direction": "inbound", "protocol": "ip", "ids_type": "network", "timestamp": "2018-10-23T07:45:56.937787", "vendor_product": "Cowrie", "type": "cowrie.sessions", "app": "cowrie", "src_ip": "16.10.10.10", "dest_port": 22, "signature": "SSH session on cowrie honeypot", "ssh_version": "'SSH-2.0-Sun_SSH_1.1.4'", "src_port": 45302, "dest_ip": "16.10.10.11", "sensor": "5e7031cf-b74d-22f9-57e0-254166752457", "transport": "tcp", "severity": "high"} -->
+<!-- {"direction": "inbound", "protocol": "ip", "ids_type": "network", "timestamp": "2018-11-14T10:32:38.686578", "app": "cowrie", "transport": "tcp", "dest_port": 22, "src_port": 45302, "severity": "high", "vendor_product": "Cowrie", "sensor": "5e7031cf-b74d-22f9-57e0-254166752457", "src_ip": "16.10.10.10", "command": "whoami", "signature": "command attempted on cowrie honeypot", "ssh_version": "'SSH-2.0-OpenSSH_7.4p1 Debian-10+deb9u4'", "type": "cowrie.sessions", "dest_ip": "16.10.10.11"} -->
+
+<decoder name="cowrie">
+  <prematch>cowrie.sessions</prematch>
+</decoder>
+
+<decoder name="cowrie-attempt">
+  <parent>cowrie</parent>
+  <prematch>"SSH login attempted</prematch>
+  <regex>^\p\pdirection\p: \p\S+\p, \pprotocol\p: \p(\S+)\p, \pids_type\p: \p(\S+)\p, \pssh_username\p: \p(\S+)\p, \papp\p: \pcowrie\p, \ptransport\p: \p\S+\p, \pdest_port\p: (\d+), \psrc_port\p: (\d+), \pseverity\p: \p\S+\p, \ptimestamp\p: \p\d\d\d\d-\d\d-\d\d\w\d\d:\d\d:\d\d.\d+\p, \pvendor_product\p: \pCowrie\p, \psensor\p: \S+, \psrc_ip\p: \p(\d+.\d+.\d+.\d+)\p, \pssh_password\p: \p\S+\p, \psignature\p: \p(\.+)\p, \pssh_version\p: \.+, \ptype\p: \pcowrie.sessions\p, \pdest_ip\p: \p(\d+.\d+.\d+.\d+)\p\p</regex>
+  <order>protocol, extra_data, user, dstport, srcport, srcip, action, dstip</order>
+</decoder>
+
+<decoder name="cowrie-session">
+  <parent>cowrie</parent>
+  <prematch>"SSH session on cowrie honeypot</prematch>
+  <regex>^\p\pdirection\p: \p\S+\p, \pprotocol\p: \p(\S+)\p, \pids_type\p: \p(\S+)\p, \ptimestamp\p: \p\d\d\d\d-\d\d-\d\d\w\d\d:\d\d:\d\d.\d+\p, \pvendor_product\p: \pCowrie\p, \ptype\p: \pcowrie.sessions\p, \papp\p: \pcowrie\p, \psrc_ip\p: \p(\d+.\d+.\d+.\d+)\p, \pdest_port\p: (\d+), \psignature\p: \p(\.+)\p, \pssh_version\p: \.+, \psrc_port\p: (\d+), \pdest_ip\p: \p(\d+.\d+.\d+.\d+)\p, \psensor\p: \S+, \ptransport\p: \p\S+\p, \pseverity\p: \p\S+\p\p</regex>
+  <order>protocol, extra_data, srcip, dstport, action, srcport, dstip</order>
+</decoder>
+
+<decoder name="cowrie-command">
+  <parent>cowrie</parent>
+  <prematch>"command attempted on cowrie honeypot</prematch>
+  <regex>^\p\pdirection\p: \p\S+\p, \pprotocol\p: \p(\S+)\p, \pids_type\p: \p(\S+)\p, \ptimestamp\p: \p\d\d\d\d-\d\d-\d\d\w\d\d:\d\d:\d\d.\d+\p, \papp\p: \pcowrie\p, \ptransport\p: \p\S+\p, \pdest_port\p: (\d+), \psrc_port\p: (\d+), \pseverity\p: \p\S+\p, \pvendor_product\p: \pCowrie\p, \psensor\p: \S+, \psrc_ip\p: \p(\d+.\d+.\d+.\d+)\p, \pcommand\p: \p\S+\p, \psignature\p: \p(\.+)\p, \pssh_version\p: \.+, \ptype\p: \pcowrie.sessions\p, \pdest_ip\p: \p(\d+.\d+.\d+.\d+)\p\p</regex>
+  <order>protocol, extra_data, dstport, srcport, srcip, action, dstip</order>
+</decoder>
+
 <!-- EOF -->

--- a/etc/rules/mhn_cowrie_rules.xml
+++ b/etc/rules/mhn_cowrie_rules.xml
@@ -1,0 +1,26 @@
+<!-- Rules for Modern Honeypot Network - Cowrie, -->
+
+<!-- IDs: 53830 - 53840 -->
+<!-- include /var/log/mhn/mhn-json.log to ossec.conf -->
+
+<group name="mhn,json">
+
+  <rule id="53830" level="8">
+    <decoded_as>cowrie</decoded_as>
+    <action>SSH login attempted on cowrie honeypot</action>
+    <description>SSH login attempted on cowrie honeypot</description>
+  </rule>
+
+  <rule id="53831" level="8">
+    <decoded_as>cowrie</decoded_as>
+    <action>SSH session on cowrie honeypot</action>
+    <description>SSH session established on cowrie honeypot</description>
+  </rule>
+
+  <rule id="53832" level="8">
+    <decoded_as>cowrie</decoded_as>
+    <action>command attempted on cowrie honeypot</action>
+    <description>A command was attempted in SSH session on cowrie honeypot</description>
+  </rule>
+
+</group>

--- a/etc/rules/mhn_dionaea_rules.xml
+++ b/etc/rules/mhn_dionaea_rules.xml
@@ -1,0 +1,13 @@
+<!-- Rules for Modern Honeypot Network - Dionaea, -->
+
+<!-- IDs: 53826 - 53829 -->
+<!-- include /var/log/mhn/mhn-json.log to ossec.conf -->
+
+<group name="mhn,json">
+
+  <rule id="53826" level="8">
+    <decoded_as>dionaea</decoded_as>
+    <description>Connection to Dionaea Honeypot identified</description>
+  </rule>
+
+</group>


### PR DESCRIPTION
Added Range, Rules and Decoder for Cowrie and Dionaea in Modern Honeypot Network. 
Did not add the mhn-json.log to the ossec.conf. Added a hint to the rule files and decoder instead. 
Not sure if this rules are to special for including it directly.