### PR TITLE
Update info links in Windows rules

### DIFF
--- a/etc/rules/msauth_rules.xml
+++ b/etc/rules/msauth_rules.xml
@@ -204,7 +204,7 @@
     <if_sid>18106</if_sid>
     <id>^529$|^4625$</id>
     <description>Logon Failure - Unknown user or bad password.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/events/com190.html</info>
+    <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4625</info>
     <group>win_authentication_failed,</group>
   </rule>
 

--- a/etc/rules/msauth_rules.xml
+++ b/etc/rules/msauth_rules.xml
@@ -123,7 +123,7 @@
     <if_sid>18104</if_sid>
     <id>^640$</id>
     <description>General account database changed.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/events/com259.html</info>
+    <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=640</info>
     <group>adduser,account_changed,</group>
   </rule>
   
@@ -213,7 +213,7 @@
     <id>^530$</id>
     <description>Logon Failure - Account logon time restriction </description>
     <description>violation.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/events/com191.html</info>
+    <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=530</info>
     <group>win_authentication_failed,login_denied,</group>
   </rule>
 
@@ -221,7 +221,7 @@
     <if_sid>18106</if_sid>
     <id>^531$</id>
     <description>Logon Failure - Account currently disabled.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/events/com192.html</info>
+    <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=531</info>
     <group>win_authentication_failed,login_denied,</group>
   </rule>
 
@@ -229,7 +229,7 @@
     <if_sid>18106</if_sid>
     <id>^532$</id>
     <description>Logon Failure - Specified account expired.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/events/com193.html</info>
+    <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=532</info>
     <group>win_authentication_failed,login_denied,</group>
   </rule>
 
@@ -238,7 +238,7 @@
     <id>^533$</id>
     <description>Logon Failure - User not allowed to login at </description>
     <description>this computer.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/events/com194.html</info>
+    <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=533</info>
     <group>win_authentication_failed,login_denied,</group>
   </rule>
 
@@ -246,7 +246,7 @@
     <if_sid>18106</if_sid>
     <id>^534$</id>
     <description>Logon Failure - User not granted logon type.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/events/com195.html</info>
+    <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=534</info>
     <group>win_authentication_failed,</group>
   </rule>
   
@@ -254,7 +254,7 @@
     <if_sid>18106</if_sid>
     <id>^535$</id>
     <description>Logon Failure - Account's password expired.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/events/com196.html</info>
+    <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=535</info>
     <group>win_authentication_failed,</group>
   </rule>
 
@@ -298,7 +298,7 @@
     <if_sid>18104</if_sid>
     <id>^671$|^4767$</id>
     <description>User account unlocked.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/events/com291.html</info>
+    <info type="link">https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4767</info>
     <group>account_changed,</group>
   </rule>
 
@@ -848,7 +848,7 @@
     <match>Failure Code: 0x1F</match>
     <description>Windows DC integrity check on decrypted </description>
     <description>field failed.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/kerberrors.html</info>
+    <!--<info type="link">http://www.ultimatewindowssecurity.com/kerberrors.html</info>-->
     <group>win_authentication_failed,attacks,</group>
   </rule>
   
@@ -856,7 +856,7 @@
     <if_sid>18139</if_sid>
     <match>Failure Code: 0x22</match>
     <description>Windows DC - Possible replay attack.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/kerberrors.html</info>
+    <!--<info type="link">http://www.ultimatewindowssecurity.com/kerberrors.html</info>-->
     <group>win_authentication_failed,attacks,</group>
   </rule>
 
@@ -864,7 +864,7 @@
     <if_sid>18139</if_sid>
     <match>Failure Code: 0x25</match>
     <description>Windows DC - Clock skew too great.</description>
-    <info type="link">http://www.ultimatewindowssecurity.com/kerberrors.html</info>
+    <!--<info type="link">http://www.ultimatewindowssecurity.com/kerberrors.html</info>-->
     <group>win_authentication_failed,attacks,</group>
   </rule>
 


### PR DESCRIPTION
Some of the UltimateWindowsSecurity links were outdated, so they have been updated.
A link to kerberos errors 404s now, and I haven't found a good replacement. Suggestions welcome. It has been removed until a replacement is found.