### PR TITLE
Dynamic decoders

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -26,6 +26,9 @@ analysisd.fts_min_size_for_str=14
 # Analysisd Enable the firewall log (at logs/firewall/firewall.log)
 # 1 to enable, 0 to disable.
 analysisd.log_fw=1
+# Maximum number of fields in a decoder (order tag)
+analysisd.decoder_order_size=10
+
 
 # Output GeoIP data at JSON alerts
 analysisd.geoip_jsonout=0

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1072,6 +1072,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
      * status,
      */
     RuleInfo *rule = curr_node->ruleinfo;
+    int i;
 
     /* Can't be null */
     if (!rule) {
@@ -1151,6 +1152,23 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
         if (!OSMatch_Execute(lf->url, strlen(lf->url), rule->url)) {
             return (NULL);
         }
+    }
+    
+    /* Check for dynamic fields */
+    
+    for (i = 0; i < 8 && rule->fields[i]; i++) {
+        int j;
+        
+        for (j = 0; j < 8; j++)
+            if (lf->decoder_info->fields[j])
+                if (strcasecmp(lf->decoder_info->fields[j], rule->fields[i]->name) == 0)
+                    break;
+
+        if (j == 8)
+            return NULL;
+        
+        if (!OSRegex_Execute(lf->fields[j], rule->fields[i]->regex))
+            return NULL;
     }
 
     /* Get TCP/IP packet information */

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -297,6 +297,8 @@ int main_analysisd(int argc, char **argv)
     }
     nowChroot();
 
+    Config.decoder_order_size = (size_t)getDefine_Int("analysisd", "decoder_order_size", 8, MAX_DECODER_ORDER_SIZE);
+
     /*
      * Anonymous Section: Load rules, decoders, and lists
      *
@@ -647,6 +649,7 @@ void OS_ReadMSG_analysisd(int m_queue)
         if (!lf) {
             ErrorExit(MEM_ERROR, ARGV0, errno, strerror(errno));
         }
+        os_calloc(Config.decoder_order_size, sizeof(char*), lf->fields);
         lf->year = prev_year;
         strncpy(lf->mon, prev_month, 3);
         lf->day = today;
@@ -680,6 +683,7 @@ void OS_ReadMSG_analysisd(int m_queue)
     /* Daemon loop */
     while (1) {
         lf = (Eventinfo *)calloc(1, sizeof(Eventinfo));
+        os_calloc(Config.decoder_order_size, sizeof(char*), lf->fields);
 
         /* This shouldn't happen */
         if (lf == NULL) {
@@ -1156,15 +1160,16 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
     
     /* Check for dynamic fields */
     
-    for (i = 0; i < 8 && rule->fields[i]; i++) {
+    for (i = 0; i < Config.decoder_order_size && rule->fields[i]; i++) {
         int j;
         
-        for (j = 0; j < 8; j++)
+        for (j = 0; j < Config.decoder_order_size; j++)
+
             if (lf->decoder_info->fields[j])
                 if (strcasecmp(lf->decoder_info->fields[j], rule->fields[i]->name) == 0)
                     break;
 
-        if (j == 8)
+        if (j == Config.decoder_order_size)
             return NULL;
         
         if (!OSRegex_Execute(lf->fields[j], rule->fields[i]->regex))

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -31,6 +31,8 @@ extern char __shost[512];
 extern OSDecoderInfo *NULL_Decoder;
 
 #define OSSEC_SERVER    "ossec-server"
+#define MAX_DECODER_ORDER_SIZE  20
+
 
 #endif /* _LOGAUDIT__H */
 

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009 Trend Micro Inc.
+/* Copyright (C) 2019 OSSEC Foundation
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it
@@ -451,42 +451,56 @@ int ReadDecodeXML(const char *file)
                 /* Check the values from the order */
                 while (*norder) {
                     if (strstr(*norder, "dstuser") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) DstUser_FP;
+                        pi->order[order_int] = DstUser_FP;
                     } else if (strstr(*norder, "srcuser") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) SrcUser_FP;
+                        pi->order[order_int] = SrcUser_FP;
+
                     }
                     /* User is an alias to dstuser */
                     else if (strstr(*norder, "user") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) DstUser_FP;
+                        pi->order[order_int] = DstUser_FP;
                     } else if (strstr(*norder, "srcip") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) SrcIP_FP;
+                        pi->order[order_int] = SrcIP_FP;
+
                     } else if (strstr(*norder, "dstip") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) DstIP_FP;
+                        pi->order[order_int] = DstIP_FP;
+
                     } else if (strstr(*norder, "srcport") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) SrcPort_FP;
