### PR TITLE
Allow permission changes to make it into the email alert.

### DIFF
--- a/src/os_maild/os_maild_client.c
+++ b/src/os_maild/os_maild_client.c
@@ -100,6 +100,16 @@ MailMsg *OS_RecvMailQ(file_queue *fileq, struct tm *p,
             body_size -= log_size;
         }
     }
+    if (al_data->perm_chg) {
+       log_size = strlen(al_data->perm_chg) + 17 + 4;
+       if (body_size > log_size) {
+           strncat(logs, "Permission change: ", 20);
+           strncat(logs, al_data->perm_chg, body_size);
+           strncat(logs, "\r\n", 4);
+           body_size -= log_size;
+       }
+    }
+
 
     /* EXTRA DATA */
     if (al_data->srcip) {


### PR DESCRIPTION
It looks like `ossec-maild` was never setup to pass on permissions changes (or that was lost somewhere over the years I dunno). 

Fixes issue #1571 reported by @junqian1992


Before:
```
Received From: ossec-builder->syscheck
Rule: 552 fired (level 7) -> "Integrity checksum changed again (3rd time)."
Portion of the log(s):

Integrity checksum changed for: '/var/test/one'
```

After:
```
Received From: ossec-builder->syscheck
Rule: 552 fired (level 7) -> "Integrity checksum changed again (3rd time)."
Portion of the log(s):

Integrity checksum changed for: '/var/test/three'
Permission change: 'rw-r--r--' to '---------'
```