### PR TITLE
fix(maild): email messages are sent infinitely

### DIFF
--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -258,6 +258,7 @@ static void OS_Run(MailConfig *mail)
                 goto snd_check_hour;
             }
 
+            fflush(fileq->fp);
             pid = fork();
             if (pid < 0) {
                 merror(FORK_ERROR, ARGV0, errno, strerror(errno));


### PR DESCRIPTION
Hi there

First of all, I'd like to thank you for such a wonderful tool.

In my environment, email messages are sent infinitely when multiple alerts are detected in a short period of time.

The following is the mail related setting.

```
  <global>
    <email_notification>yes</email_notification>
    <email_to>knqyf263@gmail.com</email_to>
    <smtp_server>127.0.0.1</smtp_server>
    <email_from>ossecm@localhost</email_from>
    <logall>yes</logall>
    <email_maxperhour>9999</email_maxperhour>
  </global>

  <email_alerts>
    <email_to>knqyf263@gmail.com</email_to>
    <event_location>192.168.33.2</event_location>
    <do_not_delay />
    <do_not_group />
  </email_alerts>

  <alerts>
    <log_alert_level>1</log_alert_level>
    <email_alert_level>5</email_alert_level>
  </alerts>
```

After debugging, I noticed that the position of `fp` used in GetAlertData of `read-alert.c` sometimes went to the beginning of a file.

I further investigated and found that `fp` was changed when the forked child process exited after `OS_Sendmail` of `maild.c`.

Then, I found this issue. Looking at the answer, this is not a bug of libc.
https://sourceware.org/bugzilla/show_bug.cgi?id=23151

Here are some excerpts from the relevant section
http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_05_01
>If the stream is open with a mode that allows reading and the underlying open file description refers to a device that is capable of seeking, the application shall either perform an fflush(), or the stream shall be closed.

After adding `fflush()` before `fork`, this problem no longer reproduces.

Thanks.