### PR TITLE
JSON archives.log config

### DIFF
--- a/src/analysisd/alerts/getloglocation.c
+++ b/src/analysisd/alerts/getloglocation.c
@@ -100,7 +100,7 @@ int OS_GetLogLocation(const Eventinfo *lf)
         ErrorExit(LINK_ERROR, ARGV0, __elogfile, EVENTS_DAILY, errno, strerror(errno));
     }
     /* For the events in JSON */
-    if (Config.jsonout_output) {
+    if (Config.logall_json) {
         /* Create the json archives logfile name */
         snprintf(__ejlogfile, OS_FLSIZE, "%s/%d/%s/ossec-%s-%02d.json",
                  EVENTS,

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1028,10 +1028,11 @@ void OS_ReadMSG_analysisd(int m_queue)
             } while ((rulenode_pt = rulenode_pt->next) != NULL);
 
             /* If configured to log all, do it */
-            if (Config.logall) {
+            if (Config.logall)
                 OS_Store(lf);
+            if (Config.logall_json)
                 jsonout_output_archive(lf);
-            }
+            
 
 CLMEM:
             /** Cleaning the memory **/

--- a/src/analysisd/config.c
+++ b/src/analysisd/config.c
@@ -24,6 +24,7 @@ int GlobalConf(const char *cfgfile)
 
     /* Default values */
     Config.logall = 0;
+    Config.logall_json = 0;
     Config.stats = 4;
     Config.integrity = 8;
     Config.rootcheck = 8;

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -95,6 +95,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
     /* XML definitions */
     const char *xml_mailnotify = "email_notification";
     const char *xml_logall = "logall";
+    const char *xml_logall_json = "logall_json";
     const char *xml_integrity = "integrity_checking";
     const char *xml_rootcheckd = "rootkit_detection";
     const char *xml_hostinfo = "host_information";
@@ -294,6 +295,21 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
                 return (OS_INVALID);
             }
         }
+        /* Log all JSON*/
+        else if (strcmp(node[i]->element, xml_logall_json) == 0) {
+            if (strcmp(node[i]->content, "yes") == 0) {
+                if (Config) {
+                    Config->logall_json = 1;
+                }
+            } else if (strcmp(node[i]->content, "no") == 0) {
+                if (Config) {
+                    Config->logall_json = 0;
+                }
+            } else {
+                merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
+                return (OS_INVALID);
+            }
+        }           
         /* Compress alerts */
         else if (strcmp(node[i]->element, xml_compress_alerts) == 0) {
             /* removed from here -- compatibility issues only */

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -15,6 +15,7 @@
 /* Configuration structure */
 typedef struct __Config {
     u_int8_t logall;
+    u_int8_t logall_json; 
     u_int8_t stats;
     u_int8_t integrity;
     u_int8_t syscheck_auto_ignore;

--- a/src/monitord/manage_files.c
+++ b/src/monitord/manage_files.c
@@ -96,12 +96,12 @@ void manage_files(int cday, int cmon, int cyear)
     int exists_json_events = 0;
     FILE *fopnetestjsonevents;
 
-    if ((fopnetestjsonevents = fopen(ajlogfile, "r"))) {
+    if ((fopnetestjsonevents = fopen(ejlogfile, "r"))) {
         exists_json_events = 1;
         fclose(fopnetestjsonevents);
     }
 
-    if ((fopnetestjsonevents = fopen(ajlogfile_old, "r"))) {
+    if ((fopnetestjsonevents = fopen(ejlogfile_old, "r"))) {
         exists_json_events = 1;
         fclose(fopnetestjsonevents);
     }


### PR DESCRIPTION
New global option:
        <logall_json>yes</logall_json>

Update fixes compression mode on this new log, and removes the
dependency on json output for alerts.log to be enabled for archives.json

Signed-off-by: Scott R. Shinn <scott@atomicorp.com>