### PR TITLE
Use the sytem zlib, except for Windows agents.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 EXTERNAL_JSON=external/cJSON/
 EXTERNAL_LUA=external/lua-5.2.3/
 EXTERNAL_ZLIB=external/zlib-1.2.11/
-ZLIB_SYSTEM?=no
+ZLIB_SYSTEM?=yes
 LUA_PLAT=posix
 LUA_ENABLE?=yes
 MAXAGENTS?=2048
@@ -172,6 +172,7 @@ endif
 MING_BASE:=
 ifeq (${TARGET}, winagent)
 CC=gcc
+ZLIB_SYSTEM=yes
 ifneq (,$(shell which amd64-mingw32msvc-gcc))
 	MING_BASE:=amd64-mingw32msvc-
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -172,7 +172,7 @@ endif
 MING_BASE:=
 ifeq (${TARGET}, winagent)
 CC=gcc
-ZLIB_SYSTEM=yes
+ZLIB_SYSTEM=no
 ifneq (,$(shell which amd64-mingw32msvc-gcc))
 	MING_BASE:=amd64-mingw32msvc-
 else


### PR DESCRIPTION
I'd rather not carry this software internally, especially when it seems to be pretty much everywhere.
I can get the system zlib to work on CentOS builds for Windows, but haven't figured out the magic for Ubuntu yet. So we'll leave that in place for the moment.