### PR TITLE
Add a no_recurse option to syscheckd.

### DIFF
--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -167,6 +167,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
     const char *xml_real_time = "realtime";
     const char *xml_report_changes = "report_changes";
     const char *xml_restrict = "restrict";
+    const char *xml_no_recurse = "no_recurse";
 
     char *restrictfile = NULL;
     char **dir;
@@ -348,6 +349,14 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                     restrictfile = NULL;
                 }
                 os_strdup(*values, restrictfile);
+            } else if (strcmp(*attrs, xml_no_recurse) == 0) {
+                if(strcmp(*values, "yes") == 0) {
+                    opts |= CHECK_NORECURSE;
+                } else {
+                    merror(SK_INV_OPT, __local_name, *values, *attrs);
+                    ret = 0;
+                    goto out_free;
+                }
             } else {
                 merror(SK_INV_ATTR, __local_name, *attrs);
                 ret = 0;
@@ -828,6 +837,7 @@ char *syscheck_opts2str(char *buf, int buflen, int opts) {
         CHECK_SHA1SUM,
         CHECK_REALTIME,
         CHECK_SEECHANGES,
+        CHECK_NORECURSE,
 	0
 	};
     char *check_strings[] = {
@@ -839,6 +849,7 @@ char *syscheck_opts2str(char *buf, int buflen, int opts) {
         "sha1sum",
         "realtime",
         "report_changes",
+        "no_recurse",
 	NULL
 	};
 

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -23,6 +23,10 @@
 #define CHECK_SHA1SUM       0000040
 #define CHECK_REALTIME      0000100
 #define CHECK_SEECHANGES    0000200
+#define CHECK_SHA256SUM     0000400
+#define CHECK_GENERIC       0001000
+#define CHECK_NORECURSE     0002000
+
 
 #include <stdio.h>
 

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -400,6 +400,21 @@ int read_dir(const char *dir_name, int opts, OSMatch *restriction)
         *s_name = '\0';
         strncpy(s_name, entry->d_name, PATH_MAX - dir_size - 2);
 
+        /* Check if the file is a directory */
+        if(opts & CHECK_NORECURSE) {
+            struct stat recurse_sb;
+            if((stat(f_name, &recurse_sb)) < 0) {
+                merror("%s: ERR: Cannot stat %s: %s", ARGV0, f_name, strerror(errno));
+            } else {
+                switch (recurse_sb.st_mode & S_IFMT) {
+                    case S_IFDIR:
+                        continue;
+                        break;
+                }
+            }
+        }
+
+
         /* Check integrity of the file */
         read_file(f_name, opts, restriction);
     }


### PR DESCRIPTION
It should keep syscheckd fromgoing down into directories to add more stuff.
I think it works with inotify, but I haven't done enough testing to
be confident.

**More testing would be great.**

Very lightly tested in a personal post-MASTER fork. The CHECK_SHA256
and CHECK_GENERIC defines come from there. Don't use them, they won't
work here.