### PR TITLE
Remove the Trend Micro output from the ossec-control script

### DIFF
--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -12,7 +12,6 @@ DIR=`dirname $PWD`;
 ###  Do not modify below here ###
 NAME="OSSEC HIDS"
 VERSION="v3.1.0"
-AUTHOR="Trend Micro Inc."
 DAEMONS="ossec-logcollector ossec-syscheckd ossec-agentd ossec-execd"
 
 [ -f /etc/ossec-init.conf ] && . /etc/ossec-init.conf
@@ -120,7 +119,7 @@ start()
 {
     SDAEMONS="ossec-execd ossec-agentd ossec-logcollector ossec-syscheckd"
 
-    echo "Starting $NAME $VERSION (by $AUTHOR)..."
+    echo "Starting $NAME $VERSION..."
     lock;
     checkpid;
 

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -20,7 +20,6 @@ fi
 
 NAME="OSSEC HIDS"
 VERSION="v3.1.0"
-AUTHOR="Trend Micro Inc."
 DAEMONS="ossec-monitord ossec-logcollector ossec-syscheckd ossec-analysisd ossec-maild ossec-execd ${DB_DAEMON} ${CSYSLOG_DAEMON} ${AGENTLESS_DAEMON}"
 
 ## Locking for the start/stop
@@ -180,7 +179,7 @@ start()
 {
     SDAEMONS="${DB_DAEMON} ${CSYSLOG_DAEMON} ${AGENTLESS_DAEMON} ossec-maild ossec-execd ossec-analysisd ossec-logcollector ossec-syscheckd ossec-monitord"
 
-    echo "Starting $NAME $VERSION (by $AUTHOR)..."
+    echo "Starting $NAME $VERSION..."
     echo | ${DIR}/bin/ossec-logtest > /dev/null 2>&1;
     if [ ! $? = 0 ]; then
         echo "ossec-analysisd: Configuration error. Exiting."

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -20,7 +20,6 @@ fi
 
 NAME="OSSEC HIDS"
 VERSION="v3.1.0"
-AUTHOR="Trend Micro Inc."
 
 [ -f /etc/ossec-init.conf ] && . /etc/ossec-init.conf;
 
@@ -194,7 +193,7 @@ start()
 {
     SDAEMONS="${DB_DAEMON} ${CSYSLOG_DAEMON} ${AGENTLESS_DAEMON} ossec-maild ossec-execd ossec-analysisd ossec-logcollector ossec-remoted ossec-syscheckd ossec-monitord"
 
-    echo "Starting $NAME $VERSION (by $AUTHOR)..."
+    echo "Starting $NAME $VERSION..."
     echo | ${DIR}/bin/ossec-logtest > /dev/null 2>&1;
     if [ ! $? = 0 ]; then
         echo "OSSEC analysisd: Testing rules failed. Configuration error. Exiting."


### PR DESCRIPTION
Trend Micro owns a lot of the code, but they're not really part of the project in any official capacity. Don't give people the impression that they are.