### PR TITLE
Fix for filename in new/delete active response

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -256,6 +256,11 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
 
     FILE *fp;
 
+    /* Expose filename variable for active response */
+    os_strdup(f_name, lf->filename);
+
+
+
     /* Get db pointer */
     fp = DB_File(lf->location, &agent_id);
     if (!fp) {
@@ -324,6 +329,9 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
             lf->data = NULL;
             return (0);
         }
+
+
+
 
         /* If we reached here, the checksum of the file has changed */
         if (saved_sum[-3] == '!') {
@@ -545,7 +553,6 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
                 os_strdup(oldsha1, lf->sha1_before);
                 os_strdup(newsha1, lf->sha1_after);
             }
-            os_strdup(f_name, lf->filename);
 
             /* Provide information about the file */
             snprintf(sdb.comment, OS_MAXSTR, "Integrity checksum changed for: "
@@ -597,6 +604,7 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
         snprintf(sdb.comment, OS_MAXSTR,
                  "New file '%.756s' "
                  "added to the file system.", f_name);
+
 
         /* Create a new log message */
         free(lf->full_log);


### PR DESCRIPTION
Exposes the filename (<expect>filename</expect>) variable in active response for events of all
types:

* Add
* Delete
* Modify

Previously this would only be exposed for modify events.  

Example:
Thu Apr 18 17:20:31 EDT 2019 /var/ossec/active-response/bin/syscheck-api.sh add - - 1555622431.75505 550 field6(syscheck) Filename: (/mnt/test-1555622360) field8() field9() field10(add0)

Thu Apr 18 17:20:41 EDT 2019 /var/ossec/active-response/bin/syscheck-api.sh add - - 1555622441.76244 553 field6(syscheck) Filename: (/mnt/test-1555622360) field8() field9() field10(add0)

Thu Apr 18 17:20:32 EDT 2019 /var/ossec/active-response/bin/syscheck-api.sh add - - 1555622432.76025 554 field6(syscheck) Filename: (/mnt/test-1555622418) field8() field9() field10(add0)

Signed-off-by: Scott R. Shinn <scott@atomicorp.com>