### PR TITLE
Fixes the size returned from a syslog tcp packet event

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -530,7 +530,7 @@ int OS_RecvTCPBuffer(int socket, char *buffer, int sizet)
 
     if ((retsize = recv(socket, buffer, sizet - 1, 0)) > 0) {
         buffer[retsize] = '\0';
-        return (0);
+        return (retsize);
     }
     return (-1);
 }


### PR DESCRIPTION
Signed-off-by: Scott R. Shinn <scott@atomicorp.com>