### PR TITLE
enhance manage_agents with duplicate ip option

### DIFF
--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -34,7 +34,7 @@ static int setenv(const char *name, const char *val, __attribute__((unused)) int
 static void helpmsg()
 {
     print_header();
-    print_out("  %s: -[Vhlj] [-a <ip> -n <name>] [-e id] [-r id] [-i id] [-f file]", ARGV0);
+    print_out("  %s: -[Vhlj] [-a <ip> -n <name>] [-d] [-e id] [-r id] [-i id] [-f file]", ARGV0);
     print_out("    -V          Version and license message");
     print_out("    -h          This help message");
     print_out("    -j          Use JSON output");
@@ -45,7 +45,7 @@ static void helpmsg()
     print_out("    -r <id>     Remove an agent (Manager only)");
     print_out("    -i <id>     Import authentication key (Agent only)");
     print_out("    -n <name>   Name for new agent");
-
+    print_out("    -d          Remove old agents with duplicated IP (on adding)");
     print_out("    -f <file>   Bulk generate client keys from file (Manager only)");
     print_out("                <file> contains lines in IP,NAME format");
     print_out("                <file> should also exist within /var/ossec due to manage_agents chrooting");
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
     /* Set the name */
     OS_SetName(ARGV0);
 
-    while ((c = getopt(argc, argv, "Vhle:r:i:f:ja:n:")) != -1) {
+    while ((c = getopt(argc, argv, "Vhle:r:i:f:ja:n:d")) != -1) {
         switch (c) {
             case 'V':
                 print_version();
@@ -161,6 +161,9 @@ int main(int argc, char **argv)
                 json_output = 1;
                 break;
             case 'a':
+#ifdef CLIENT
+                ErrorExit("%s: Agent adding only available on a master.", ARGV0);
+#endif
                 if (!optarg)
                     ErrorExit("%s: -a needs an argument.", ARGV0);
                 setenv("OSSEC_ACTION", "a", 1);
@@ -326,6 +329,9 @@ int main(int argc, char **argv)
                 break;
             case 'V':
                 print_version();
+                break;
+            case 'd':
+                setenv("OSSEC_REMOVE_DUPLICATED", "y", 1);
                 break;
             default:
                 printf("\n ** Invalid Action ** \n\n");

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -92,6 +92,7 @@ extern fpos_t fp_pos;
 #define ADD_ERROR_ID    "\n** ID '%s' already present. They must be unique.\n\n"
 #define ADD_ERROR_NAME  "\n** Name '%s' already present. Please enter a new name.\n\n"
 #define IP_ERROR        "\n** Invalid IP '%s'. Please enter a valid IP Address.\n\n"
+#define IP_DUP_ERROR    "\n** Duplicated IP '%s'. Please enter an unique IP Address.\n\n"
 #define NO_AGENT        "\n** No agent available. You need to add one first.\n"
 #define NO_ID           "\n** Invalid ID '%s' given. ID is not present.\n"
 #define NO_KEY          "\n** Invalid authentication key. Starting over again.\n"


### PR DESCRIPTION
New option -d

This is used in conjuction with the -a flag to remove an agent pinned to
an already used IP.

Original: vmfdez90 AT gmail.com

Signed-off-by: Scott R. Shinn <scott@atomicorp.com>