### PR TITLE
Remoted will not exit on empty keys

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -50,6 +50,8 @@ remoted.comp_average_printout=19999
 # Verify msg id (set to 0 to disable it)
 remoted.verify_msg_id=1
 
+# Don't exit when client.keys empty
+remoted.pass_empty_keyfile=0
 
 # Maild strict checking (0=disabled, 1=enabled)
 maild.strict_checking=1

--- a/src/error_messages/error_messages.h
+++ b/src/error_messages/error_messages.h
@@ -133,6 +133,8 @@
 
 /* remoted */
 #define NO_REM_CONN     "%s(1750): ERROR: No remote connection configured. Exiting."
+#define NO_CLIENT_KEYS  "%s(1751): ERROR: File client.keys not found or empty."
+
 
 /* 1760 - 1769 -- reserved for maild */
 

--- a/src/headers/sec.h
+++ b/src/headers/sec.h
@@ -69,6 +69,8 @@ void OS_StartCounter(keystore *keys) __attribute((nonnull));
 /* Remove counter for id */
 void OS_RemoveCounter(const char *id) __attribute((nonnull));
 
+/* Configure to pass if keys file is empty */
+void OS_PassEmptyKeyfile();
 
 /** Function prototypes -- agent authorization **/
 

--- a/src/remoted/main.c
+++ b/src/remoted/main.c
@@ -127,6 +127,12 @@ int main(int argc, char **argv)
         exit(0);
     }
 
+    /* Don't exit when client.keys empty (if set) */
+    if (getDefine_Int("remoted", "pass_empty_keyfile", 0, 1)) {
+        OS_PassEmptyKeyfile();
+    }
+
+
     /* Check if the user and group given are valid */
     uid = Privsep_GetUser(user);
     gid = Privsep_GetGroup(group);


### PR DESCRIPTION
Adds new option: remoted.pass_empty_keyfile

when set to 1, remoted will not exit if client.keys has no defined
agents.

Original: vmfdez90 AT gmail.com

Signed-off-by: Scott R. Shinn <scott@atomicorp.com>