### PR TITLE
Allow reuse ID and improve search algorithm finding available ID key

### DIFF
--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -388,7 +388,11 @@ int remove_agent()
 
             /* Remove the agent, but keep the id */
             fsetpos(fp, &fp_pos);
+#ifdef REUSE_ID
+            fprintf(fp, "#%s #*#*#*#*#*#*#*#*#*#*#", u_id);
+#else
             fprintf(fp, "%s #*#*#*#*#*#*#*#*#*#*#", u_id);
+#endif
 
             fclose(fp);
 


### PR DESCRIPTION
**Problem:**
- Currently ossec doesn't support reuse ID for client key .
   - Even-though if i try to remove completely client key manually( remove from client.keys), current algorithm still can not found correct available ID as it work correctly only incase of IDs have an ordering.
   - This problem makes the number of ID keeps increase and when ID = MAX_AGENTS + AUTHD_FIRST_ID we can't register a new agent and have to rebuild ossec with higher MAXAGENTS.
- Take so much time for searching an available ID
Ossec use "Dichotomic search", we have to loop into all client.keys file each times check for ID exist (O (nlogn).

**Solution:**
- Support reuse ID 
- Create BitMap to store every ID already allocated, and we only need to loop in entire of client key in 2 times. So this solution have complexity O(n) instead of O(nlogn) as previous version.

**Test:**
Already did a patch for ossec-hids 3.0.0 and did testing in my system everything working ok.