+                        pi->order[order_int] = SrcPort_FP;
+
                     } else if (strstr(*norder, "dstport") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) DstPort_FP;
+                        pi->order[order_int] = DstPort_FP;
+
                     } else if (strstr(*norder, "protocol") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) Protocol_FP;
+                        pi->order[order_int] = Protocol_FP;
+
                     } else if (strstr(*norder, "action") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) Action_FP;
+                        pi->order[order_int] = Action_FP;
+
                     } else if (strstr(*norder, "id") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) ID_FP;
+                        pi->order[order_int] = ID_FP;
+
                     } else if (strstr(*norder, "url") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) Url_FP;
+                        pi->order[order_int] = Url_FP;
+
                     } else if (strstr(*norder, "data") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) Data_FP;
+                        pi->order[order_int] = Data_FP;
+
                     } else if (strstr(*norder, "extra_data") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) Data_FP;
+                        pi->order[order_int] = Data_FP;
+
                     } else if (strstr(*norder, "status") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) Status_FP;
+                        pi->order[order_int] = Status_FP;
+
                     } else if (strstr(*norder, "system_name") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) SystemName_FP;
+                        pi->order[order_int] = SystemName_FP;
+
                     } else if (strstr(*norder, "filename") != NULL) {
-                        pi->order[order_int] = (void (*)(void *, char *)) FileName_FP;
+                        pi->order[order_int] = FileName_FP;
                     } else {
-                        ErrorExit("decode-xml: Wrong field '%s' in the order"
-                                  " of decoder '%s'", *norder, pi->name);
+                        pi->order[order_int] = DynamicField_FP;
+                        pi->fields[order_int] = strdup(*norder);
+
                     }
 
                     free(*norder);

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -450,49 +450,59 @@ int ReadDecodeXML(const char *file)
 
                 /* Check the values from the order */
                 while (*norder) {
-                    if (strstr(*norder, "dstuser") != NULL) {
+
+                    char *word = &(*norder)[strspn(*norder, " ")];
+                    word[strcspn(word, " ")] = '\0';
+
+                    if (strlen(word) == 0) {
+                        ErrorExit("decode-xml: Wrong field '%s' in the order"
+                                  " of decoder '%s'", *norder, pi->name);
+                    }
+
+                    if (!strcmp(word, "dstuser")) {
                         pi->order[order_int] = DstUser_FP;
-                    } else if (strstr(*norder, "srcuser") != NULL) {
+                    } else if (!strcmp(word, "srcuser")) {
                         pi->order[order_int] = SrcUser_FP;
 
                     }
                     /* User is an alias to dstuser */
-                    else if (strstr(*norder, "user") != NULL) {
+                    else if (!strcmp(word, "user")) {
                         pi->order[order_int] = DstUser_FP;
-                    } else if (strstr(*norder, "srcip") != NULL) {
+
+                    } else if (!strcmp(word, "srcip")) {
                         pi->order[order_int] = SrcIP_FP;
 
-                    } else if (strstr(*norder, "dstip") != NULL) {
+                    } else if (!strcmp(word, "dstip")) {
                         pi->order[order_int] = DstIP_FP;
 
-                    } else if (strstr(*norder, "srcport") != NULL) {
+                    } else if (!strcmp(word, "srcport")) {
                         pi->order[order_int] = SrcPort_FP;
 
-                    } else if (strstr(*norder, "dstport") != NULL) {
+                    } else if (!strcmp(word, "dstport")) {
                         pi->order[order_int] = DstPort_FP;
 
-                    } else if (strstr(*norder, "protocol") != NULL) {
+                    } else if (!strcmp(word, "protocol")) {
                         pi->order[order_int] = Protocol_FP;
 
-                    } else if (strstr(*norder, "action") != NULL) {
+                    } else if (!strcmp(word, "action")) {
                         pi->order[order_int] = Action_FP;
 
-                    } else if (strstr(*norder, "id") != NULL) {
+                    } else if (!strcmp(word, "id")) {
                         pi->order[order_int] = ID_FP;
 
-                    } else if (strstr(*norder, "url") != NULL) {
+                    } else if (!strcmp(word, "url")) {
                         pi->order[order_int] = Url_FP;
 
-                    } else if (strstr(*norder, "data") != NULL) {
+                    } else if (!strcmp(word, "data")) {
                         pi->order[order_int] = Data_FP;
 
-                    } else if (strstr(*norder, "extra_data") != NULL) {
+                    } else if (!strcmp(word, "extra_data")) {
                         pi->order[order_int] = Data_FP;
 
-                    } else if (strstr(*norder, "status") != NULL) {
+                    } else if (!strcmp(word, "status")) {
                         pi->order[order_int] = Status_FP;
 
-                    } else if (strstr(*norder, "system_name") != NULL) {
+                    } else if (!strcmp(word, "system_name")) {
                         pi->order[order_int] = SystemName_FP;
 
                     } else if (strstr(*norder, "filename") != NULL) {

--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -14,6 +14,8 @@
 #include "eventinfo.h"
 #include "decoder.h"
 #include "plugin_decoders.h"
+#include "config.h"
+
 
 #ifdef TESTRULE
 #undef XML_LDECODER
@@ -436,20 +438,21 @@ int ReadDecodeXML(const char *file)
                 char **norder, **s_norder;
                 int order_int = 0;
 
-                /* Maximum number is 8 for the order */
-                norder = OS_StrBreak(',', elements[j]->content, 8);
-                s_norder = norder;
-                os_calloc(8, sizeof(void *), pi->order);
+                /* Maximum number for the order is limited by decoder_order_size */
+                norder = OS_StrBreak(',', elements[j]->content, MAX_DECODER_ORDER_SIZE);
 
-                /* Initialize the function pointers */
-                while (order_int < 8) {
-                    pi->order[order_int] = NULL;
-                    order_int++;
-                }
+                s_norder = norder;
+                os_calloc(Config.decoder_order_size, sizeof(void *), pi->order);
+                os_calloc(Config.decoder_order_size, sizeof(char *), pi->fields);
+
                 order_int = 0;
 
                 /* Check the values from the order */
                 while (*norder) {
+
+                    if (order_int >= Config.decoder_order_size) {
+                        ErrorExit("%s: ERROR: Order has too many fields.", ARGV0);
+                    }
 
                     char *word = &(*norder)[strspn(*norder, " ")];
                     word[strcspn(word, " ")] = '\0';

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -12,6 +12,8 @@
 #include "os_xml/os_xml.h"
 #include "eventinfo.h"
 #include "decoder.h"
+#include "config.h"
+
 
 
 /* Use the osdecoders to decode the received event */
@@ -189,6 +191,10 @@ void DecodeEvent(Eventinfo *lf)
                 lf->decoder_info = nnode;
 
                 for (i = 0; nnode->regex->sub_strings[i]; i++) {
+                    if (i >= Config.decoder_order_size) {
+                        ErrorExit("%s: ERROR: Regex has too many groups.", ARGV0);
+                    }
+
                     if (nnode->order[i])
                         nnode->order[i](lf, nnode->regex->sub_strings[i], i);
                     else

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009 Trend Micro Inc.
+/* Copyright (C) 2019 OSSEC Foundation
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it
@@ -146,7 +146,7 @@ void DecodeEvent(Eventinfo *lf)
         /* Get the regex */
         while (child_node) {
             if (nnode->regex) {
-                int i = 0;
+                int i;
 
                 /* With regex we have multiple options
                  * regarding the offset:
@@ -186,18 +186,14 @@ void DecodeEvent(Eventinfo *lf)
                     regex_prev++;
                 }
 
-                while (nnode->regex->sub_strings[i]) {
-                    if (nnode->order[i]) {
-                        nnode->order[i](lf, nnode->regex->sub_strings[i]);
-                        nnode->regex->sub_strings[i] = NULL;
-                        i++;
-                        continue;
-                    }
+                for (i = 0; nnode->regex->sub_strings[i]; i++) {
+                    if (nnode->order[i])
+                        nnode->order[i](lf, nnode->regex->sub_strings[i], i);
+                    else
+                        /* We do not free any memory used above */
+                        os_free(nnode->regex->sub_strings[i]);
 
-                    /* We do not free any memory used above */
-                    os_free(nnode->regex->sub_strings[i]);
                     nnode->regex->sub_strings[i] = NULL;
-                    i++;
                 }
 
                 /* If we have a next regex, try getting it */
@@ -227,7 +223,7 @@ void DecodeEvent(Eventinfo *lf)
 
 /*** Event decoders ****/
 
-void *DstUser_FP(Eventinfo *lf, char *field)
+void *DstUser_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -239,7 +235,7 @@ void *DstUser_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *SrcUser_FP(Eventinfo *lf, char *field)
+void *SrcUser_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -251,7 +247,7 @@ void *SrcUser_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *SrcIP_FP(Eventinfo *lf, char *field)
+void *SrcIP_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -277,7 +273,7 @@ void *SrcIP_FP(Eventinfo *lf, char *field)
 
 }
 
-void *DstIP_FP(Eventinfo *lf, char *field)
+void *DstIP_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -301,7 +297,7 @@ void *DstIP_FP(Eventinfo *lf, char *field)
 
 }
 
-void *SrcPort_FP(Eventinfo *lf, char *field)
+void *SrcPort_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -313,7 +309,7 @@ void *SrcPort_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *DstPort_FP(Eventinfo *lf, char *field)
+void *DstPort_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -325,7 +321,7 @@ void *DstPort_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *Protocol_FP(Eventinfo *lf, char *field)
+void *Protocol_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -337,7 +333,7 @@ void *Protocol_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *Action_FP(Eventinfo *lf, char *field)
+void *Action_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -349,7 +345,7 @@ void *Action_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *ID_FP(Eventinfo *lf, char *field)
+void *ID_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -361,7 +357,7 @@ void *ID_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *Url_FP(Eventinfo *lf, char *field)
+void *Url_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -373,7 +369,7 @@ void *Url_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *Data_FP(Eventinfo *lf, char *field)
+void *Data_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -385,7 +381,7 @@ void *Data_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *Status_FP(Eventinfo *lf, char *field)
+void *Status_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -397,7 +393,7 @@ void *Status_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *SystemName_FP(Eventinfo *lf, char *field)
+void *SystemName_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -409,7 +405,8 @@ void *SystemName_FP(Eventinfo *lf, char *field)
     return (NULL);
 }
 
-void *FileName_FP(Eventinfo *lf, char *field)
+
+void *FileName_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
 #ifdef TESTRULE
     if (!alert_only) {
@@ -422,9 +419,21 @@ void *FileName_FP(Eventinfo *lf, char *field)
 }
 
 
-void *None_FP(__attribute__((unused)) Eventinfo *lf, char *field)
+
+void *DynamicField_FP(Eventinfo *lf, char *field, int order)
+{
+#ifdef TESTRULE
+    if (!alert_only) {
+        print_out("       %s: '%s'", lf->decoder_info->fields[order], field);
+    }
+#endif
+
+    lf->fields[order] = field;
+    return (NULL);
+}
+
+void *None_FP(__attribute__((unused)) Eventinfo *lf, char *field, __attribute__((unused)) int order)
 {
     free(field);
     return (NULL);
 }
-

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 OSSEC Foundation
+/* Copyright (C) 2019 Trend Micro Inc.
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -186,6 +186,8 @@ void DecodeEvent(Eventinfo *lf)
                     regex_prev++;
                 }
 
+                lf->decoder_info = nnode;
+
                 for (i = 0; nnode->regex->sub_strings[i]; i++) {
                     if (nnode->order[i])
                         nnode->order[i](lf, nnode->regex->sub_strings[i], i);

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -18,6 +18,8 @@
 #define AFTER_PREVREGEX 0x004   /* 4   */
 #define AFTER_ERROR     0x010
 
+struct _Eventinfo;
+
 /* Decoder structure */
 typedef struct {
     u_int8_t  get_next;
@@ -33,13 +35,14 @@ typedef struct {
     char *parent;
     char *name;
     char *ftscomment;
+    char *fields[8];
 
     OSRegex *regex;
     OSRegex *prematch;
     OSMatch *program_name;
 
     void (*plugindecoder)(void *lf);
-    void (**order)(void *lf, char *field);
+    void* (**order)(struct _Eventinfo *, char *, int);
 } OSDecoderInfo;
 
 /* List structure */
@@ -65,4 +68,3 @@ void RootcheckInit(void);
 int ReadDecodeXML(const char *file);
 
 #endif
-

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -35,7 +35,7 @@ typedef struct {
     char *parent;
     char *name;
     char *ftscomment;
-    char *fields[8];
+    char **fields;
 
     OSRegex *regex;
     OSRegex *prematch;

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -39,7 +39,7 @@ typedef struct _Eventinfo {
     char *url;
     char *data;
     char *systemname;
-    char *fields[8];
+    char **fields;
 
     /* Pointer to the rule that generated it */
     RuleInfo *generated_rule;

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 OSSEC Foundation
+/* Copyright (C) 2019 Trend Micro Inc.
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -1,5 +1,5 @@
-/* Copyright (C) 2009 Trend Micro Inc.
- * All right reserved.
+/* Copyright (C) 2019 OSSEC Foundation
+ * All rights reserved.
  *
  * This program is a free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -39,6 +39,7 @@ typedef struct _Eventinfo {
     char *url;
     char *data;
     char *systemname;
+    char *fields[8];
 
     /* Pointer to the rule that generated it */
     RuleInfo *generated_rule;
@@ -137,21 +138,23 @@ EventNode *OS_GetLastEvent(void);
 void OS_CreateEventList(int maxsize);
 
 /* Pointers to the event decoders */
-void *SrcUser_FP(Eventinfo *lf, char *field);
-void *DstUser_FP(Eventinfo *lf, char *field);
-void *SrcIP_FP(Eventinfo *lf, char *field);
-void *DstIP_FP(Eventinfo *lf, char *field);
-void *SrcPort_FP(Eventinfo *lf, char *field);
-void *DstPort_FP(Eventinfo *lf, char *field);
-void *Protocol_FP(Eventinfo *lf, char *field);
-void *Action_FP(Eventinfo *lf, char *field);
-void *ID_FP(Eventinfo *lf, char *field);
-void *Url_FP(Eventinfo *lf, char *field);
-void *Data_FP(Eventinfo *lf, char *field);
-void *Status_FP(Eventinfo *lf, char *field);
-void *SystemName_FP(Eventinfo *lf, char *field);
-void *FileName_FP(Eventinfo *lf, char *field);
-void *None_FP(Eventinfo *lf, char *field);
+void *SrcUser_FP(Eventinfo *lf, char *field, int order);
+void *DstUser_FP(Eventinfo *lf, char *field, int order);
+void *SrcIP_FP(Eventinfo *lf, char *field, int order);
+void *DstIP_FP(Eventinfo *lf, char *field, int order);
+void *SrcPort_FP(Eventinfo *lf, char *field, int order);
+void *DstPort_FP(Eventinfo *lf, char *field, int order);
+void *Protocol_FP(Eventinfo *lf, char *field, int order);
+void *Action_FP(Eventinfo *lf, char *field, int order);
+void *ID_FP(Eventinfo *lf, char *field, int order);
+void *Url_FP(Eventinfo *lf, char *field, int order);
+void *Data_FP(Eventinfo *lf, char *field, int order);
+void *Status_FP(Eventinfo *lf, char *field, int order);
+void *SystemName_FP(Eventinfo *lf, char *field, int order);
+void *FileName_FP(Eventinfo *lf, char *field, int order);
+void *DynamicField_FP(Eventinfo *lf, char *field, int order);
+void *None_FP(Eventinfo *lf, char *field, int order);
+
 
 #endif /* _EVTINFO__H */
 

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015 Trend Micro Inc.
+/* Copyright (C) 2019 OSSEC Foundation
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it
@@ -24,6 +24,8 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     cJSON *rule;
     cJSON *file_diff;
     char *out;
+    int i;
+
 
     extern long int __crt_ftell;
 
@@ -120,6 +122,19 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->full_log) {
         cJSON_AddStringToObject(root, "full_log", lf->full_log);
     }
+
+
+    //Dynamic fields
+    if(lf->decoder_info){
+        //ToDO: use constant instead of 8.
+        for(i=0;i<8;i++){
+            if (lf->decoder_info->fields[i] && lf->fields[i])
+                cJSON_AddStringToObject(root, lf->decoder_info->fields[i], lf->fields[i]);
+        }
+    }
+
+
+
     if (lf->generated_rule->last_events && lf->generated_rule->last_events[1] && lf->generated_rule->last_events[1][0]) {
         cJSON_AddStringToObject(root, "previous_output", lf->generated_rule->last_events[1]);
     }
@@ -185,6 +200,8 @@ char *Archiveinfo_to_jsonstr(const Eventinfo *lf)
 {
     cJSON *root;
     char *out;
+    int i;
+
 
     root = cJSON_CreateObject();
 
@@ -232,6 +249,15 @@ char *Archiveinfo_to_jsonstr(const Eventinfo *lf)
 
    if(lf->data)
        cJSON_AddStringToObject(root, "data", lf->data);
+
+    //Dynamic fields
+    if(lf->decoder_info){
+        //ToDO: use constant instead of 8.
+        for(i=0;i<8;i++){
+            if (lf->decoder_info->fields[i] && lf->fields[i])
+                cJSON_AddStringToObject(root, lf->decoder_info->fields[i], lf->fields[i]);
+        }
+    }
 
    if(lf->systemname)
        cJSON_AddStringToObject(root, "systemname", lf->systemname);

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -124,17 +124,6 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     }
 
 
-    //Dynamic fields
-    if(lf->decoder_info){
-        //ToDO: use constant instead of 8.
-        for(i=0;i<8;i++){
-            if (lf->decoder_info->fields[i] && lf->fields[i])
-                cJSON_AddStringToObject(root, lf->decoder_info->fields[i], lf->fields[i]);
-        }
-    }
-
-
-
     if (lf->generated_rule->last_events && lf->generated_rule->last_events[1] && lf->generated_rule->last_events[1][0]) {
         cJSON_AddStringToObject(root, "previous_output", lf->generated_rule->last_events[1]);
     }
@@ -187,6 +176,35 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if ( lf->systemname ) {
         cJSON_AddStringToObject(root, "systemname", lf->systemname);
     }
+
+    // DecoderInfo
+    if(lf->decoder_info){
+        cJSON *decoder;
+        // Dynamic fields
+        if (lf->decoder_info->fields) {
+            for (i = 0; i < Config.decoder_order_size; i++) {
+                if (lf->decoder_info->fields[i] && lf->fields[i]) {
+                    cJSON_AddStringToObject(root, lf->decoder_info->fields[i], lf->fields[i]);
+                }
+            }
+        }
+
+        cJSON_AddItemToObject(root, "decoder", decoder = cJSON_CreateObject());
+
+        if (lf->decoder_info->fts)
+            cJSON_AddNumberToObject(decoder, "fts", lf->decoder_info->fts);
+        if (lf->decoder_info->accumulate)
+            cJSON_AddNumberToObject(decoder, "accumulate", lf->decoder_info->accumulate);
+
+        if (lf->decoder_info->parent)
+            cJSON_AddStringToObject(decoder, "parent", lf->decoder_info->parent);
+        if (lf->decoder_info->name)
+            cJSON_AddStringToObject(decoder, "name", lf->decoder_info->name);
+        if (lf->decoder_info->ftscomment)
+            cJSON_AddStringToObject(decoder, "ftscomment", lf->decoder_info->ftscomment);
+
+    }
+
 
     W_ParseJSON(root, lf);
 
@@ -249,15 +267,6 @@ char *Archiveinfo_to_jsonstr(const Eventinfo *lf)
 
    if(lf->data)
        cJSON_AddStringToObject(root, "data", lf->data);
-
-    //Dynamic fields
-    if(lf->decoder_info){
-        //ToDO: use constant instead of 8.
-        for(i=0;i<8;i++){
-            if (lf->decoder_info->fields[i] && lf->fields[i])
-                cJSON_AddStringToObject(root, lf->decoder_info->fields[i], lf->fields[i]);
-        }
-    }
 
    if(lf->systemname)
        cJSON_AddStringToObject(root, "systemname", lf->systemname);
@@ -329,6 +338,15 @@ char *Archiveinfo_to_jsonstr(const Eventinfo *lf)
     // DecoderInfo
     if(lf->decoder_info){
         cJSON *decoder;
+        // Dynamic fields
+        if (lf->decoder_info->fields) {
+            for (i = 0; i < Config.decoder_order_size; i++) {
+                if (lf->decoder_info->fields[i] && lf->fields[i]) {
+                    cJSON_AddStringToObject(root, lf->decoder_info->fields[i], lf->fields[i]);
+                }
+            }
+        }
+
         cJSON_AddItemToObject(root, "decoder", decoder = cJSON_CreateObject());
 
         if (lf->decoder_info->fts) 

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 OSSEC Foundation
+/* Copyright (C) 2019 Trend Micro Inc.
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009 Trend Micro Inc.
+/* Copyright (C) 2019 OSSEC Foundation 
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it
@@ -1464,6 +1464,7 @@ RuleInfo *zerorulemember(int id, int level,
     ruleinfo_pt->hostname = NULL;
     ruleinfo_pt->program_name = NULL;
     ruleinfo_pt->action = NULL;
+    os_calloc(Config.decoder_order_size, sizeof(FieldInfo*), ruleinfo_pt->fields);
 
     /* Zero last matched events */
     ruleinfo_pt->__frequency = 0;

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -81,6 +81,8 @@ int Rules_OP_ReadRules(const char *rulefile)
     const char *xml_status = "status";
     const char *xml_action = "action";
     const char *xml_compiled = "compiled_rule";
+    const char *xml_field = "field";
+    const char *xml_name = "name";
 
     const char *xml_list = "list";
     const char *xml_list_lookup = "lookup";
@@ -307,6 +309,7 @@ int Rules_OP_ReadRules(const char *rulefile)
             /* Rule elements block */
             {
                 int k = 0;
+                int ifield = 0;
                 int info_type = 0;
                 int count_info_detail = 0;
                 RuleInfoDetail *last_info_detail = NULL;
@@ -581,6 +584,29 @@ int Rules_OP_ReadRules(const char *rulefile)
                         config_ruleinfo->action =
                             loadmemory(config_ruleinfo->action,
                                        rule_opt[k]->content);
+                    } else if (strcasecmp(rule_opt[k]->element, xml_field) == 0) {
+                        if (rule_opt[k]->attributes[0]) {
+                            os_calloc(1, sizeof(FieldInfo), config_ruleinfo->fields[ifield]);
+
+                            if (strcasecmp(rule_opt[k]->attributes[0], xml_name) == 0) {
+                                config_ruleinfo->fields[ifield]->name = loadmemory(config_ruleinfo->fields[ifield]->name, rule_opt[k]->values[0]);
+                            } else {
+                                merror("%s: Bad attribute '%s' for field.", ARGV0, rule_opt[k]->attributes[0]);
+                                return -1;
+                            }
+                        } else {
+                            merror("%s: No such attribute '%s' for field.", ARGV0, xml_name);
+                            return (-1);
+                        }
+
+                        os_calloc(1, sizeof(OSRegex), config_ruleinfo->fields[ifield]->regex);
+
+                        if (!OSRegex_Compile(rule_opt[k]->content, config_ruleinfo->fields[ifield]->regex, 0)) {
+                            merror(REGEX_COMPILE, ARGV0, rule_opt[k]->content, config_ruleinfo->fields[ifield]->regex->error);
+                            return -1;
+                        }
+
+                        ifield++;
                     } else if (strcasecmp(rule_opt[k]->element, xml_list) == 0) {
                         debug1("-> %s == %s", rule_opt[k]->element, xml_list);
                         if (rule_opt[k]->attributes && rule_opt[k]->values && rule_opt[k]->content) {
@@ -956,6 +982,9 @@ int Rules_OP_ReadRules(const char *rulefile)
                         OS_ClearXML(&xml);
                         return (-1);
                     }
+
+
+
                     k++;
                 }
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 OSSEC Foundation 
+/* Copyright (C) 2019 Trend Micro Inc.
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 OSSEC Foundation 
+/* Copyright (C) 2019 Trend Micro Inc. 
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -1,5 +1,5 @@
-/* Copyright (C) 2009 Trend Micro Inc.
- * All right reserved.
+/* Copyright (C) 2019 OSSEC Foundation 
+ * All rights reserved.
  *
  * This program is a free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
@@ -148,7 +148,8 @@ typedef struct _RuleInfo {
     OSMatch *hostname;
     OSMatch *program_name;
     OSMatch *extra_data;
-    FieldInfo *fields[8];
+    FieldInfo **fields;
+
     char *action;
 
     char *comment; /* description in the xml */

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -72,6 +72,11 @@ typedef struct _RuleInfoDetail {
     struct _RuleInfoDetail *next;
 } RuleInfoDetail;
 
+typedef struct _FieldInfo {
+    char *name;
+    OSRegex *regex;
+} FieldInfo;
+
 typedef struct _RuleInfo {
     int sigid;  /* id attribute -- required*/
     int level;  /* level attribute --required */
@@ -143,6 +148,7 @@ typedef struct _RuleInfo {
     OSMatch *hostname;
     OSMatch *program_name;
     OSMatch *extra_data;
+    FieldInfo *fields[8];
     char *action;
 
     char *comment; /* description in the xml */

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 OSSEC Foundation
+/* Copyright (C) 2019 Trend Micro Inc.
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009 Trend Micro Inc.
+/* Copyright (C) 2019 OSSEC Foundation
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it
@@ -184,6 +184,8 @@ int main(int argc, char **argv)
         ErrorExit(CHROOT_ERROR, ARGV0, dir, errno, strerror(errno));
     }
     nowChroot();
+
+    Config.decoder_order_size = (size_t)getDefine_Int("analysisd", "decoder_order_size", 8, MAX_DECODER_ORDER_SIZE);
 
     /*
      * Anonymous Section: Load rules, decoders, and lists

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -25,6 +25,7 @@ typedef struct __Config {
     u_int8_t mailbylevel;
     u_int8_t logbylevel;
     u_int8_t logfw;
+    int decoder_order_size;
 
     /* Prelude support */
     u_int8_t prelude;


### PR DESCRIPTION
Adding support for dynamically defined decoder & rules. 

example in a decoder:
        <regex>From (\.+): \.+ (/\S+)[(\S+)] uid/euid:(\d+)/(\d+) gid/egid:(\d+)/(\d+), parent (\S+) \S+:(\d+)/(\d+) \S+:(\d+)/(\d+)</regex>

        <order>srcip, grsecurity.command.by,grsecurity.processid,grsecurity.uid,grsecurity.euid,grsecurity.gid,grsecurity.egid,grsecurity.parent.process,grsecurity.parent.uid,grsecurity.parent.euid,grsecurity.parent.gid,grsecurity.parent.egid</order>


New internal config option:
analysisd.decoder_order_size