### PR TITLE
Added dangerous commands/background activity catching rules

### DIFF
--- a/etc/rules/ms_powershell_rules.xml
+++ b/etc/rules/ms_powershell_rules.xml
@@ -31,7 +31,7 @@
   
   <rule id="20503" level="2">
     <if_sid>20501</if_sid>
-    <regex>Set-StrictMode -Version 1; \.+OriginInfo | Set-StrictMode -Version 1; \.+\w+</regex>
+    <regex>Set-StrictMode -Version 1; \.+\w+</regex>
     <description>A wrong/misspelled command was tried</description>
   </rule>
 

--- a/etc/rules/ms_powershell_rules.xml
+++ b/etc/rules/ms_powershell_rules.xml
@@ -2,7 +2,7 @@
 
 <!-- Not recommended by CIS due to Windows default ACL settings -->
 <!-- Turn on logging: Computer Configuration > Policies > Administrative Templates > Windows Components > Windows PowerShell -> Turn on PowerShell Script Block Logging -->
-
+<!-- Add <localfile> <location>Powershell</location> <log_format>eventlog</log_format> </localfile> to ossec.conf on Windows Agent -->
 <!-- Rule IDs 20500-2509 -->
 
 <group name="windows,powershell,">

--- a/etc/rules/ms_powershell_rules.xml
+++ b/etc/rules/ms_powershell_rules.xml
@@ -31,14 +31,14 @@
   
   <rule id="20503" level="2">
     <if_sid>20501</if_sid>
-    <match>CommandInvocation(Set-StrictMode)</match>
-    <description>Invocation of command Set-StrictMode</description>
+    <regex>Set-StrictMode -Version 1; \.+OriginInfo | Set-StrictMode -Version 1; \.+\w+</regex>
+    <description>A wrong/misspelled command was tried</description>
   </rule>
 
   <rule id="20504" level="2">
     <if_sid>20501</if_sid>
-    <match>CommandInvocation(Out-Default)</match>
-    <description>Invocation of command Out-Default</description>
+    <match>CommandLine= CommandInvocation</match>
+    <description>Powershell background activity</description>
   </rule>
 
   <rule id="20505" level="12">

--- a/etc/rules/ms_powershell_rules.xml
+++ b/etc/rules/ms_powershell_rules.xml
@@ -3,6 +3,7 @@
 <!-- Not recommended by CIS due to Windows default ACL settings -->
 <!-- Turn on logging: Computer Configuration > Policies > Administrative Templates > Windows Components > Windows PowerShell -> Turn on PowerShell Script Block Logging -->
 <!-- Add <localfile> <location>Powershell</location> <log_format>eventlog</log_format> </localfile> to ossec.conf on Windows Agent -->
+
 <!-- Rule IDs 20500-2509 -->
 
 <group name="windows,powershell,">
@@ -26,6 +27,24 @@
     <id>^403$</id>
     <match>PowerShell</match>
     <description>Windows PowerShell was stopped.</description>
+  </rule>
+  
+  <rule id="20503" level="2">
+    <if_sid>20501</if_sid>
+    <match>CommandInvocation(Set-StrictMode)</match>
+    <description>Invocation of command Set-StrictMode</description>
+  </rule>
+
+  <rule id="20504" level="2">
+    <if_sid>20501</if_sid>
+    <match>CommandInvocation(Out-Default)</match>
+    <description>Invocation of command Out-Default</description>
+  </rule>
+
+  <rule id="20505" level="12">
+    <if_sid>20501</if_sid>
+    <match>Set-ExecutionPolicy|Mimikatz|EncodedCommand|Payload|Find-AVSignature|DllInjection|ReflectivePEInjection|Invoke-Shellcode|Invoke--Shellcode|Invoke-ShellcodeMSIL|Get-GPPPassword|Get-Keystrokes|Get-TimedScreenshot|Get-VaultCredential|Invoke-CredentialInjection|Invoke-NinjaCopy|Invoke-TokenManipulation|Out-Minidump|Set-MasterBootRecord|New-ElevatedPersistenceOption|Invoke-CallbackIEX|Invoke-PSInject|Invoke-DllEncode|Get-ServiceUnquoted|Get-ServiceEXEPerms|Get-ServicePerms|Invoke-ServiceUserAdd|Invoke-ServiceCMD|Write-UserAddServiceBinary|Write-CMDServiceBinary|Write-UserAddMSI|Write-ServiceEXE|Write-ServiceEXECMD|Restore-ServiceEXE|Invoke-ServiceStart|Invoke-ServiceStop|Invoke-ServiceEnable|Invoke-ServiceDisable|Invoke-FindDLLHijack|Invoke-FindPathHijack|Get-RegAlwaysInstallElevated|Get-RegAutoLogon|Get-UnattendedInstallFiles|Get-Webconfig|Get-Webconfig|Get-ApplicationHost|Invoke-AllChecks|Invoke-MassCommand|Invoke-MassMimikatz|Invoke-MassSearch|Invoke-MassTemplate|Invoke-MassTokens|HTTP-Backdoor|Add-ScrnSaveBackdoor|Gupt-Backdoor|Invoke-ADSBackdoor|Execute-OnTime|DNS_TXT_Pwnage|Out-Word|Out-Excel|Out-Java|Out-Shortcut|Out-CHM|Out-HTA|Enable-DuplicateToken|Remove-Update|Execute-DNSTXT-Code|Download-Execute-PS|Execute-Command-MSSQL|Download_Execute|Get-PassHashes|Invoke-CredentialsPhish|Get-LsaSecret|Get-Information|Invoke-MimikatzWDigestDowngrade|Copy-VSS|Check-VM|Invoke-NetworkRelay|Create-MultipleSessions|Run-EXEonRemote|Invoke-BruteForce|Port-Scan|Invoke-PowerShellIcmp|Invoke-PowerShellUdp|Invoke-PsGcatAgent|Invoke-PoshRatHttps|Invoke-PowerShellTcp|Invoke-PoshRatHttp|Invoke-PowerShellWmi|Invoke-PSGcat|Remove-PoshRat|TexttoEXE|Invoke-Encode|Invoke-Decode|Base64ToString|StringtoBase64|Do-Exfiltration|Parse_Keys|Add-Exfiltration|Add-Persistence|Remove-Persistence|Invoke-CreateCertificate|powercat|Find-PSServiceAccounts|Get-PSADForestKRBTGTInfo|Discover-PSMSSQLServers|Discover-PSMSExchangeServers|Get-PSADForestInfo|Get-KerberosPolicy|Discover-PSInterestingServices</match>
+    <description>Possibly Dangerous Command Detected (https://gist.github.com/gfoss/2b39d680badd2cad9d82#file-powershell-command-line-logging)</description>
   </rule>
 
 </group>


### PR DESCRIPTION
Added rule for dangerous powershell commands +
Added rules with level 2 for catching less critical background activity commands like powershell starting or error printing for less wrong mail warnings.