### PR TITLE
Fixes a segnetation fault in a paticular overwrite

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -1447,8 +1447,10 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
     /* If it is a context rule, search for it */
     if (rule->context == 1) {
         if (!(rule->context_opts & SAME_DODIFF)) {
-            if (!rule->event_search(lf, rule)) {
-                return (NULL);
+            if (rule->event_search) {
+                if (!rule->event_search(lf, rule)) {
+                    return (NULL);
+                }
             }
         }
     }


### PR DESCRIPTION
when used to overwrite an existing rule


Original: Vikman Fdez-Castro

Signed-off-by: Scott R. Shinn <scott@atomicorp.com>