### PR TITLE
Corrected check values

### DIFF
--- a/src/rootcheck/db/cis_win10_enterprise_L1_rcl.txt
+++ b/src/rootcheck/db/cis_win10_enterprise_L1_rcl.txt
@@ -219,7 +219,7 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> EveryoneIncludesAno
 #
 #2.3.10.6 Ensure 'Network access: Named Pipes that can be accessed anonymously' is set to 'None'
 [CIS - Microsoft Windows 10 - 2.3.10.6 Ensure 'Network access: Named Pipes that can be accessed anonymously' is set to 'None'] [any] [https://workbench.cisecurity.org/benchmarks/766]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> r:\.;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> r:\S*;
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> !NullSessionPipes;
 #
 #
@@ -247,7 +247,7 @@ r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> restrictremotesam -
 #
 #2.3.10.11 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'
 [CIS - Microsoft Windows 10 - 2.3.10.11 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'] [any] [https://workbench.cisecurity.org/benchmarks/766]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\.+;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\S*;
 #
 #
 #2.3.10.12 Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'

--- a/src/rootcheck/db/cis_win2012r2_domainL1_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_domainL1_rcl.txt
@@ -266,7 +266,7 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -
 #
 #2.3.10.10 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'
 [CIS - Microsoft Windows Server 2012 R2 - 2.3.10.10: Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\.+;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\S*;
 #
 #
 #2.3.10.11 Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'

--- a/src/rootcheck/db/cis_win2012r2_memberL1_rcl.txt
+++ b/src/rootcheck/db/cis_win2012r2_memberL1_rcl.txt
@@ -250,7 +250,7 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> EveryoneIncludesAno
 #
 #2.3.10.6 Configure 'Network access: Named Pipes that can be accessed anonymously'
 [CIS - Microsoft Windows Server 2012 R2 - 2.3.10.6: Configure 'Network access: Named Pipes that can be accessed anonymously'] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> r:\.;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> r:\S*;
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> !NullSessionPipes;
 #
 #
@@ -271,7 +271,7 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -
 #
 #2.3.10.10 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'
 [CIS - Microsoft Windows Server 2012 R2 - 2.3.10.10: Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'] [any] [https://workbench.cisecurity.org/benchmarks/288]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\.+;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\S*;
 #
 #
 #2.3.10.11 Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'

--- a/src/rootcheck/db/cis_win2016_domainL1_rcl.txt
+++ b/src/rootcheck/db/cis_win2016_domainL1_rcl.txt
@@ -242,7 +242,7 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -
 #2.3.10.11 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'
 [CIS - Microsoft Windows Server 2016 - 2.3.10.11 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'] [any] [https://workbench.cisecurity.org/benchmarks/515]
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\S*;
-#.+
+#
 #
 #2.3.10.12 Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'
 [CIS - Microsoft Windows Server 2016 - 2.3.10.12 Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'] [any] [https://workbench.cisecurity.org/benchmarks/515]

--- a/src/rootcheck/db/cis_win2016_domainL1_rcl.txt
+++ b/src/rootcheck/db/cis_win2016_domainL1_rcl.txt
@@ -241,8 +241,8 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -
 #
 #2.3.10.11 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'
 [CIS - Microsoft Windows Server 2016 - 2.3.10.11 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'] [any] [https://workbench.cisecurity.org/benchmarks/515]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\.+;
-#
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\S*;
+#.+
 #
 #2.3.10.12 Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'
 [CIS - Microsoft Windows Server 2016 - 2.3.10.12 Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'] [any] [https://workbench.cisecurity.org/benchmarks/515]

--- a/src/rootcheck/db/cis_win2016_memberL1_rcl.txt
+++ b/src/rootcheck/db/cis_win2016_memberL1_rcl.txt
@@ -229,7 +229,7 @@ r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa -> EveryoneIncludesAno
 #
 #2.3.10.6 Configure 'Network access: Named Pipes that can be accessed anonymously'
 [CIS - Microsoft Windows Server 2016 - 2.3.10.6 Configure 'Network access: Named Pipes that can be accessed anonymously'] [any] [https://workbench.cisecurity.org/benchmarks/515]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> r:\.;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionPipes -> r:\S*;
 r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> !NullSessionPipes;
 #
 #
@@ -255,7 +255,7 @@ r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa -> restrictremotesam -
 #
 #2.3.10.11 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'
 [CIS - Microsoft Windows Server 2016 - 2.3.10.11 Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'] [any] [https://workbench.cisecurity.org/benchmarks/515]
-r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\.+;
+r:HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters -> NullSessionShares -> r:\S*;
 #
 #
 #2.3.10.12 Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'


### PR DESCRIPTION
Corrected check value for NullSessionShares at all windows member_L1 and domain_L1 rootchecks and NullSessionPipes for rootchecks at all member_L1 and windows 10 L1 rootchecks.

This registry values should be empty regarding to CIS. Empty registry values seems to be filled with spaces (could somebody confirm this behavior?). So ossec should alert if there is anything not spaces within.