### PR TITLE
Fix issue when compiling with PCRE2_SYSTEM=yes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -685,7 +685,11 @@ winagent:
 ####################
 
 .PHONY: external lua
+ifeq (${PCRE2_SYSTEM},no)
 external: libcJSON.a ${EXTERNAL_ZLIB}libz.a lua libpcre2-8.a
+else
+external: libcJSON.a ${EXTERNAL_ZLIB}libz.a lua
+endif
 
 lua:
 ifeq (${LUA_ENABLE},yes)
@@ -767,10 +771,6 @@ else
 		--enable-static && \
 	make install-libLTLIBRARIES install-nodist_includeHEADERS
 endif
-else
-libpcre2-8.a: ${PCRE2_LOCATION}/libpcre2-8.a
-	cp $< $@
-	${OSSEC_RANLIB} $@
 endif
 
 
@@ -801,11 +801,17 @@ os_regex_o := $(os_regex_c:.c=.o)
 os_regex/%.o: os_regex/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -c $^ -o $@
 
+ifeq (${PCRE2_SYSTEM},no)
 os_regex.a: ${os_regex_o} libpcre2-8.a
 	(mkdir -p libpcre2_objs && cd libpcre2_objs && ${QUIET_LINK}${MING_BASE}ar -x ../libpcre2-8.a)
 	${OSSEC_LINK} $@ ${os_regex_o} $(addprefix libpcre2_objs/,$(shell ${MING_BASE}ar -t libpcre2-8.a))
 	${OSSEC_RANLIB} $@
 	rm -rf libpcre2_objs
+else
+os_regex.a: ${os_regex_o}
+	${OSSEC_LINK} $@ $^
+	${OSSEC_RANLIB} $@
+endif
 
 #### os_net ##########
 


### PR DESCRIPTION
Fix part of issue [#1663](https://github.com/ossec/ossec-hids/issues/1663), 
The use of flag PCRE2_SYSTEM was not completely handled. 