### PR TITLE
Fix for agentd/maild when ipv6 is disabled and/or hostnames are used instead of IPs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ matrix:
 
 before_script:
 - sudo apt-get update -qq
+- sudo apt-get install -y libevent-dev
 - ( wget https://ftp.pcre.org/pub/pcre/pcre2-10.32.tar.gz
   && tar xzf pcre2-10.32.tar.gz -C src/external )
 - if [[ "${GEOIP}" == "yes"  ]]; then ( sudo apt-get install geoip-bin geoip-database libgeoip-dev libgeoip1 ); fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -128,7 +128,7 @@ endif # winagent
 
 ## OpenBSD doesn't need the imsg stuff.
 ifneq (${uname_S},OpenBSD)
-        COMPAT_CFLAGS+=-I./external/compat
+        CFLAGS+=-I./external/compat
         COMPAT_FILES+=./external/compat/imsg.c ./external/compat/imsg-buffer.c
 endif
 
@@ -826,7 +826,7 @@ os_net_c := $(wildcard os_net/*.c)
 os_net_o := $(os_net_c:.c=.o)
 
 os_net/%.o: os_net/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} $(COMPAT_CFLAGS) -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS}  -c $^ -o $@
 
 os_net.a: ${os_net_o}
 	${OSSEC_LINK} $@ $^
@@ -838,7 +838,7 @@ shared_c := $(wildcard shared/*.c)
 shared_o := $(shared_c:.c=.o)
 
 shared/%.o: shared/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} $(COMPAT_CFLAGS) -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS}  -c $^ -o $@
 
 shared.a: ${shared_o}
 	${OSSEC_LINK} $@ $^
@@ -850,7 +850,7 @@ config_c := $(wildcard config/*.c)
 config_o := $(config_c:.c=.o)
 
 config/%.o: config/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} $(COMPAT_CFLAGS) -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS}  -c $^ -o $@
 
 config.a: ${config_o}
 	${OSSEC_LINK} $@ $^
@@ -909,7 +909,7 @@ os_dns_c := $(wildcard os_dns/*.c)
 os_dns_o := $(os_dns_c:.c=.o)
 
 os_dns/os_dns.o: os_dns/os_dns.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I/usr/local/include ${COMPAT_CFLAGS} -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I/usr/local/include -c $^ -o $@
 endif
 
 #### os_mail #########
@@ -964,7 +964,7 @@ os_execd_c := $(wildcard os_execd/*.c)
 os_execd_o := $(os_execd_c:.c=.o)
 
 os_execd/%.o: os_execd/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} $(COMPAT_CFLAGS) -DARGV0=\"ossec-execd\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS}  -DARGV0=\"ossec-execd\" -c $^ -o $@
 
 ossec-execd: ${os_execd_o} ${ossec_libs} ${JSON_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${JSON_INCLUDE} $^ -lm ${OSSEC_LDFLAGS} -o $@
@@ -1006,7 +1006,7 @@ endif
 client_agent_o := $(client_agent_c:.c=.o)
 
 client-agent/%.o: client-agent/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I./client-agent $(COMPAT_CFLAGS) ${ZLIB_INCLUDE} -DARGV0=\"ossec-agentd\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I./client-agent  ${ZLIB_INCLUDE} -DARGV0=\"ossec-agentd\" -c $^ -o $@
 
 ossec-agentd: ${client_agent_o} ${ossec_libs} ${ZLIB_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} ${DNS_CFLAGS} -levent ${COMPAT_FILES} -o $@
@@ -1131,7 +1131,7 @@ os_auth_c := ${wildcard os_auth/*.c}
 os_auth_o := $(os_auth_c:.c=.o)
 
 os_auth/%.o: os_auth/%.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} $(COMPAT_CFLAGS) -I./os_auth -DARGV0=\"ossec-authd\" -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS}  -I./os_auth -DARGV0=\"ossec-authd\" -c $^ -o $@
 
 agent-auth: addagent/validate.o os_auth/main-client.o os_auth/ssl.o os_auth/check_cert.o ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${JSON_INCLUDE} -I./os_auth $^ ${OSSEC_LDFLAGS} -o $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,6 +104,7 @@ else
 ifeq (${uname_S},OpenBSD)
 #		DEFINES+=-DOpenBSD
 		DEFINES+=-pthread
+		CFLAGS+=-lutil
 		LUA_PLAT=posix
 		CFLAGS+=-I/usr/local/include
 		OSSEC_LDFLAGS+=-L/usr/local/lib
@@ -919,7 +920,7 @@ os_maild/%.o: os_maild/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-maild\" -c $^ -o $@
 
 ossec-maild: ${os_maild_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -levent ${COMPAT_FILES} -o $@
 
 #### os_dbd ##########
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -125,6 +125,12 @@ endif # AIX
 endif # Linux
 endif # winagent
 
+## OpenBSD doesn't need the imsg stuff.
+ifneq (${uname_S},OpenBSD)
+        COMPAT_CFLAGS+=-I./external/compat
+        COMPAT_FILES+=./external/compat/imsg.c ./external/compat/imsg-buffer.c
+endif
+
 ifdef DEBUGAD
 	DEFINES+=+DDEBUGAD
 endif
@@ -895,10 +901,18 @@ os_crypto.a: ${crypto_o}
 	${OSSEC_LINK} $@ $^
 	${OSSEC_RANLIB} $@
 
+#### os_dns ########
+
+os_dns_c := $(wildcard os_dns/*.c)
+os_dns_o := $(os_dns_c:.c=.o)
+
+os_dns/os_dns.o: os_dns/os_dns.c
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I/usr/local/include ${COMPAT_CFLAGS} -lutil -levent -c $^ -o $@
+
 
 #### os_mail #########
 
-os_maild_c := $(wildcard os_maild/*.c)
+os_maild_c := $(wildcard os_maild/*.c) $(wildcard os_dns/*.c)
 os_maild_o := $(os_maild_c:.c=.o)
 
 os_maild/%.o: os_maild/%.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -904,12 +904,13 @@ os_crypto.a: ${crypto_o}
 
 #### os_dns ########
 
+ifneq (${TARGET},winagent)
 os_dns_c := $(wildcard os_dns/*.c)
 os_dns_o := $(os_dns_c:.c=.o)
 
 os_dns/os_dns.o: os_dns/os_dns.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I/usr/local/include ${COMPAT_CFLAGS} -c $^ -o $@
-
+endif
 
 #### os_mail #########
 
@@ -997,7 +998,11 @@ ossec-remoted: ${remoted_o} ${ossec_libs} ${ZLIB_LIB}
 
 #### ossec-agentd ####
 
+ifneq (${TARGET},winagent)
 client_agent_c := $(wildcard client-agent/*.c)  $(wildcard os_dns/*.c)
+else
+client_agent_c := $(wildcard client-agent/*.c)
+endif
 client_agent_o := $(client_agent_c:.c=.o)
 
 client-agent/%.o: client-agent/%.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,7 +104,7 @@ else
 ifeq (${uname_S},OpenBSD)
 #		DEFINES+=-DOpenBSD
 		DEFINES+=-pthread
-		CFLAGS+=-lutil
+		DNS_CFLAGS+=-lutil
 		LUA_PLAT=posix
 		CFLAGS+=-I/usr/local/include
 		OSSEC_LDFLAGS+=-L/usr/local/lib
@@ -908,7 +908,7 @@ os_dns_c := $(wildcard os_dns/*.c)
 os_dns_o := $(os_dns_c:.c=.o)
 
 os_dns/os_dns.o: os_dns/os_dns.c
-	${OSSEC_CC} ${OSSEC_CFLAGS} -I/usr/local/include ${COMPAT_CFLAGS} -lutil -levent -c $^ -o $@
+	${OSSEC_CC} ${OSSEC_CFLAGS} -I/usr/local/include ${COMPAT_CFLAGS} -c $^ -o $@
 
 
 #### os_mail #########
@@ -920,7 +920,7 @@ os_maild/%.o: os_maild/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -DARGV0=\"ossec-maild\" -c $^ -o $@
 
 ossec-maild: ${os_maild_o} ${ossec_libs}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} -levent ${COMPAT_FILES} -o $@
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} $^ ${OSSEC_LDFLAGS} ${DNS_CFLAGS} -levent ${COMPAT_FILES} -o $@
 
 #### os_dbd ##########
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ EXTERNAL_LUA=external/lua-5.2.3/
 EXTERNAL_ZLIB=external/zlib-1.2.11/
 EXTERNAL_PCRE2=external/pcre2-10.32/
 ZLIB_SYSTEM?=yes
-PCRE2_SYSTEM?=no
+PCRE2_SYSTEM?=yes
 LUA_PLAT=posix
 LUA_ENABLE?=no
 MAXAGENTS?=2048
@@ -28,7 +28,8 @@ USE_PRELUDE?=no
 USE_ZEROMQ?=no
 USE_GEOIP?=no
 USE_INOTIFY=no
-USE_PCRE2_JIT=yes
+USE_PCRE2_JIT=no
+DEBUG=yes
 
 ifneq (${TARGET},winagent)
 	USE_OPENSSL?=auto

--- a/src/Makefile
+++ b/src/Makefile
@@ -997,14 +997,14 @@ ossec-remoted: ${remoted_o} ${ossec_libs} ${ZLIB_LIB}
 
 #### ossec-agentd ####
 
-client_agent_c := $(wildcard client-agent/*.c)
+client_agent_c := $(wildcard client-agent/*.c)  $(wildcard os_dns/*.c)
 client_agent_o := $(client_agent_c:.c=.o)
 
 client-agent/%.o: client-agent/%.c
 	${OSSEC_CC} ${OSSEC_CFLAGS} -I./client-agent ${ZLIB_INCLUDE} -DARGV0=\"ossec-agentd\" -c $^ -o $@
 
 ossec-agentd: ${client_agent_o} ${ossec_libs} ${ZLIB_LIB}
-	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} -o $@
+	${OSSEC_CCBIN} ${OSSEC_CFLAGS} ${ZLIB_INCLUDE} $^ ${OSSEC_LDFLAGS} ${DNS_CFLAGS} -levent ${COMPAT_FILES} -o $@
 
 #### addagent ######
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ EXTERNAL_LUA=external/lua-5.2.3/
 EXTERNAL_ZLIB=external/zlib-1.2.11/
 EXTERNAL_PCRE2=external/pcre2-10.32/
 ZLIB_SYSTEM?=yes
-PCRE2_SYSTEM?=yes
+PCRE2_SYSTEM?=no
 LUA_PLAT=posix
 LUA_ENABLE?=no
 MAXAGENTS?=2048
@@ -29,8 +29,7 @@ USE_PRELUDE?=no
 USE_ZEROMQ?=no
 USE_GEOIP?=no
 USE_INOTIFY=no
-USE_PCRE2_JIT=no
-DEBUG=yes
+USE_PCRE2_JIT=yes
 
 ifneq (${TARGET},winagent)
 	USE_OPENSSL?=auto

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -11,6 +11,9 @@
 #include "agentd.h"
 #include "os_net/os_net.h"
 
+#ifndef WIN32
+#include "os_dns/os_dns.h"
+#endif //WIN32
 
 /* Start the agent daemon */
 void AgentdStart(const char *dir, int uid, int gid, const char *user, const char *group)
@@ -30,6 +33,36 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
         nowDaemon();
         goDaemon();
     }
+
+#ifndef WIN32
+    /* Prepare for os_dns */
+    struct imsgbuf osdns_ibuf;
+    int imsg_fds[2];
+    if ((socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC, imsg_fds)) == -1) {
+        ErrorExit("%s: ERROR: Could not create socket pair.", ARGV0);
+    }
+    if (setnonblock(imsg_fds[0]) < 0) {
+        ErrorExit("%s: ERROR: Could not set imsg_fds[0] to nonblock", ARGV0);
+    }
+    if (setnonblock(imsg_fds[1]) < 0) {
+        ErrorExit("%s: ERROR: Could not set imsg_fds[1] to nonblock", ARGV0);
+    }
+
+    /* Fork os_dns process */
+    switch(fork()) {
+        case -1:
+            ErrorExit("%s: ERROR: Cannot fork() os_dns process", ARGV0);
+        case 0:
+            close(imsg_fds[0]);
+            imsg_init(&osdns_ibuf, imsg_fds[1]);
+            exit(osdns(&osdns_ibuf, ARGV0));
+    }
+
+    /* Setup imsg for the rest of agentd */
+    close(imsg_fds[1]);
+    imsg_init(&agt->ibuf, imsg_fds[1]);
+
+#endif  //WIN32
 
     /* Set group ID */
     if (Privsep_SetGroup(gid) < 0) {

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -115,7 +115,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     }
 
     /* Try to connect to the server */
-    if (!connect_server(0, server_ibuf)) {
+    if (!connect_server(0, &server_ibuf)) {
         ErrorExit(UNABLE_CONN, ARGV0);
     }
 
@@ -136,7 +136,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     /* Try to connect to server */
     os_setwait();
 
-    start_agent(1, server_ibuf);
+    start_agent(1, &server_ibuf);
 
     os_delwait();
 
@@ -148,7 +148,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
 #ifdef WIN32
     run_notify();
 #else
-    run_notify(server_ibuf);
+    run_notify(&server_ibuf);
 #endif //WIN32
 
     /* Maxfd must be higher socket +1 */
@@ -168,7 +168,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
 #ifdef WIN32
         run_notify();
 #else
-        run_notify(server_ibuf);
+        run_notify(&server_ibuf);
 #endif //WIN32
 
         /* Wait with a timeout for any descriptor */
@@ -189,7 +189,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
 #ifdef WIN32
             EventForward();
 #else
-            EventForward(server_ibuf);
+            EventForward(&server_ibuf);
 #endif
         }
     }

--- a/src/client-agent/agentd.c
+++ b/src/client-agent/agentd.c
@@ -36,7 +36,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
 
 #ifndef WIN32
     /* Prepare for os_dns */
-    struct imsgbuf osdns_ibuf;
+    struct imsgbuf osdns_ibuf, server_ibuf;
     int imsg_fds[2];
     if ((socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC, imsg_fds)) == -1) {
         ErrorExit("%s: ERROR: Could not create socket pair.", ARGV0);
@@ -60,7 +60,8 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
 
     /* Setup imsg for the rest of agentd */
     close(imsg_fds[1]);
-    imsg_init(&agt->ibuf, imsg_fds[1]);
+    //imsg_init(&agt->ibuf, imsg_fds[1]);
+    imsg_init(&server_ibuf, imsg_fds[1]);
 
 #endif  //WIN32
 
@@ -114,7 +115,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     }
 
     /* Try to connect to the server */
-    if (!connect_server(0)) {
+    if (!connect_server(0, server_ibuf)) {
         ErrorExit(UNABLE_CONN, ARGV0);
     }
 
@@ -135,7 +136,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     /* Try to connect to server */
     os_setwait();
 
-    start_agent(1);
+    start_agent(1, server_ibuf);
 
     os_delwait();
 
@@ -144,7 +145,11 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
     intcheck_file(OSSEC_DEFINES, dir);
 
     /* Send first notification */
+#ifdef WIN32
     run_notify();
+#else
+    run_notify(server_ibuf);
+#endif //WIN32
 
     /* Maxfd must be higher socket +1 */
     maxfd++;
@@ -160,7 +165,11 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
         fdtimeout.tv_usec = 0;
 
         /* Continuously send notifications */
+#ifdef WIN32
         run_notify();
+#else
+        run_notify(server_ibuf);
+#endif //WIN32
 
         /* Wait with a timeout for any descriptor */
         rc = select(maxfd, &fdset, NULL, NULL, &fdtimeout);
@@ -177,7 +186,11 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
 
         /* For the forwarder */
         if (FD_ISSET(agt->m_queue, &fdset)) {
+#ifdef WIN32
             EventForward();
+#else
+            EventForward(server_ibuf);
+#endif
         }
     }
 }

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -29,7 +29,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
 #ifdef WIN32
 void *EventForward(void);
 #else
-void *EventForward(struct imsgbuf *ibuf);
+void *EventForward(void);
 #endif //WIN32
 
 /* Receiver messages */
@@ -51,21 +51,21 @@ char *getsharedfiles(void);
 #ifdef WIN32
 void start_agent(int is_startup);
 #else
-void start_agent(int is_startup, struct imsgbuf *ibuf);
+void start_agent(int is_startup);
 #endif
 
 /* Connect to the server */
 #ifdef WIN32
 int connect_server(int initial_id);
 #else
-int connect_server(int initial_id, struct imsgbuf *ibuf);
+int connect_server(int initial_id);
 #endif
 
 /* Notify server */
 #ifdef WIN32
 void run_notify(void);
 #else
-void run_notify(struct imsgbuf *ibuf);
+void run_notify(void);
 #endif
 
 /* libevent callback */
@@ -82,6 +82,9 @@ extern time_t available_server;
 extern int run_foreground;
 extern keystore keys;
 extern agent *agt;
+#ifndef WIN32
+struct imsgbuf server_ibuf;
+#endif //WIN32
 
 #endif /* __AGENTD_H */
 

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -48,6 +48,9 @@ int connect_server(int initial_id);
 /* Notify server */
 void run_notify(void);
 
+/* libevent callback */
+void os_agent_cb(int fd, short ev, void *arg);
+
 /*** Global variables ***/
 
 /* Global variables. Only modified during startup. */

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -13,6 +13,10 @@
 #include "config/config.h"
 #include "config/client-config.h"
 
+#ifndef WIN32
+#include <imsg.h>
+#endif //WIN32
+
 /*** Function Prototypes ***/
 
 /* Client configuration */
@@ -22,7 +26,11 @@ int ClientConf(const char *cfgfile);
 void AgentdStart(const char *dir, int uid, int gid, const char *user, const char *group) __attribute__((noreturn));
 
 /* Event Forwarder */
+#ifdef WIN32
 void *EventForward(void);
+#else
+void *EventForward(struct imsgbuf ibuf);
+#endif //WIN32
 
 /* Receiver messages */
 void *receive_msg(void);
@@ -40,13 +48,25 @@ int send_msg(int agentid, const char *msg);
 char *getsharedfiles(void);
 
 /* Initialize handshake to server */
+#ifdef WIN32
 void start_agent(int is_startup);
+#else
+void start_agent(int is_startup, struct imsgbuf ibuf);
+#endif
 
 /* Connect to the server */
+#ifdef WIN32
 int connect_server(int initial_id);
+#else
+int connect_server(int initial_id, struct imsgbuf ibuf);
+#endif
 
 /* Notify server */
+#ifdef WIN32
 void run_notify(void);
+#else
+void run_notify(struct imsgbuf ibuf);
+#endif
 
 /* libevent callback */
 void os_agent_cb(int fd, short ev, void *arg);

--- a/src/client-agent/agentd.h
+++ b/src/client-agent/agentd.h
@@ -29,7 +29,7 @@ void AgentdStart(const char *dir, int uid, int gid, const char *user, const char
 #ifdef WIN32
 void *EventForward(void);
 #else
-void *EventForward(struct imsgbuf ibuf);
+void *EventForward(struct imsgbuf *ibuf);
 #endif //WIN32
 
 /* Receiver messages */
@@ -51,21 +51,21 @@ char *getsharedfiles(void);
 #ifdef WIN32
 void start_agent(int is_startup);
 #else
-void start_agent(int is_startup, struct imsgbuf ibuf);
+void start_agent(int is_startup, struct imsgbuf *ibuf);
 #endif
 
 /* Connect to the server */
 #ifdef WIN32
 int connect_server(int initial_id);
 #else
-int connect_server(int initial_id, struct imsgbuf ibuf);
+int connect_server(int initial_id, struct imsgbuf *ibuf);
 #endif
 
 /* Notify server */
 #ifdef WIN32
 void run_notify(void);
 #else
-void run_notify(struct imsgbuf ibuf);
+void run_notify(struct imsgbuf *ibuf);
 #endif
 
 /* libevent callback */

--- a/src/client-agent/event-forward.c
+++ b/src/client-agent/event-forward.c
@@ -17,7 +17,7 @@
 #endif
 
 /* Receive a message locally on the agent and forward it to the manager */
-void *EventForward(struct imsgbuf *ibuf)
+void *EventForward(void)
 {
     ssize_t recv_b;
     char msg[OS_MAXSTR + 1];
@@ -31,11 +31,7 @@ void *EventForward(struct imsgbuf *ibuf)
 
         send_msg(0, msg);
 
-#ifdef WIN32
         run_notify();
-#else
-        run_notify(ibuf);
-#endif //WIN32
     }
 
     return (NULL);

--- a/src/client-agent/event-forward.c
+++ b/src/client-agent/event-forward.c
@@ -12,9 +12,12 @@
 #include "os_net/os_net.h"
 #include "sec.h"
 
+#ifndef WIN32
+#include <imsg.h>
+#endif
 
 /* Receive a message locally on the agent and forward it to the manager */
-void *EventForward()
+void *EventForward(struct imsgbuf ibuf)
 {
     ssize_t recv_b;
     char msg[OS_MAXSTR + 1];
@@ -28,7 +31,11 @@ void *EventForward()
 
         send_msg(0, msg);
 
+#ifdef WIN32
         run_notify();
+#else
+        run_notify(ibuf);
+#endif //WIN32
     }
 
     return (NULL);

--- a/src/client-agent/event-forward.c
+++ b/src/client-agent/event-forward.c
@@ -17,7 +17,7 @@
 #endif
 
 /* Receive a message locally on the agent and forward it to the manager */
-void *EventForward(struct imsgbuf ibuf)
+void *EventForward(struct imsgbuf *ibuf)
 {
     ssize_t recv_b;
     char msg[OS_MAXSTR + 1];

--- a/src/client-agent/main.c
+++ b/src/client-agent/main.c
@@ -16,6 +16,9 @@
 #define ARGV0 "ossec-agentd"
 #endif
 
+extern struct imsgbuf server_ibuf;
+
+
 /* Prototypes */
 static void help_agentd(void) __attribute((noreturn));
 

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -59,7 +59,11 @@ char *getsharedfiles()
 #ifndef WIN32
 
 /* Periodically send notification to server */
+#ifdef WIN#2
 void run_notify()
+#else
+void run_notify(struct imsgbuf ibuf)
+#endif //WIN32
 {
     char keep_alive_random[1024];
     char tmp_msg[OS_SIZE_1024 + 1];
@@ -79,7 +83,11 @@ void run_notify()
         os_setwait();
 
         /* Send sync message */
+#ifndef WIN32
+        start_agent(0,ibuf);
+#else
         start_agent(0);
+#endif //WIN32
 
         verbose(SERVER_UP, ARGV0);
         os_delwait();

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -62,7 +62,7 @@ char *getsharedfiles()
 #ifdef WIN#2
 void run_notify()
 #else
-void run_notify(struct imsgbuf ibuf)
+void run_notify(struct imsgbuf *ibuf)
 #endif //WIN32
 {
     char keep_alive_random[1024];

--- a/src/client-agent/notify.c
+++ b/src/client-agent/notify.c
@@ -59,11 +59,7 @@ char *getsharedfiles()
 #ifndef WIN32
 
 /* Periodically send notification to server */
-#ifdef WIN#2
 void run_notify()
-#else
-void run_notify(struct imsgbuf *ibuf)
-#endif //WIN32
 {
     char keep_alive_random[1024];
     char tmp_msg[OS_SIZE_1024 + 1];
@@ -83,11 +79,7 @@ void run_notify(struct imsgbuf *ibuf)
         os_setwait();
 
         /* Send sync message */
-#ifndef WIN32
-        start_agent(0,ibuf);
-#else
         start_agent(0);
-#endif //WIN32
 
         verbose(SERVER_UP, ARGV0);
         os_delwait();

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -21,7 +21,9 @@
 /* Attempt to connect to all configured servers */
 int connect_server(int initial_id)
 {
+#ifdef WIN32
     unsigned int attempts = 2;
+#endif //WIN32
     int rc = initial_id;
 
     /* Checking if the initial is zero, meaning we have to
@@ -83,7 +85,7 @@ int connect_server(int initial_id)
         event_dispatch();
 
         if(agt->sock < 0) {
-		merror("%s [dns]: ERROR: socket error"); //XXX what do?
+		merror("%s [dns]: ERROR: socket error", ARGV0); //XXX what do?
 #else
         agt->sock = OS_ConnectUDP(agt->port, agt->rip[rc]);
 
@@ -239,7 +241,7 @@ void os_agent_cb(int fd, short ev, void *arg) {
     struct imsg imsg;
     struct imsgbuf *ibuf = (struct imsgbuf *)arg;
 
-    if (ev && EV_READ) {
+    if (ev & EV_READ) {
         if ((n = imsg_read(ibuf) == -1 && errno != EAGAIN)) {
             ErrorExit("%s: ERROR: imsg_read() failed: %s", ARGV0, strerror(errno));
         }

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -232,18 +232,26 @@ void start_agent(int is_startup)
 /* Callback for the AGENT_REQ */
 void os_agent_cb(int fd, short ev, void *arg) {
 
+    /* Quiet a warning */
+    if (fd) { }
+
     ssize_t n;
     struct imsg imsg;
     struct imsgbuf *ibuf = (struct imsgbuf *)arg;
 
-    if ((n = imsg_read(ibuf) == -1 && errno != EAGAIN)) {
-        ErrorExit("%s: ERROR: imsg_read() failed: %s", ARGV0, strerror(errno));
-    }
-    if (n == 0) {
-        debug1("%s: WARN: n == 0", ARGV0);
-    }
-    if (n == EAGAIN) {
-        debug1("%s: DEBUG: n == EAGAIN", ARGV0);
+    if (ev && EV_READ) {
+        if ((n = imsg_read(ibuf) == -1 && errno != EAGAIN)) {
+            ErrorExit("%s: ERROR: imsg_read() failed: %s", ARGV0, strerror(errno));
+        }
+        if (n == 0) {
+            debug1("%s: WARN: n == 0", ARGV0);
+        }
+        if (n == EAGAIN) {
+            debug1("%s: DEBUG: n == EAGAIN", ARGV0);
+        }
+    } else {
+        merror("%s: ERROR: not EV_READ", ARGV0);
+        return;
     }
     if ((n = imsg_get(ibuf, &imsg)) == -1) {
         merror("%s: ERROR: imsg_get() failed: %s", ARGV0, strerror(errno));

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -82,7 +82,8 @@ int connect_server(int initial_id)
 
         event_dispatch();
 
-        if(agt->sock > 0) {
+        if(agt->sock < 0) {
+		merror("%s [dns]: ERROR: socket error"); //XXX what do?
 #else
         agt->sock = OS_ConnectUDP(agt->port, agt->rip[rc]);
 

--- a/src/client-agent/start_agent.c
+++ b/src/client-agent/start_agent.c
@@ -21,7 +21,7 @@
 #ifdef WIN32
 int connect_server(int initial_id)
 #else
-int connect_server(int initial_id, struct imsgbuf ibuf)
+int connect_server(int initial_id, struct imsgbuf *ibuf)
 #endif
 {
     unsigned int attempts = 2;
@@ -128,7 +128,7 @@ int connect_server(int initial_id, struct imsgbuf ibuf)
 #ifdef WIN32
 void start_agent(int is_startup)
 #else
-void start_agent(int is_startup, struct imsgbuf ibuf)
+void start_agent(int is_startup, struct imsgbuf *ibuf)
 #endif
 {
     ssize_t recv_b = 0;

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -10,6 +10,10 @@
 #ifndef __CAGENTD_H
 #define __CAGENTD_H
 
+#ifndef WIN32
+#include <imsg.h>
+#endif //WIN32
+
 /* Configuration structure */
 typedef struct _agent {
     char *port;
@@ -22,6 +26,11 @@ typedef struct _agent {
     int notify_time;
     int max_time_reconnect_try;
     char *profile;
+
+#ifdef WIN32
+    struct imsgbuf ibuf;
+#endif //WIN32
+
 } agent;
 
 #endif /* __CAGENTD_H */

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -27,7 +27,7 @@ typedef struct _agent {
     int max_time_reconnect_try;
     char *profile;
 
-#ifdef WIN32
+#ifndef WIN32
     struct imsgbuf ibuf;
 #endif //WIN32
 

--- a/src/config/client-config.h
+++ b/src/config/client-config.h
@@ -11,6 +11,10 @@
 #define __CAGENTD_H
 
 #ifndef WIN32
+#include <sys/types.h>
+#include <sys/queue.h>
+#include <sys/uio.h>
+#include <stdint.h>
 #include <imsg.h>
 #endif //WIN32
 

--- a/src/config/email-alerts-config.c
+++ b/src/config/email-alerts-config.c
@@ -6,7 +6,6 @@
  * License (version 2) as published by the FSF - Free Software
  * Foundation
  */
-
 #include "shared.h"
 #include "mail-config.h"
 #include "config.h"

--- a/src/config/mail-config.h
+++ b/src/config/mail-config.h
@@ -10,6 +10,12 @@
 #ifndef _MCCONFIG__H
 #define _MCCONFIG__H
 
+#include <sys/types.h>
+#include <sys/queue.h>
+#include <sys/uio.h>
+#include <stdint.h>
+#include <imsg.h>
+
 #include "shared.h"
 
 /* Mail config structure */
@@ -38,6 +44,9 @@ typedef struct _MailConfig {
     /* Use GeoIP */
     int geoip;
 #endif
+
+    /* ibuf for imsg */
+    struct imsgbuf ibuf;
 
     OSMatch **gran_location;
     OSMatch **gran_group;

--- a/src/config/mail-config.h
+++ b/src/config/mail-config.h
@@ -10,11 +10,13 @@
 #ifndef _MCCONFIG__H
 #define _MCCONFIG__H
 
+#ifndef WIN32
 #include <sys/types.h>
 #include <sys/queue.h>
 #include <sys/uio.h>
 #include <stdint.h>
 #include <imsg.h>
+#endif //WIN32
 
 #include "shared.h"
 
@@ -45,8 +47,10 @@ typedef struct _MailConfig {
     int geoip;
 #endif
 
+#ifndef WIN32
     /* ibuf for imsg */
     struct imsgbuf ibuf;
+#endif //WIN32
 
     OSMatch **gran_location;
     OSMatch **gran_group;

--- a/src/external/compat/imsg-buffer.c
+++ b/src/external/compat/imsg-buffer.c
@@ -1,0 +1,315 @@
+/*	$OpenBSD: imsg-buffer.c,v 1.3 2013/11/13 20:40:24 benno Exp $	*/
+
+/*
+ * Copyright (c) 2003, 2004 Henning Brauer <henning@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef OPENBSD
+
+#include "includes.h"
+
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#ifndef HAVE_EXPLICIT_BZERO
+#include <strings.h>
+#endif
+#include <unistd.h>
+
+#include "imsg.h"
+
+int	ibuf_realloc(struct ibuf *, size_t);
+void	ibuf_enqueue(struct msgbuf *, struct ibuf *);
+void	ibuf_dequeue(struct msgbuf *, struct ibuf *);
+
+struct ibuf *
+ibuf_open(size_t len)
+{
+	struct ibuf	*buf;
+
+	if ((buf = calloc(1, sizeof(struct ibuf))) == NULL)
+		return (NULL);
+	if ((buf->buf = malloc(len)) == NULL) {
+		free(buf);
+		return (NULL);
+	}
+	buf->size = buf->max = len;
+	buf->fd = -1;
+
+	return (buf);
+}
+
+struct ibuf *
+ibuf_dynamic(size_t len, size_t max)
+{
+	struct ibuf	*buf;
+
+	if (max < len)
+		return (NULL);
+
+	if ((buf = ibuf_open(len)) == NULL)
+		return (NULL);
+
+	if (max > 0)
+		buf->max = max;
+
+	return (buf);
+}
+
+int
+ibuf_realloc(struct ibuf *buf, size_t len)
+{
+	u_char	*b;
+
+	/* on static buffers max is eq size and so the following fails */
+	if (buf->wpos + len > buf->max) {
+		errno = ENOMEM;
+		return (-1);
+	}
+
+	b = realloc(buf->buf, buf->wpos + len);
+	if (b == NULL)
+		return (-1);
+	buf->buf = b;
+	buf->size = buf->wpos + len;
+
+	return (0);
+}
+
+int
+ibuf_add(struct ibuf *buf, const void *data, size_t len)
+{
+	if (buf->wpos + len > buf->size)
+		if (ibuf_realloc(buf, len) == -1)
+			return (-1);
+
+	memcpy(buf->buf + buf->wpos, data, len);
+	buf->wpos += len;
+	return (0);
+}
+
+void *
+ibuf_reserve(struct ibuf *buf, size_t len)
+{
+	void	*b;
+
+	if (buf->wpos + len > buf->size)
+		if (ibuf_realloc(buf, len) == -1)
+			return (NULL);
+
+	b = buf->buf + buf->wpos;
+	buf->wpos += len;
+	return (b);
+}
+
+void *
+ibuf_seek(struct ibuf *buf, size_t pos, size_t len)
+{
+	/* only allowed to seek in already written parts */
+	if (pos + len > buf->wpos)
+		return (NULL);
+
+	return (buf->buf + pos);
+}
+
+size_t
+ibuf_size(struct ibuf *buf)
+{
+	return (buf->wpos);
+}
+
+size_t
+ibuf_left(struct ibuf *buf)
+{
+	return (buf->max - buf->wpos);
+}
+
+void
+ibuf_close(struct msgbuf *msgbuf, struct ibuf *buf)
+{
+	ibuf_enqueue(msgbuf, buf);
+}
+
+int
+ibuf_write(struct msgbuf *msgbuf)
+{
+	struct iovec	 iov[IOV_MAX];
+	struct ibuf	*buf;
+	unsigned int	 i = 0;
+	ssize_t	n;
+
+	bzero(&iov, sizeof(iov));
+	TAILQ_FOREACH(buf, &msgbuf->bufs, entry) {
+		if (i >= IOV_MAX)
+			break;
+		iov[i].iov_base = buf->buf + buf->rpos;
+		iov[i].iov_len = buf->wpos - buf->rpos;
+		i++;
+	}
+
+again:
+	if ((n = writev(msgbuf->fd, iov, i)) == -1) {
+		if (errno == EINTR)
+			goto again;
+		if (errno == ENOBUFS)
+			errno = EAGAIN;
+		return (-1);
+	}
+
+	if (n == 0) {			/* connection closed */
+		errno = 0;
+		return (0);
+	}
+
+	msgbuf_drain(msgbuf, n);
+
+	return (1);
+}
+
+void
+ibuf_free(struct ibuf *buf)
+{
+	free(buf->buf);
+	free(buf);
+}
+
+void
+msgbuf_init(struct msgbuf *msgbuf)
+{
+	msgbuf->queued = 0;
+	msgbuf->fd = -1;
+	TAILQ_INIT(&msgbuf->bufs);
+}
+
+void
+msgbuf_drain(struct msgbuf *msgbuf, size_t n)
+{
+	struct ibuf	*buf, *next;
+
+	for (buf = TAILQ_FIRST(&msgbuf->bufs); buf != NULL && n > 0;
+	    buf = next) {
+		next = TAILQ_NEXT(buf, entry);
+		if (buf->rpos + n >= buf->wpos) {
+			n -= buf->wpos - buf->rpos;
+			ibuf_dequeue(msgbuf, buf);
+		} else {
+			buf->rpos += n;
+			n = 0;
+		}
+	}
+}
+
+void
+msgbuf_clear(struct msgbuf *msgbuf)
+{
+	struct ibuf	*buf;
+
+	while ((buf = TAILQ_FIRST(&msgbuf->bufs)) != NULL)
+		ibuf_dequeue(msgbuf, buf);
+}
+
+int
+msgbuf_write(struct msgbuf *msgbuf)
+{
+	struct iovec	 iov[IOV_MAX];
+	struct ibuf	*buf;
+	unsigned int	 i = 0;
+	ssize_t		 n;
+	struct msghdr	 msg;
+	struct cmsghdr	*cmsg;
+	union {
+		struct cmsghdr	hdr;
+		char		buf[CMSG_SPACE(sizeof(int))];
+	} cmsgbuf;
+
+	bzero(&iov, sizeof(iov));
+	bzero(&msg, sizeof(msg));
+	TAILQ_FOREACH(buf, &msgbuf->bufs, entry) {
+		if (i >= IOV_MAX)
+			break;
+		iov[i].iov_base = buf->buf + buf->rpos;
+		iov[i].iov_len = buf->wpos - buf->rpos;
+		i++;
+		if (buf->fd != -1)
+			break;
+	}
+
+	msg.msg_iov = iov;
+	msg.msg_iovlen = i;
+
+	if (buf != NULL && buf->fd != -1) {
+		msg.msg_control = (caddr_t)&cmsgbuf.buf;
+		msg.msg_controllen = sizeof(cmsgbuf.buf);
+		cmsg = CMSG_FIRSTHDR(&msg);
+		cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+		cmsg->cmsg_level = SOL_SOCKET;
+		cmsg->cmsg_type = SCM_RIGHTS;
+		*(int *)CMSG_DATA(cmsg) = buf->fd;
+	}
+
+again:
+	if ((n = sendmsg(msgbuf->fd, &msg, 0)) == -1) {
+		if (errno == EINTR)
+			goto again;
+		if (errno == ENOBUFS)
+			errno = EAGAIN;
+		return (-1);
+	}
+
+	if (n == 0) {			/* connection closed */
+		errno = 0;
+		return (0);
+	}
+
+	/*
+	 * assumption: fd got sent if sendmsg sent anything
+	 * this works because fds are passed one at a time
+	 */
+	if (buf != NULL && buf->fd != -1) {
+		close(buf->fd);
+		buf->fd = -1;
+	}
+
+	msgbuf_drain(msgbuf, n);
+
+	return (1);
+}
+
+void
+ibuf_enqueue(struct msgbuf *msgbuf, struct ibuf *buf)
+{
+	TAILQ_INSERT_TAIL(&msgbuf->bufs, buf, entry);
+	msgbuf->queued++;
+}
+
+void
+ibuf_dequeue(struct msgbuf *msgbuf, struct ibuf *buf)
+{
+	TAILQ_REMOVE(&msgbuf->bufs, buf, entry);
+
+	if (buf->fd != -1)
+		close(buf->fd);
+
+	msgbuf->queued--;
+	ibuf_free(buf);
+}
+
+#endif //OPENBSD
+

--- a/src/external/compat/imsg.c
+++ b/src/external/compat/imsg.c
@@ -1,0 +1,334 @@
+/*	$OpenBSD: imsg.c,v 1.5 2013/12/26 17:32:33 eric Exp $	*/
+
+/*
+ * Copyright (c) 2003, 2004 Henning Brauer <henning@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef OPENBSD
+
+#include "includes.h"
+
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#ifndef HAVE_EXPLICIT_BZERO
+#include <strings.h>
+#endif
+#include <unistd.h>
+
+#include "imsg.h"
+
+int	 imsg_fd_overhead = 0;
+
+int	 imsg_get_fd(struct imsgbuf *);
+
+int
+available_fds(unsigned int n)
+{
+	unsigned int	i;
+	int		ret, fds[256];
+
+	if (n > (sizeof(fds)/sizeof(fds[0])))
+		return (1);
+
+	ret = 0;
+	for (i = 0; i < n; i++) {
+		fds[i] = -1;
+		if ((fds[i] = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+			ret = 1;
+			break;
+		}
+	}
+
+	for (i = 0; i < n && fds[i] >= 0; i++)
+		close(fds[i]);
+
+	return (ret);
+}
+
+void
+imsg_init(struct imsgbuf *ibuf, int fd)
+{
+	msgbuf_init(&ibuf->w);
+	bzero(&ibuf->r, sizeof(ibuf->r));
+	ibuf->fd = fd;
+	ibuf->w.fd = fd;
+	ibuf->pid = getpid();
+	TAILQ_INIT(&ibuf->fds);
+}
+
+ssize_t
+imsg_read(struct imsgbuf *ibuf)
+{
+	struct msghdr		 msg;
+	struct cmsghdr		*cmsg;
+	union {
+		struct cmsghdr hdr;
+		char	buf[CMSG_SPACE(sizeof(int) * 1)];
+	} cmsgbuf;
+	struct iovec		 iov;
+	ssize_t			 n = -1;
+	int			 fd;
+	struct imsg_fd		*ifd;
+
+	bzero(&msg, sizeof(msg));
+
+	iov.iov_base = ibuf->r.buf + ibuf->r.wpos;
+	iov.iov_len = sizeof(ibuf->r.buf) - ibuf->r.wpos;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = &cmsgbuf.buf;
+	msg.msg_controllen = sizeof(cmsgbuf.buf);
+
+	if ((ifd = calloc(1, sizeof(struct imsg_fd))) == NULL)
+		return (-1);
+
+again:
+	if (available_fds(imsg_fd_overhead +
+	    (CMSG_SPACE(sizeof(int))-CMSG_SPACE(0))/sizeof(int))) {
+		errno = EAGAIN;
+		free(ifd);
+		return (-1);
+	}
+	
+	if ((n = recvmsg(ibuf->fd, &msg, 0)) == -1) {
+		if (errno == EMSGSIZE)
+			goto fail;
+		if (errno != EINTR && errno != EAGAIN)
+			goto fail;
+		goto again;
+	}
+
+	ibuf->r.wpos += n;
+
+	for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL;
+	    cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+		if (cmsg->cmsg_level == SOL_SOCKET &&
+		    cmsg->cmsg_type == SCM_RIGHTS) {
+			int i;
+			int j;
+
+			/*
+			 * We only accept one file descriptor.  Due to C
+			 * padding rules, our control buffer might contain
+			 * more than one fd, and we must close them.
+			 */
+			j = ((char *)cmsg + cmsg->cmsg_len -
+			    (char *)CMSG_DATA(cmsg)) / sizeof(int);
+			for (i = 0; i < j; i++) {
+				fd = ((int *)CMSG_DATA(cmsg))[i];
+				if (ifd != NULL) {
+					ifd->fd = fd;
+					TAILQ_INSERT_TAIL(&ibuf->fds, ifd,
+					    entry);
+					ifd = NULL;
+				} else
+					close(fd);
+			}
+		}
+		/* we do not handle other ctl data level */
+	}
+
+fail:
+	if (ifd)
+		free(ifd);
+	return (n);
+}
+
+ssize_t
+imsg_get(struct imsgbuf *ibuf, struct imsg *imsg)
+{
+	size_t			 av, left, datalen;
+
+	av = ibuf->r.wpos;
+
+	if (IMSG_HEADER_SIZE > av)
+		return (0);
+
+	memcpy(&imsg->hdr, ibuf->r.buf, sizeof(imsg->hdr));
+	if (imsg->hdr.len < IMSG_HEADER_SIZE ||
+	    imsg->hdr.len > MAX_IMSGSIZE) {
+		errno = ERANGE;
+		return (-1);
+	}
+	if (imsg->hdr.len > av)
+		return (0);
+	datalen = imsg->hdr.len - IMSG_HEADER_SIZE;
+	ibuf->r.rptr = ibuf->r.buf + IMSG_HEADER_SIZE;
+	if ((imsg->data = malloc(datalen)) == NULL)
+		return (-1);
+
+	if (imsg->hdr.flags & IMSGF_HASFD)
+		imsg->fd = imsg_get_fd(ibuf);
+	else
+		imsg->fd = -1;
+
+	memcpy(imsg->data, ibuf->r.rptr, datalen);
+
+	if (imsg->hdr.len < av) {
+		left = av - imsg->hdr.len;
+		memmove(&ibuf->r.buf, ibuf->r.buf + imsg->hdr.len, left);
+		ibuf->r.wpos = left;
+	} else
+		ibuf->r.wpos = 0;
+
+	return (datalen + IMSG_HEADER_SIZE);
+}
+
+int
+imsg_compose(struct imsgbuf *ibuf, uint32_t type, uint32_t peerid,
+    pid_t pid, int fd, const void *data, uint16_t datalen)
+{
+	struct ibuf	*wbuf;
+
+	if ((wbuf = imsg_create(ibuf, type, peerid, pid, datalen)) == NULL)
+		return (-1);
+
+	if (imsg_add(wbuf, data, datalen) == -1)
+		return (-1);
+
+	wbuf->fd = fd;
+
+	imsg_close(ibuf, wbuf);
+
+	return (1);
+}
+
+int
+imsg_composev(struct imsgbuf *ibuf, uint32_t type, uint32_t peerid,
+    pid_t pid, int fd, const struct iovec *iov, int iovcnt)
+{
+	struct ibuf	*wbuf;
+	int		 i, datalen = 0;
+
+	for (i = 0; i < iovcnt; i++)
+		datalen += iov[i].iov_len;
+
+	if ((wbuf = imsg_create(ibuf, type, peerid, pid, datalen)) == NULL)
+		return (-1);
+
+	for (i = 0; i < iovcnt; i++)
+		if (imsg_add(wbuf, iov[i].iov_base, iov[i].iov_len) == -1)
+			return (-1);
+
+	wbuf->fd = fd;
+
+	imsg_close(ibuf, wbuf);
+
+	return (1);
+}
+
+/* ARGSUSED */
+struct ibuf *
+imsg_create(struct imsgbuf *ibuf, uint32_t type, uint32_t peerid,
+    pid_t pid, uint16_t datalen)
+{
+	struct ibuf	*wbuf;
+	struct imsg_hdr	 hdr;
+
+	datalen += IMSG_HEADER_SIZE;
+	if (datalen > MAX_IMSGSIZE) {
+		errno = ERANGE;
+		return (NULL);
+	}
+
+	hdr.type = type;
+	hdr.flags = 0;
+	hdr.peerid = peerid;
+	if ((hdr.pid = pid) == 0)
+		hdr.pid = ibuf->pid;
+	if ((wbuf = ibuf_dynamic(datalen, MAX_IMSGSIZE)) == NULL) {
+		return (NULL);
+	}
+	if (imsg_add(wbuf, &hdr, sizeof(hdr)) == -1)
+		return (NULL);
+
+	return (wbuf);
+}
+
+int
+imsg_add(struct ibuf *msg, const void *data, uint16_t datalen)
+{
+	if (datalen)
+		if (ibuf_add(msg, data, datalen) == -1) {
+			ibuf_free(msg);
+			return (-1);
+		}
+	return (datalen);
+}
+
+void
+imsg_close(struct imsgbuf *ibuf, struct ibuf *msg)
+{
+	struct imsg_hdr	*hdr;
+
+	hdr = (struct imsg_hdr *)msg->buf;
+
+	hdr->flags &= ~IMSGF_HASFD;
+	if (msg->fd != -1)
+		hdr->flags |= IMSGF_HASFD;
+
+	hdr->len = (uint16_t)msg->wpos;
+
+	ibuf_close(&ibuf->w, msg);
+}
+
+void
+imsg_free(struct imsg *imsg)
+{
+	free(imsg->data);
+}
+
+int
+imsg_get_fd(struct imsgbuf *ibuf)
+{
+	int		 fd;
+	struct imsg_fd	*ifd;
+
+	if ((ifd = TAILQ_FIRST(&ibuf->fds)) == NULL)
+		return (-1);
+
+	fd = ifd->fd;
+	TAILQ_REMOVE(&ibuf->fds, ifd, entry);
+	free(ifd);
+
+	return (fd);
+}
+
+int
+imsg_flush(struct imsgbuf *ibuf)
+{
+	while (ibuf->w.queued)
+		if (msgbuf_write(&ibuf->w) <= 0)
+			return (-1);
+	return (0);
+}
+
+void
+imsg_clear(struct imsgbuf *ibuf)
+{
+	int	fd;
+
+	msgbuf_clear(&ibuf->w);
+	while ((fd = imsg_get_fd(ibuf)) != -1)
+		close(fd);
+}
+#endif //OPENBSD
+

--- a/src/external/compat/imsg.h
+++ b/src/external/compat/imsg.h
@@ -1,0 +1,121 @@
+/*	$OpenBSD: imsg.h,v 1.3 2013/12/26 17:32:33 eric Exp $	*/
+
+/*
+ * Copyright (c) 2006, 2007 Pierre-Yves Ritschard <pyr@openbsd.org>
+ * Copyright (c) 2006, 2007, 2008 Reyk Floeter <reyk@openbsd.org>
+ * Copyright (c) 2003, 2004 Henning Brauer <henning@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef OPENBSD
+
+#ifndef _IMSG_H_
+#define _IMSG_H_
+
+#define IBUF_READ_SIZE		65535
+#define IMSG_HEADER_SIZE	sizeof(struct imsg_hdr)
+#define MAX_IMSGSIZE		16384
+
+#include <stdint.h>
+
+//#include "defines.h"
+
+struct ibuf {
+	TAILQ_ENTRY(ibuf)	 entry;
+	u_char			*buf;
+	size_t			 size;
+	size_t			 max;
+	size_t			 wpos;
+	size_t			 rpos;
+	int			 fd;
+};
+
+struct msgbuf {
+	TAILQ_HEAD(, ibuf)	 bufs;
+	uint32_t		 queued;
+	int			 fd;
+};
+
+struct ibuf_read {
+	u_char			 buf[IBUF_READ_SIZE];
+	u_char			*rptr;
+	size_t			 wpos;
+};
+
+struct imsg_fd {
+	TAILQ_ENTRY(imsg_fd)	entry;
+	int			fd;
+};
+
+struct imsgbuf {
+	TAILQ_HEAD(, imsg_fd)	 fds;
+	struct ibuf_read	 r;
+	struct msgbuf		 w;
+	int			 fd;
+	pid_t			 pid;
+};
+
+#define IMSGF_HASFD	1
+
+struct imsg_hdr {
+	uint32_t	 type;
+	uint16_t	 len;
+	uint16_t	 flags;
+	uint32_t	 peerid;
+	uint32_t	 pid;
+};
+
+struct imsg {
+	struct imsg_hdr	 hdr;
+	int		 fd;
+	void		*data;
+};
+
+
+/* buffer.c */
+struct ibuf	*ibuf_open(size_t);
+struct ibuf	*ibuf_dynamic(size_t, size_t);
+int		 ibuf_add(struct ibuf *, const void *, size_t);
+void		*ibuf_reserve(struct ibuf *, size_t);
+void		*ibuf_seek(struct ibuf *, size_t, size_t);
+size_t		 ibuf_size(struct ibuf *);
+size_t		 ibuf_left(struct ibuf *);
+void		 ibuf_close(struct msgbuf *, struct ibuf *);
+int		 ibuf_write(struct msgbuf *);
+void		 ibuf_free(struct ibuf *);
+void		 msgbuf_init(struct msgbuf *);
+void		 msgbuf_clear(struct msgbuf *);
+int		 msgbuf_write(struct msgbuf *);
+void		 msgbuf_drain(struct msgbuf *, size_t);
+
+/* imsg.c */
+int	 available_fds(unsigned int);
+void	 imsg_init(struct imsgbuf *, int);
+ssize_t	 imsg_read(struct imsgbuf *);
+ssize_t	 imsg_get(struct imsgbuf *, struct imsg *);
+int	 imsg_compose(struct imsgbuf *, uint32_t, uint32_t, pid_t,
+	    int, const void *, uint16_t);
+int	 imsg_composev(struct imsgbuf *, uint32_t, uint32_t,  pid_t,
+	    int, const struct iovec *, int);
+struct ibuf *imsg_create(struct imsgbuf *, uint32_t, uint32_t, pid_t,
+	    uint16_t);
+int	 imsg_add(struct ibuf *, const void *, uint16_t);
+void	 imsg_close(struct imsgbuf *, struct ibuf *);
+void	 imsg_free(struct imsg *);
+int	 imsg_flush(struct imsgbuf *);
+void	 imsg_clear(struct imsgbuf *);
+
+#endif
+#endif //OPENBSD
+

--- a/src/external/compat/includes.h
+++ b/src/external/compat/includes.h
@@ -1,0 +1,75 @@
+/* $OpenBSD: includes.h,v 1.54 2006/07/22 20:48:23 stevesk Exp $ */
+
+/*
+ * Author: Tatu Ylonen <ylo@cs.hut.fi>
+ * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+ *                    All rights reserved
+ * This file includes most of the needed system headers.
+ *
+ * As far as I am concerned, the code I have written for this software
+ * can be used freely for any purpose.  Any derived versions of this
+ * software must be clearly marked as such, and if the derived work is
+ * incompatible with the protocol description in the RFC file, it must be
+ * called by a name other than "ssh" or "Secure Shell".
+ */
+
+#ifndef OPENBSD
+
+#ifndef INCLUDES_H
+#define INCLUDES_H
+
+//#include "config.h"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* activate extra prototypes for glibc */
+#endif
+
+#include <sys/types.h>
+#include <sys/socket.h> /* For CMSG_* */
+
+#ifdef HAVE_LIMITS_H
+# include <limits.h> /* For PATH_MAX */
+#endif
+#ifdef HAVE_BSTRING_H
+# include <bstring.h>
+#endif
+
+#ifdef HAVE_ENDIAN_H
+# include <endian.h>
+#endif
+#ifdef HAVE_MAILLOCK_H
+# include <maillock.h> /* For _PATH_MAILDIR */
+#endif
+#ifdef HAVE_PATHS_H
+# include <paths.h>
+#endif
+
+#ifdef HAVE_RPC_TYPES_H
+# include <rpc/types.h> /* For INADDR_LOOPBACK */
+#endif
+#ifdef USE_PAM
+#if defined(HAVE_SECURITY_PAM_APPL_H)
+# include <security/pam_appl.h>
+#elif defined (HAVE_PAM_PAM_APPL_H)
+# include <pam/pam_appl.h>
+#endif
+#endif
+#include <errno.h>
+
+/* chl */
+#ifdef HAVE_NETDB_H
+# include <netdb.h>
+#endif
+/* end of chl*/
+
+#include <openssl/opensslv.h> /* For OPENSSL_VERSION_NUMBER */
+
+//#include "defines.h"
+
+//#include "openbsd-compat.h"
+
+//#include "entropy.h"
+
+#endif /* INCLUDES_H */
+#endif //OPENBSD
+

--- a/src/external/compat/setproctitle.c
+++ b/src/external/compat/setproctitle.c
@@ -1,0 +1,179 @@
+/* Based on conf.c from UCB sendmail 8.8.8 */
+
+/*
+ * Copyright 2003 Damien Miller
+ * Copyright (c) 1983, 1995-1997 Eric P. Allman
+ * Copyright (c) 1988, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef OPENBSD
+
+#include "includes.h"
+
+#ifndef HAVE_SETPROCTITLE
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#ifdef HAVE_SYS_PSTAT_H
+#include <sys/pstat.h>
+#endif
+#include <string.h>
+
+#if defined(HAVE_VIS_H) && !defined(BROKEN_STRNVIS)
+#include <vis.h>
+#else
+#include "bsd-vis.h"
+#endif
+
+#define SPT_NONE	0	/* don't use it at all */
+#define SPT_PSTAT	1	/* use pstat(PSTAT_SETCMD, ...) */
+#define SPT_REUSEARGV	2	/* cover argv with title information */
+
+#ifndef SPT_TYPE
+# define SPT_TYPE	SPT_NONE
+#endif
+
+#ifndef SPT_PADCHAR
+# define SPT_PADCHAR	'\0'
+#endif
+
+#if SPT_TYPE == SPT_REUSEARGV
+static char *argv_start = NULL;
+static size_t argv_env_len = 0;
+#endif
+
+#endif /* HAVE_SETPROCTITLE */
+
+void
+compat_init_setproctitle(int argc, char *argv[])
+{
+#if !defined(HAVE_SETPROCTITLE) && \
+    defined(SPT_TYPE) && SPT_TYPE == SPT_REUSEARGV
+	extern char **environ;
+	char *lastargv = NULL;
+	char **envp = environ;
+	int i;
+
+	/*
+	 * NB: This assumes that argv has already been copied out of the
+	 * way. This is true for sshd, but may not be true for other 
+	 * programs. Beware.
+	 */
+
+	if (argc == 0 || argv[0] == NULL)
+		return;
+
+	/* Fail if we can't allocate room for the new environment */
+	for (i = 0; envp[i] != NULL; i++)
+		;
+	if ((environ = calloc(i + 1, sizeof(*environ))) == NULL) {
+		environ = envp;	/* put it back */
+		return;
+	}
+
+	/*
+	 * Find the last argv string or environment variable within 
+	 * our process memory area.
+	 */
+	for (i = 0; i < argc; i++) {
+		if (lastargv == NULL || lastargv + 1 == argv[i])
+			lastargv = argv[i] + strlen(argv[i]);
+	}
+	for (i = 0; envp[i] != NULL; i++) {
+		if (lastargv + 1 == envp[i])
+			lastargv = envp[i] + strlen(envp[i]);
+	}
+
+	argv[1] = NULL;
+	argv_start = argv[0];
+	argv_env_len = lastargv - argv[0] - 1;
+
+	/* 
+	 * Copy environment 
+	 * XXX - will truncate env on strdup fail
+	 */
+	for (i = 0; envp[i] != NULL; i++)
+		environ[i] = strdup(envp[i]);
+	environ[i] = NULL;
+#endif /* SPT_REUSEARGV */
+}
+
+#ifndef HAVE_SETPROCTITLE
+void
+setproctitle(const char *fmt, ...)
+{
+#if SPT_TYPE != SPT_NONE
+	va_list ap;
+	char buf[1024], ptitle[1024];
+	size_t len;
+	int r;
+	extern char *__progname;
+#if SPT_TYPE == SPT_PSTAT
+	union pstun pst;
+#endif
+
+#if SPT_TYPE == SPT_REUSEARGV
+	if (argv_env_len <= 0)
+		return;
+#endif
+
+	strlcpy(buf, __progname, sizeof(buf));
+
+	r = -1;
+	va_start(ap, fmt);
+	if (fmt != NULL) {
+		len = strlcat(buf, ": ", sizeof(buf));
+		if (len < sizeof(buf))
+			r = vsnprintf(buf + len, sizeof(buf) - len , fmt, ap);
+	}
+	va_end(ap);
+	if (r == -1 || (size_t)r >= sizeof(buf) - len)
+		return;
+	strnvis(ptitle, buf, sizeof(ptitle),
+	    VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL);
+
+#if SPT_TYPE == SPT_PSTAT
+	pst.pst_command = ptitle;
+	pstat(PSTAT_SETCMD, pst, strlen(ptitle), 0, 0);
+#elif SPT_TYPE == SPT_REUSEARGV
+/*	debug("setproctitle: copy \"%s\" into len %d", 
+	    buf, argv_env_len); */
+	len = strlcpy(argv_start, ptitle, argv_env_len);
+	for(; len < argv_env_len; len++)
+		argv_start[len] = SPT_PADCHAR;
+#endif
+
+#endif /* SPT_NONE */
+}
+
+#endif /* HAVE_SETPROCTITLE */
+
+#endif //OPENBSD
+

--- a/src/external/compat/strlcat.c
+++ b/src/external/compat/strlcat.c
@@ -1,0 +1,66 @@
+/*	$OpenBSD: strlcat.c,v 1.13 2005/08/08 08:05:37 espie Exp $	*/
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* OPENBSD ORIGINAL: lib/libc/string/strlcat.c */
+
+#ifndef OPENBSD
+
+#include "includes.h"
+#ifndef HAVE_STRLCAT
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Appends src to string dst of size siz (unlike strncat, siz is the
+ * full size of dst, not space left).  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz <= strlen(dst)).
+ * Returns strlen(src) + MIN(siz, strlen(initial dst)).
+ * If retval >= siz, truncation occurred.
+ */
+size_t
+strlcat(char *dst, const char *src, size_t siz)
+{
+	char *d = dst;
+	const char *s = src;
+	size_t n = siz;
+	size_t dlen;
+
+	/* Find the end of dst and adjust bytes left but don't go past end */
+	while (n-- != 0 && *d != '\0')
+		d++;
+	dlen = d - dst;
+	n = siz - dlen;
+
+	if (n == 0)
+		return(dlen + strlen(s));
+	while (*s != '\0') {
+		if (n != 1) {
+			*d++ = *s;
+			n--;
+		}
+		s++;
+	}
+	*d = '\0';
+
+	return(dlen + (s - src));	/* count does not include NUL */
+}
+
+#endif /* !HAVE_STRLCAT */
+#endif // OPENBSD
+

--- a/src/external/compat/strlcpy.c
+++ b/src/external/compat/strlcpy.c
@@ -1,0 +1,63 @@
+/*	$OpenBSD: strlcpy.c,v 1.11 2006/05/05 15:27:38 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/* OPENBSD ORIGINAL: lib/libc/string/strlcpy.c */
+
+#ifndef OPENBSD
+
+#include "includes.h"
+#ifndef HAVE_STRLCPY
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy src to string dst of size siz.  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz == 0).
+ * Returns strlen(src); if retval >= siz, truncation occurred.
+ */
+size_t
+strlcpy(char *dst, const char *src, size_t siz)
+{
+	char *d = dst;
+	const char *s = src;
+	size_t n = siz;
+
+	/* Copy as many bytes as will fit */
+	if (n != 0) {
+		while (--n != 0) {
+			if ((*d++ = *s++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src */
+	if (n == 0) {
+		if (siz != 0)
+			*d = '\0';		/* NUL-terminate dst */
+		while (*s++)
+			;
+	}
+
+	return(s - src - 1);	/* count does not include NUL */
+}
+
+#endif /* !HAVE_STRLCPY */
+
+#endif //OPENBSD
+

--- a/src/os_dns/Makefile
+++ b/src/os_dns/Makefile
@@ -1,0 +1,6 @@
+all:
+	cc -I.. -I../headers -I/usr/local/include -c os_dns.c ../shared/debug_op.c ../shared/privsep_op.c
+
+clean:
+	rm -f *.core *.o
+

--- a/src/os_dns/README
+++ b/src/os_dns/README
@@ -21,3 +21,15 @@ Reply from os_dns:
 Eventually I'll need to figure out if I want to use this
 for udp as well, and how to pass the protocol along.
 
+Todo:
+
+* Cleanup - everything is still too noisy
+
+* errors - I don't think I've handled the errors very well
+
+* kill - there's no way to kill both processes currently
+
+* signals - these need to be gone over
+
+* probably lots of other things
+

--- a/src/os_dns/README
+++ b/src/os_dns/README
@@ -1,0 +1,23 @@
+Attempt to write a forkable daemon to do dns lookups for
+chrooted processes (maild/agentd).
+
+
+I hope to provide a re-usable support "daemon" that the 
+other daemons can use for name lookups. maild would 
+fork a copy of os_dns and query it via imsg for the IP
+address of the mail server.
+
+os_dns would not be chrooted, but will run with lowered 
+privs. unveil and pledge could also be used on OpenBSD
+to limit its usefulness to attackers.
+
+Request to os_dns:
+* hostname
+
+Reply from os_dns:
+* The socket with a connection started
+
+
+Eventually I'll need to figure out if I want to use this
+for udp as well, and how to pass the protocol along.
+

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -253,11 +253,8 @@ int osdns(struct imsgbuf *ibuf, char *os_name) {
         ErrorExit("%s [dns]: ERROR: Cannot setuid.", os_name);
     }
 
-    char *y = NULL;
-    snprintf(y, 256, "%s-dns", dname);
-
-    if (CreatePID(y, getpid()) < 0) {
-        ErrorExit(PID_ERROR, y);
+    if (CreatePID(dname, getpid()) < 0) {
+        ErrorExit(PID_ERROR, dname);
     }
 
     /* Setup libevent */

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -45,7 +45,7 @@ void osdns_accept(int fd, short ev, void *arg) {
     struct imsgbuf *ibuf = (struct imsgbuf *)arg;
 
 #ifdef CLIENT
-    agent *agt;
+    extern agent *agt;
     unsigned int attempts = 2;
 #endif //CLIENT
 
@@ -150,8 +150,8 @@ void osdns_accept(int fd, short ev, void *arg) {
             case AGENT_REQ:
                 memcpy(&agt, imsg.data, sizeof(agt));
 
-                int a_sock, rc = 0;
-                a_sock = OS_ConnectUDP(agt->port, agt->rip[rc]);
+                int rc = 0;
+                agt->sock = OS_ConnectUDP(agt->port, agt->rip[rc]);
                 if (agt->sock < 0) {
                     agt->sock = -1;
                     merror(CONNS_ERROR, dname, agt->rip[rc]);

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -36,7 +36,7 @@ void osdns_accept(int fd, short ev, void *arg) {
 
 
     /* We have a request from ossec-maild */
-    struct dns_request dnsr;
+    struct os_dns_request dnsr;
     ssize_t n, datalen;
     struct imsg imsg;
     struct imsgbuf *ibuf = (struct imsgbuf *)arg;

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -22,6 +22,11 @@
 #include "os_net/os_net.h"
 #include "os_dns.h"
 
+#ifdef CLIENT
+#include "client-agent/agentd.h"
+#include "config/client-config.h"
+#endif //CLIENT
+
 char *dname = NULL;
 
 void osdns_accept(int fd, short ev, void *arg) {
@@ -38,6 +43,11 @@ void osdns_accept(int fd, short ev, void *arg) {
     ssize_t n, datalen;
     struct imsg imsg;
     struct imsgbuf *ibuf = (struct imsgbuf *)arg;
+
+#ifdef CLIENT
+    agent *agt;
+    unsigned int attempts = 2;
+#endif //CLIENT
 
 
     if (ev & EV_READ) {
@@ -136,33 +146,53 @@ void osdns_accept(int fd, short ev, void *arg) {
              * break out the agentd stuff from maild. It's not ideal, but
              * it should work for now.
              */
+#ifdef CLIENT
             case AGENT_REQ:
-                agent agent;
-                memcpy(&agent, imsg.data, sizeof(agent));
+                memcpy(&agt, imsg.data, sizeof(agt));
 
                 int a_sock, rc = 0;
-                a_sock = OS_ConnectUDP(agent->port, agent->rip[rc]);
+                a_sock = OS_ConnectUDP(agt->port, agt->rip[rc]);
                 if (agt->sock < 0) {
                     agt->sock = -1;
-                    merror(CONNS_ERROR, ARGV0, agt->rip[rc]);
+                    merror(CONNS_ERROR, dname, agt->rip[rc]);
                     rc++;
 
+                    /* Fail */
                     if (agt->rip[rc] == NULL) {
                         attempts += 10;
                         /* Only log that if we have more than 1 server configured */
                         if (agt->rip[1]) {
-                            merror("%s: ERROR: Unable to connect to any server.", ARGV0);
+                            merror("%s: ERROR: Unable to connect to any server.", dname);
                         }
 
                         sleep(attempts);
                         rc = 0;
                     }
                 } else {
+                    /* Success */
                     /* Send the socket back to agentd */
+                    if ((imsg_compose(ibuf, DNS_RESP, 0, 0, agt->sock, &idata, sizeof(idata))) == -1) {
+                        merror("%s [dns]: ERROR: DNS_RESP imsg_compose() failed: %s", dname, strerror(errno));
+                        freeaddrinfo(result);
+                        return;
+                    } else {
+                        if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                            merror("%s [dns]: ERROR: DNS_RESP msgbuf_write() failed: %s", dname, strerror(errno));
+                            freeaddrinfo(result);
+                            return;
+                        }
+                        if (n == 0) {
+                            debug1("%s [dns]: DEBUG: n == 0", dname);
+                            return;
+                        }
+                        freeaddrinfo(result);
+                        return;
+                    }
 
                 }
 
                 break;
+#endif //CLIENT
             default:
                 merror("%s [dns]: ERROR: Unknown imsg type", dname);
                 if ((imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &idata, sizeof(idata))) == -1) {

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -235,7 +235,11 @@ int osdns(struct imsgbuf *ibuf, char *os_name) {
 
     /* setuid() ossecm */
     /* This is static ossecm for now, I'll figure out the trick later */
+#ifdef CLIENT
+    char *login = "ossec";
+#else
     char *login = "ossecm";
+#endif //CLIENT
     struct passwd *pw;
 
 

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -81,7 +81,7 @@ void osdns_accept(int fd, short ev, void *arg) {
 
                 /* socket */
                 int sock;
-                sock = getaddrinfo(dnsr.hostname, dnsr.protocol, &hints, &result);
+                sock = getaddrinfo(dnsr.hostname, "smtp", &hints, &result);
                 if (sock != 0) {
                     merror("%s [dns]: ERROR: getaddrinfo() error: %s\n", dname, gai_strerror(sock));
 

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -236,9 +236,9 @@ int osdns(struct imsgbuf *ibuf, char *os_name) {
     /* setuid() ossecm */
     /* This is static ossecm for now, I'll figure out the trick later */
 #ifdef CLIENT
-    char *login = "ossec";
+    char *login = USER;
 #else
-    char *login = "ossecm";
+    char *login = MAILUSER;
 #endif //CLIENT
     struct passwd *pw;
 
@@ -251,6 +251,13 @@ int osdns(struct imsgbuf *ibuf, char *os_name) {
     }
     if (Privsep_SetUser(pw->pw_uid) < 0) {
         ErrorExit("%s [dns]: ERROR: Cannot setuid.", os_name);
+    }
+
+    char *y = NULL;
+    snprintf(y, 256, "%s-dns", dname);
+
+    if (CreatePID(y, getpid()) < 0) {
+        ErrorExit(PID_ERROR, y);
     }
 
     /* Setup libevent */

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -22,8 +22,6 @@
 #include "os_net/os_net.h"
 #include "os_dns.h"
 
-
-
 void osdns_accept(int fd, short ev, void *arg) {
 
     /* sssssssh */
@@ -172,14 +170,14 @@ void osdns_accept(int fd, short ev, void *arg) {
  *
  * Focusing on TCP right now.
  */
-int osdns(struct imsgbuf *ibuf) {
+int osdns(struct imsgbuf *ibuf, char *os_name) {
 
 
 #if __OpenBSD__
     setproctitle("[dns]");
 #endif
 
-    merror("ossec-maild [dns]: INFO: Starting osdns");
+    merror("%s [dns]: INFO: Starting osdns", os_name);
 
     /* setuid() ossecm */
     /* This is static ossecm for now, I'll figure out the trick later */

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -69,7 +69,7 @@ void osdns_accept(int fd, short ev, void *arg) {
         switch(imsg.hdr.type) {
             case DNS_REQ:
                 memcpy(&dnsr, imsg.data, sizeof(dnsr));
-                int idata = 42;
+                int idata = 42; /* XXX Not sure why this is actually needed */
                 struct addrinfo hints, *result, *rp = NULL;
                 memset(&hints, 0, sizeof(hints));
                 hints.ai_family = AF_UNSPEC;
@@ -130,6 +130,66 @@ void osdns_accept(int fd, short ev, void *arg) {
                         }
                     }
                 }
+                break;
+            /*
+             * Until I find a better way to pass this stuff around,
+             * break out the agentd stuff from maild. It's not ideal, but
+             * it should work for now.
+             */
+            case AGENT_REQ:
+                memcpy(&dnsr, imsg.data, sizeof(dnsr));
+                memset(&hints, 0, sizeof(hints));
+                hints.ai_family = AF_UNSPEC;
+                hints.ai_socktype = SOCK_DGRAM;
+
+                int a_sock;
+                a_sock = getaddrinfo(dnsr.hostname, "1514", &hints, &result);
+                if (a_sock != 0) {
+                    merror("%s [dns]: ERROR: getaddrinfo() error: %s\n", dname, gai_strerror(a_sock));
+                    struct os_dns_error os_dns_err;
+                    os_dns_err.code = a_sock;
+                    os_dns_err.msg = gai_strerror(a_sock);
+                    imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &os_dns_err, sizeof(&os_dns_err));
+                    if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                        merror("%s [dns]: ERROR: msgbuf_write() failed (DNS_FAIL): %s", dname, strerror(errno));
+                    }
+                    if (n == 0) {
+                        debug2("%s [dns]: DEBUG: DNS_FAIL n == 0", dname);
+                    }
+                    if (n == EAGAIN) {
+                        merror("%s [dns]: DEBUG: EAGAIN 1", dname);
+                    }
+                }
+                a_sock = -1;
+                for(rp = result; rp; rp = rp->ai_next) {
+                    a_sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+                    if (a_sock == -1) {
+                        merror("%s [dns]: ERROR: socket() error", dname);
+                    } else {
+                        if (connect(a_sock, rp->ai_addr, rp->ai_addrlen) == -1) {
+                            merror("%s [dns]: ERROR: connect() failed.", dname);
+                            //XXX return error to caller
+                        } else {
+                            if ((imsg_compose(ibuf, DNS_RESP, 0, 0, a_sock, &idata, sizeof(idata))) == -1) {
+                                merror("%s [dns]: ERROR: DNS_RESP imsg_compose() failed: %s", dname, strerror(errno));
+                                freeaddrinfo(result);
+                                return;
+                            } else {
+                                if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                                    merror("%s [dns]: ERROR: DNS_RESP msgbuf_write() failed: %s", dname, strerror(errno));
+                                    freeaddrinfo(result);
+                                    return;
+                                }
+                                if (n == 0) {
+                                    debug2("%s [dns]: DEBUG: DNS_RESP n == 0", dname);
+                                }
+                                freeaddrinfo(result);
+                                return;
+                            }
+                        }
+                    }
+                }
+
                 break;
             default:
                 merror("%s [dns]: ERROR: Unknown imsg type", dname);

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -28,7 +28,6 @@ void osdns_accept(int fd, short ev, void *arg) {
 
     /* sssssssh */
     if (fd) { }
-    if (ev) { }
 
     /* temporary things */
     char *protocol = "tcp";
@@ -41,106 +40,114 @@ void osdns_accept(int fd, short ev, void *arg) {
     struct imsgbuf *ibuf = (struct imsgbuf *)arg;
 
 
-    if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN) {
-        ErrorExit("%s [dns]: ERROR: imsg_read() failed: %s", dname, strerror(errno));
+    if (ev & EV_READ) {
+        if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN) {
+            ErrorExit("%s [dns]: ERROR: imsg_read() failed: %s", dname, strerror(errno));
+            return;
+        }
+        if (n == 0) {
+            debug2("%s [dns]: DEBUG: n == 0", dname);
+        }
+    } else {
+        merror("Not EV_READ");
         return;
     }
-    if (n == 0) {
-        merror("%s [dns]: DEBUG: n == 0", dname);
-    }
 
-    if ((n = imsg_get(ibuf, &imsg)) == -1) {
-        merror("%s [dns]: ERROR: imsg_get() failed: %s", dname, strerror(errno));
-        return;
-    }
-    if (n == 0) {
-        merror("%s [dns]: DEBUG: imsg_get() n == 0", dname);
-    }
+    for (;;) {
+        if ((n = imsg_get(ibuf, &imsg)) == -1) {
+            merror("%s [dns]: ERROR: imsg_get() failed: %s", dname, strerror(errno));
+            return;
+        }
+        if (n == 0) {
+            debug2("%s [dns]: DEBUG: imsg_get() n == 0", dname);
+            break; /* No more messages */
+        }
 
 
-    datalen = imsg.hdr.len - IMSG_HEADER_SIZE;
+        datalen = imsg.hdr.len - IMSG_HEADER_SIZE;
 
-    switch(imsg.hdr.type) {
-        case DNS_REQ:
-            memcpy(&dnsr, imsg.data, sizeof(dnsr));
-            int idata = 42;
-            struct addrinfo hints, *result, *rp = NULL;
-            memset(&hints, 0, sizeof(hints));
-            hints.ai_family = AF_UNSPEC;
-            if (strncmp(protocol, "tcp", 3) == 0) {
-                hints.ai_socktype = SOCK_STREAM;
-            } else if (strncmp(protocol, "udp", 3) == 0) {
-                hints.ai_socktype = SOCK_DGRAM;
-            }
-
-            /* socket */
-            int sock;
-            sock = getaddrinfo(dnsr.hostname, "smtp", &hints, &result);
-            if (sock != 0) {
-                merror("%s [dns]: ERROR: getaddrinfo() error: %s\n", dname, gai_strerror(sock));
-
-                struct os_dns_error os_dns_err;
-                os_dns_err.code = sock;
-                os_dns_err.msg = gai_strerror(sock);
-
-                imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &os_dns_err, sizeof(&os_dns_err));
-                if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
-                    merror("%s [dns]: ERROR: msgbuf_write() failed (DNS_FAIL): %s", dname, strerror(errno));
+        switch(imsg.hdr.type) {
+            case DNS_REQ:
+                memcpy(&dnsr, imsg.data, sizeof(dnsr));
+                int idata = 42;
+                struct addrinfo hints, *result, *rp = NULL;
+                memset(&hints, 0, sizeof(hints));
+                hints.ai_family = AF_UNSPEC;
+                if (strncmp(protocol, "tcp", 3) == 0) {
+                    hints.ai_socktype = SOCK_STREAM;
+                } else if (strncmp(protocol, "udp", 3) == 0) {
+                    hints.ai_socktype = SOCK_DGRAM;
                 }
-                if (n == 0) {
-                    merror("%s [dns]: DEBUG: DNS_FAIL n == 0", dname);
-                }
-                if (n == EAGAIN) {
-                    merror("%s [dns]: DEBUG: EAGAIN 1", dname);
-                }
-            }
 
-            sock = -1;
-            for(rp = result; rp; rp = rp->ai_next) {
-                sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-                if (sock == -1) {
-                    merror("%s [dns]: ERROR: socket() error", dname);
-                } else {
-                    if (connect(sock, rp->ai_addr, rp->ai_addrlen) == -1) {
-                        merror("%s [dns]: ERROR: connect() failed.", dname);
-                        //XXX return error to caller
+                /* socket */
+                int sock;
+                sock = getaddrinfo(dnsr.hostname, dnsr.protocol, &hints, &result);
+                if (sock != 0) {
+                    merror("%s [dns]: ERROR: getaddrinfo() error: %s\n", dname, gai_strerror(sock));
+
+                    struct os_dns_error os_dns_err;
+                    os_dns_err.code = sock;
+                    os_dns_err.msg = gai_strerror(sock);
+
+                    imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &os_dns_err, sizeof(&os_dns_err));
+                    if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                        merror("%s [dns]: ERROR: msgbuf_write() failed (DNS_FAIL): %s", dname, strerror(errno));
+                    }
+                    if (n == 0) {
+                        debug2("%s [dns]: DEBUG: DNS_FAIL n == 0", dname);
+                    }
+                    if (n == EAGAIN) {
+                        merror("%s [dns]: DEBUG: EAGAIN 1", dname);
+                    }
+                }
+
+                sock = -1;
+                for(rp = result; rp; rp = rp->ai_next) {
+                    sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+                    if (sock == -1) {
+                        merror("%s [dns]: ERROR: socket() error", dname);
                     } else {
-                        if ((imsg_compose(ibuf, DNS_RESP, 0, 0, sock, &idata, sizeof(idata))) == -1) {
-                            merror("%s [dns]: ERROR: DNS_RESP imsg_compose() failed: %s", dname, strerror(errno));
-                            freeaddrinfo(result);
-                            return;
+                        if (connect(sock, rp->ai_addr, rp->ai_addrlen) == -1) {
+                            merror("%s [dns]: ERROR: connect() failed.", dname);
+                            //XXX return error to caller
                         } else {
-                            if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
-                                merror("%s [dns]: ERROR: DNS_RESP msgbuf_write() failed: %s", dname, strerror(errno));
+                            if ((imsg_compose(ibuf, DNS_RESP, 0, 0, sock, &idata, sizeof(idata))) == -1) {
+                                merror("%s [dns]: ERROR: DNS_RESP imsg_compose() failed: %s", dname, strerror(errno));
+                                freeaddrinfo(result);
+                                return;
+                            } else {
+                                if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                                    merror("%s [dns]: ERROR: DNS_RESP msgbuf_write() failed: %s", dname, strerror(errno));
+                                    freeaddrinfo(result);
+                                    return;
+                                }
+                                if (n == 0) {
+                                    debug2("%s [dns]: DEBUG: DNS_RESP n == 0", dname);
+                                }
                                 freeaddrinfo(result);
                                 return;
                             }
-                            if (n == 0) {
-                                merror("%s [dns]: DEBUG: DNS_RESP n == 0", dname);
-                            }
-                            freeaddrinfo(result);
-                            return;
                         }
                     }
                 }
-            }
-            break;
-        default:
-            merror("%s [dns]: ERROR: Unknown imsg type", dname);
-            if ((imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &idata, sizeof(idata))) == -1) {
-                merror("%s [dns]: ERROR: DNS_FAIL imsg_compose() failed: %s", dname, strerror(errno));
+                break;
+            default:
+                merror("%s [dns]: ERROR: Unknown imsg type", dname);
+                if ((imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &idata, sizeof(idata))) == -1) {
+                    merror("%s [dns]: ERROR: DNS_FAIL imsg_compose() failed: %s", dname, strerror(errno));
+                    return;
+                } else {
+                    if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                        merror("%s [dns]: ERROR: DNS_FAIL msgbuf_write failed: %s", dname, strerror(errno));
+                        return;
+                    }
+                    if (n == 0) {
+                        debug2("%s [dns]: DEBUG: DNS_FAIL n == 0", dname);
+                        return;
+                    }
+                }
                 return;
-            } else {
-                if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
-                    merror("%s [dns]: ERROR: DNS_FAIL msgbuf_write failed: %s", dname, strerror(errno));
-                    return;
-                }
-                if (n == 0) {
-                    merror("%s [dns]: DEBUG: DNS_FAIL n == 0", dname);
-                    return;
-                }
-            }
-            return;
+        }
     }
 
 
@@ -162,7 +169,7 @@ int osdns(struct imsgbuf *ibuf, char *os_name) {
     setproctitle("[dns]");
 #endif
 
-    merror("%s [dns]: INFO: Starting osdns", os_name);
+    debug1("%s [dns]: INFO: Starting osdns", os_name);
 
     /* setuid() ossecm */
     /* This is static ossecm for now, I'll figure out the trick later */
@@ -187,7 +194,7 @@ int osdns(struct imsgbuf *ibuf, char *os_name) {
         ErrorExit("%s [dns]: event_init() failed.", os_name);
     }
 
-    merror("%s [dns]: INFO: Starting libevent.", os_name);
+    debug1("%s [dns]: INFO: Starting libevent.", os_name);
     struct event ev_accept;
     event_set(&ev_accept, ibuf->fd, EV_READ|EV_PERSIST, osdns_accept, ibuf);
     event_add(&ev_accept, NULL);
@@ -197,9 +204,4 @@ int osdns(struct imsgbuf *ibuf, char *os_name) {
 
     return(0);
 }
-
-
-
-
-
 

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -1,3 +1,12 @@
+/* Copyright (C) 2019 Daniel Parriott <ddpbsd@gmail.com>
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -43,10 +43,6 @@ void osdns_accept(int fd, short ev, void *arg) {
     /* sssssssh */
     if (fd) { }
 
-    /* temporary things */
-    char *protocol = "tcp";
-
-
     /* We have a request from ossec-maild */
     struct os_dns_request dnsr;
     ssize_t n, datalen;
@@ -62,7 +58,6 @@ void osdns_accept(int fd, short ev, void *arg) {
     if (ev & EV_READ) {
         if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN) {
             ErrorExit("%s [dns]: ERROR: imsg_read() failed: %s", dname, strerror(errno));
-            return;
         }
         if (n == 0) {
             debug2("%s [dns]: DEBUG: n == 0", dname);
@@ -86,21 +81,25 @@ void osdns_accept(int fd, short ev, void *arg) {
         datalen = imsg.hdr.len - IMSG_HEADER_SIZE;
 
         switch(imsg.hdr.type) {
+            /*
+             * OS_Sendmail() sends a DNS_REQ for the smtp_server
+             * osdns() sends back a socket to the connection to the smtp_server
+             */
             case DNS_REQ:
                 if (datalen != sizeof(&dnsr)) {
-                    //XXX error
                     merror("%s [dns]: ERROR: DNS_REQ wrong length (%lu)", dname, datalen);
                     struct os_dns_error os_dns_err;
                     //os_dns_err.msg = "wrong len";
                     imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &os_dns_err, sizeof(&os_dns_err));
                     if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
-                        merror("%s [dns]: ERROR: msgbuf_write() failed (DNS_FAIL size): %a", dname, strerror(errno));
+                        merror("%s [dns]: ERROR: msgbuf_write() failed (DNS_FAIL size): %s", dname, strerror(errno));
+                        return;
                     }
                     if (n == 0) {
                         debug2("%s [dns]: DEBUG: DNS_FAIL size n == 0", dname);
                     }
                     if (n == EAGAIN) {
-                        merror("%s [dns]: DEBUG EAGAIN size", dname);
+                        debug2("%s [dns]: DEBUG EAGAIN size", dname);
                     }
                 }
                 memcpy(&dnsr, imsg.data, sizeof(dnsr));
@@ -108,11 +107,7 @@ void osdns_accept(int fd, short ev, void *arg) {
                 struct addrinfo hints, *result, *rp = NULL;
                 memset(&hints, 0, sizeof(hints));
                 hints.ai_family = AF_UNSPEC;
-                if (strncmp(protocol, "tcp", 3) == 0) {
-                    hints.ai_socktype = SOCK_STREAM;
-                } else if (strncmp(protocol, "udp", 3) == 0) {
-                    hints.ai_socktype = SOCK_DGRAM;
-                }
+                hints.ai_socktype = SOCK_STREAM;
 
                 /* socket */
                 int sock;
@@ -132,7 +127,7 @@ void osdns_accept(int fd, short ev, void *arg) {
                         debug2("%s [dns]: DEBUG: DNS_FAIL n == 0", dname);
                     }
                     if (n == EAGAIN) {
-                        merror("%s [dns]: DEBUG: EAGAIN 1", dname);
+                        debug2("%s [dns]: DEBUG: EAGAIN 1", dname);
                     }
                 }
 
@@ -178,59 +173,65 @@ void osdns_accept(int fd, short ev, void *arg) {
                     debug2("%s [dns]: DEBUG: DNS_FAIL n == 0", dname);
                 }
                 if (n == EAGAIN) {
-                    merror("%s [dns]: DEBUG: EAGAIN 1", dname);
+                    debug2("%s [dns]: DEBUG: EAGAIN 1", dname);
                 }
                 break;
-            /*
-             * Until I find a better way to pass this stuff around,
-             * break out the agentd stuff from maild. It's not ideal, but
-             * it should work for now.
-             */
 #ifdef CLIENT
             case AGENT_REQ:
+                /*
+                 * agentd needs to find the IP of the ossec server
+                 * This should give agentd a socket to use for the traffic
+                 */
                 memcpy(&agt, imsg.data, sizeof(agt));
 
                 int rc = 0;
-                agt->sock = OS_ConnectUDP(agt->port, agt->rip[rc]);
-                if (agt->sock < 0) {
-                    agt->sock = -1;
-                    merror(CONNS_ERROR, dname, agt->rip[rc]);
-                    rc++;
-
-                    /* Fail */
-                    if (agt->rip[rc] == NULL) {
+                while (agt->rip[rc] != NULL) {
+                    agt->sock = OS_ConnectUDP(agt->port, agt->rip[rc]);
+                    if (agt->sock < 0) {
+                        agt->sock = -1;
+                        merror(CONNS_ERROR, dname, agt->rip[rc]);
                         attempts += 10;
-                        /* Only log that if we have more than 1 server configured */
-                        if (agt->rip[1]) {
-                            merror("%s: ERROR: Unable to connect to any server.", dname);
-                        }
-
                         sleep(attempts);
-                        rc = 0;
-                    }
-                } else {
-                    /* Success */
-                    /* Send the socket back to agentd */
-                    if ((imsg_compose(ibuf, DNS_RESP, 0, 0, agt->sock, &idata, sizeof(idata))) == -1) {
-                        merror("%s [dns]: ERROR: DNS_RESP imsg_compose() failed: %s", dname, strerror(errno));
-                        freeaddrinfo(result);
-                        return;
+                        if (rc > 0) {
+                            merror("Could not connect to any server.");
+                            struct os_dns_error os_dns_err;
+                            os_dns_err.code = -1;
+                            imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &os_dns_err, sizeof(&os_dns_err));
+                            if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                                    merror("%s [dns]: ERROR: msgbuf_write() failed (AGENT_REQ)", dname);
+                                    return;
+                            }
+                            if (n == 0) {
+                                debug2("%s [dns]: DEBUG: AGENT_REQ size n == 0", dname);
+                                return;
+                            }
+                                    
+                        } else {
+                            rc++;
+                        }
                     } else {
-                        if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
-                            merror("%s [dns]: ERROR: DNS_RESP msgbuf_write() failed: %s", dname, strerror(errno));
+                        /* Success */
+                        /* Send the socket back to agentd */
+                        if ((imsg_compose(ibuf, DNS_RESP, 0, 0, agt->sock, &idata, sizeof(idata))) == -1) {
+                            merror("%s [dns]: ERROR: DNS_RESP imsg_compose() failed: %s", dname, strerror(errno));
+                            freeaddrinfo(result);
+                            return;
+                        } else {
+                            if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                                merror("%s [dns]: ERROR: DNS_RESP msgbuf_write() failed: %s", dname, strerror(errno));
+                                freeaddrinfo(result);
+                                return;
+                            }
+                            if (n == 0) {
+                                debug1("%s [dns]: DEBUG: n == 0", dname);
+                                return;
+                            }
                             freeaddrinfo(result);
                             return;
                         }
-                        if (n == 0) {
-                            debug1("%s [dns]: DEBUG: n == 0", dname);
-                            return;
-                        }
-                        freeaddrinfo(result);
-                        return;
+
                     }
-
                 }
-
                 break;
 #endif //CLIENT
             default:

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -61,6 +61,7 @@ void osdns_accept(int fd, short ev, void *arg) {
         }
         if (n == 0) {
             debug2("%s [dns]: DEBUG: n == 0", dname);
+            return;
         }
     } else {
         merror("Not EV_READ");
@@ -74,7 +75,7 @@ void osdns_accept(int fd, short ev, void *arg) {
         }
         if (n == 0) {
             debug2("%s [dns]: DEBUG: imsg_get() n == 0", dname);
-            break; /* No more messages */
+            return; /* No more messages */
         }
 
 
@@ -97,9 +98,11 @@ void osdns_accept(int fd, short ev, void *arg) {
                     }
                     if (n == 0) {
                         debug2("%s [dns]: DEBUG: DNS_FAIL size n == 0", dname);
+                        return;
                     }
                     if (n == EAGAIN) {
                         debug2("%s [dns]: DEBUG EAGAIN size", dname);
+                        return; //XXX
                     }
                 }
                 memcpy(&dnsr, imsg.data, sizeof(dnsr));
@@ -125,9 +128,11 @@ void osdns_accept(int fd, short ev, void *arg) {
                     }
                     if (n == 0) {
                         debug2("%s [dns]: DEBUG: DNS_FAIL n == 0", dname);
+                        return;
                     }
                     if (n == EAGAIN) {
                         debug2("%s [dns]: DEBUG: EAGAIN 1", dname);
+                        return; //XXX
                     }
                 }
 

--- a/src/os_dns/os_dns.c
+++ b/src/os_dns/os_dns.c
@@ -1,0 +1,222 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <err.h>
+#include <sys/types.h>
+#include <sys/queue.h>
+#include <sys/uio.h>
+#include <stdint.h>
+#include <imsg.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <pwd.h>
+
+/* Requires libevent */
+#include <event.h>
+
+#include "headers/privsep_op.h"
+#include "headers/debug_op.h"
+#include "os_net/os_net.h"
+#include "os_dns.h"
+
+
+
+void osdns_accept(int fd, short ev, void *arg) {
+
+    /* sssssssh */
+    if (fd) { }
+    if (ev) { }
+    merror("ossec-maild [dns]: INFO: osdns_accept()");
+
+    /* temporary things */
+    char *protocol = "tcp";
+
+
+    /* We have a request from ossec-maild */
+    struct dns_request dnsr;
+    ssize_t n, datalen;
+    struct imsg imsg;
+    struct imsgbuf *ibuf = (struct imsgbuf *)arg;
+
+    merror("ossec-maild [dns]: DEBUG: Starting imsg stuff.");
+
+    if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN) {
+        ErrorExit("ossec-maild [dns]: ERROR: imsg_read() failed: %s", strerror(errno));
+        return;
+    }
+    if (n == 0) {
+        merror("ossec-maild [dns]: DEBUG: n == 0");
+    }
+    merror("ossec-maild [dns]: DEBUG: imsg_read() succeeded.");
+
+    if ((n = imsg_get(ibuf, &imsg)) == -1) {
+        merror("ossec-maild [dns]: ERROR: imsg_get() failed: %s", strerror(errno));
+        return;
+    }
+    if (n == 0) {
+        merror("ossec-maild [dns]: DEBUG: imsg_get() n == 0");
+    }
+
+    merror("ossec-maild [dns]: DEBUG: imsg_get() successful");
+
+    datalen = imsg.hdr.len - IMSG_HEADER_SIZE;
+    merror("ossec-maild [dns]: DEBUG datalen: %zd (hdr.len: %d/%lu)", datalen, imsg.hdr.len, IMSG_HEADER_SIZE); 
+
+    switch(imsg.hdr.type) {
+        case DNS_REQ:
+            merror("ossec-maild [dns]: DEBUG: It's the memcpy, isn't it?");
+            memcpy(&dnsr, imsg.data, sizeof(dnsr));
+            //memcpy(&hostname, imsg.data, datalen);
+            //memcpy(&hostname, imsg.data, datalen);
+            //hostname = imsg.data;
+            //hostname = strndup(imsg.data, 255);
+            //strlcpy(hostname, (char *)imsg.data, 255);
+            merror("ossec-maild [dns]: DEBUG: hostname: XXX%sXXX (%lu)", dnsr.hostname, sizeof(dnsr.hostname));
+            //strlcpy(&hostname, "ix.example.com", 15);
+            //merror("ossec-maild [dns]: DEBUG: hostname: XXX%sXXX (%lu)", &hostname, sizeof(hostname));
+            int idata = 42;
+            struct addrinfo hints, *result, *rp = NULL;
+            memset(&hints, 0, sizeof(hints));
+            hints.ai_family = AF_UNSPEC;
+            if (strncmp(protocol, "tcp", 3) == 0) {
+                hints.ai_socktype = SOCK_STREAM;
+            } else if (strncmp(protocol, "udp", 3) == 0) {
+                hints.ai_socktype = SOCK_DGRAM;
+            }
+
+            merror("ossec-maild [dns]: DEBUG: Starting socket work.");
+            /* socket */
+            int sock;
+            sock = getaddrinfo(dnsr.hostname, "smtp", &hints, &result);
+            if (sock != 0) {
+                merror("ossec-maild [dns]: ERROR: getaddrinfo() error: %s\n", gai_strerror(sock));
+                imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &idata, sizeof(idata));
+                if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                    merror("ossec-maild [dns]: ERROR: msgbuf_write() failed (DNS_FAIL): %s", strerror(errno));
+                }
+                if (n == 0) {
+                    merror("ossec-maild [dns]: DEBUG: DNS_FAIL n == 0");
+                }
+                if (n == EAGAIN) {
+                    merror("ossec-maild [dns]: DEBUG: EAGAIN 1");
+                }
+                merror("ossec-maild [dns]: DEBUG: Got past the imsg stuff");
+                //return;
+            }
+
+            merror("ossec-maild [dns]: DEBUG: getaddrinfo() seems to have succeeded.");
+
+            sock = -1;
+            for(rp = result; rp; rp = rp->ai_next) {
+                sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+                if (sock == -1) {
+                    merror("ossec-maild [dns]: ERROR: socket() error");
+                } else {
+                    merror("ossec-maild [dns]: DEBUG: Connecting...");
+                    if (connect(sock, rp->ai_addr, rp->ai_addrlen) == -1) {
+                        merror("ossec-maild [dns]: ERROR: connect() failed.");
+                        //XXX return error to caller
+                    } else {
+                        merror("ossec-maild [dns]: DEBUG: Did I totally forget to tell OS_Sendmail() that we have a socket?");
+                        if ((imsg_compose(ibuf, DNS_RESP, 0, 0, sock, &idata, sizeof(idata))) == -1) {
+                            merror("ossec-maild [dns]: ERROR: DNS_RESP imsg_compose() failed: %s", strerror(errno));
+                            freeaddrinfo(result);
+                            return;
+                        } else {
+                            if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                                merror("ossec-maild [dns]: ERROR: DNS_RESP msgbuf_write() failed: %s", strerror(errno));
+                                freeaddrinfo(result);
+                                return;
+                            }
+                            if (n == 0) {
+                                merror("ossec-maild [dns]: DEBUG: DNS_RESP n == 0");
+                            }
+                            freeaddrinfo(result);
+                            return;
+                        }
+                    }
+                }
+            }
+            break;
+        default:
+            merror("ossec-maild [dns]: ERROR: Unknown imsg type");
+            if ((imsg_compose(ibuf, DNS_FAIL, 0, 0, -1, &idata, sizeof(idata))) == -1) {
+                merror("ossec-maild [dns]: ERROR: DNS_FAIL imsg_compose() failed: %s", strerror(errno));
+                return;
+            } else {
+                if ((n = msgbuf_write(&ibuf->w) == -1) && errno != EAGAIN) {
+                    merror("ossec-maild [dns]: ERROR: DNS_FAIL msgbuf_write failed: %s", strerror(errno));
+                    return;
+                }
+                if (n == 0) {
+                    merror("ossec-maild [dns]: DEBUG: DNS_FAIL n == 0");
+                    return;
+                }
+            }
+            return;
+    }
+
+
+
+    merror("ossec-maild [dns]: DEBUG: how did I get here?");
+    return;
+}
+
+/* osdns() is simple, it received the ibuf and
+ * sets up the event loop for the parent to query.
+ * osdns_accept() will pass a socket back to the 
+ * parent with the connection established.
+ *
+ * Focusing on TCP right now.
+ */
+int osdns(struct imsgbuf *ibuf) {
+
+
+#if __OpenBSD__
+    setproctitle("[dns]");
+#endif
+
+    merror("ossec-maild [dns]: INFO: Starting osdns");
+
+    /* setuid() ossecm */
+    /* This is static ossecm for now, I'll figure out the trick later */
+    char *login = "ossecm";
+    struct passwd *pw;
+
+
+    pw = getpwnam(login);
+
+
+    if (Privsep_SetGroup(pw->pw_gid) < 0) {
+        ErrorExit("ossec-maild [dns]: ERROR: Cannot setgid.");
+    }
+    if (Privsep_SetUser(pw->pw_uid) < 0) {
+        ErrorExit("ossec-maild [dns]: ERROR: Cannot setuid.");
+    }
+
+    /* Setup libevent */
+    struct event_base *eb;
+    eb = event_init();
+    if (!eb) {
+        ErrorExit("ossec-maild [dns]: event_init() failed.");
+    }
+
+    merror("ossec-maild [dns]: INFO: Starting libevent.");
+    struct event ev_accept;
+    event_set(&ev_accept, ibuf->fd, EV_READ|EV_PERSIST, osdns_accept, ibuf);
+    event_add(&ev_accept, NULL);
+    event_dispatch();
+
+
+
+    return(0);
+}
+
+
+
+
+
+

--- a/src/os_dns/os_dns.h
+++ b/src/os_dns/os_dns.h
@@ -14,6 +14,7 @@ struct os_dns_request {
     char *hostname;
     size_t hname_len;
     char *caller;
+    char *protocol;
 };
 
 struct os_dns_error {

--- a/src/os_dns/os_dns.h
+++ b/src/os_dns/os_dns.h
@@ -1,6 +1,6 @@
 #include <imsg.h>
 
-int osdns(struct imsgbuf *ibuf);
+int osdns(struct imsgbuf *ibuf, char *os_name);
 void osdns_accept(int fd, short ev, void *arg);
 
 /* Two types of messages */

--- a/src/os_dns/os_dns.h
+++ b/src/os_dns/os_dns.h
@@ -1,0 +1,17 @@
+
+
+int osdns(struct imsgbuf *ibuf);
+void osdns_accept(int fd, short ev, void *arg);
+
+/* Two types of messages */
+enum imsg_type {
+    DNS_REQ,
+    DNS_RESP,
+    DNS_FAIL
+};
+
+struct dns_request {
+    char *hostname;
+    size_t hname_len;
+};
+

--- a/src/os_dns/os_dns.h
+++ b/src/os_dns/os_dns.h
@@ -7,7 +7,8 @@ void osdns_accept(int fd, short ev, void *arg);
 enum imsg_type {
     DNS_REQ,
     DNS_RESP,
-    DNS_FAIL
+    DNS_FAIL,
+    AGENT_REQ
 };
 
 struct os_dns_request {
@@ -15,6 +16,7 @@ struct os_dns_request {
     size_t hname_len;
     char *caller;
     char *protocol;
+    char *port;
 };
 
 struct os_dns_error {

--- a/src/os_dns/os_dns.h
+++ b/src/os_dns/os_dns.h
@@ -18,6 +18,6 @@ struct os_dns_request {
 
 struct os_dns_error {
     int code;
-    char *msg;
+    const char *msg;
 };
 

--- a/src/os_dns/os_dns.h
+++ b/src/os_dns/os_dns.h
@@ -1,4 +1,4 @@
-
+#include <imsg.h>
 
 int osdns(struct imsgbuf *ibuf);
 void osdns_accept(int fd, short ev, void *arg);

--- a/src/os_dns/os_dns.h
+++ b/src/os_dns/os_dns.h
@@ -10,9 +10,10 @@ enum imsg_type {
     DNS_FAIL
 };
 
-struct dns_request {
+struct os_dns_request {
     char *hostname;
     size_t hname_len;
+    char *caller;
 };
 
 struct os_dns_error {

--- a/src/os_dns/os_dns.h
+++ b/src/os_dns/os_dns.h
@@ -15,3 +15,8 @@ struct dns_request {
     size_t hname_len;
 };
 
+struct os_dns_error {
+    int code;
+    char *msg;
+};
+

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009 Trend Micro Inc.
+/* Copyright (C) 2019 Trend Micro Inc.
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -275,7 +275,9 @@ static void OS_Run(MailConfig *mail)
         if ((mail_timeout == NEXTMAIL_TIMEOUT) && (p->tm_hour == thishour)) {
             /* Get more messages */
         }
-
+        else if ((mailtosend > mail->maxperhour) && (mailtosend != 0)) {
+            merror("%s: INFO: Max emails per hour reached.", ARGV0);
+        }
         /* Hour changed: send all suppressed mails */
         else if (((mailtosend < mail->maxperhour) && (mailtosend != 0)) ||
                  ((p->tm_hour != thishour) && (childcount < MAXCHILDPROCESS))) {

--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -179,7 +179,7 @@ int main(int argc, char **argv)
         case 0:
             close(imsg_fds[0]);
             imsg_init(&osdns_ibuf, imsg_fds[1]);
-            exit(osdns(&osdns_ibuf));
+            exit(osdns(&osdns_ibuf, ARGV0));
     }
 
     /* Setup imsg for the rest of maild */

--- a/src/os_maild/maild.h
+++ b/src/os_maild/maild.h
@@ -77,5 +77,7 @@ extern unsigned int mail_timeout;
 extern unsigned int   _g_subject_level;
 extern char _g_subject[SUBJECT_SIZE + 2];
 
+void os_sendmail_cb(int fd, short ev, void *arg);
+
 #endif
 

--- a/src/os_maild/maild.h
+++ b/src/os_maild/maild.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009 Trend Micro Inc.
+/* Copyright (C) 2019 Trend Micro Inc.
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -91,7 +91,7 @@ void os_sendmail_cb(int fd, short ev, void *arg) {
             return;
         default:
             merror("%s: ERROR Wrong imsg type.", ARGV0);
-            return;
+            break;
     }
 
 
@@ -138,18 +138,12 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
             ErrorExit("%s: ERROR: event_init() failed.", ARGV0);
         }
 
-        merror("ossec-maild: DEBUG: mail->ibuf.fd: %d", mail->ibuf.fd);
-
         struct event ev_accept;
         event_set(&ev_accept, mail->ibuf.fd, EV_READ, os_sendmail_cb, &mail->ibuf);
         event_add(&ev_accept, NULL);
 
-        merror("ossec-maild: DEBUG: Preparing imsg stuff");
-        //struct imsg imsg;
         ssize_t n;
         
-        merror("ossec-maild: DEBUG: pre-strlcpy");
-       
         struct os_dns_request dnsr; 
         dnsr.hostname = mail->smtpserver;
         dnsr.hname_len = strnlen(dnsr.hostname, 256);
@@ -167,11 +161,10 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
             debug2("%s: INFO: (write) n == 0", ARGV0);
         }
 
-        merror("ossec-maild: DEBUG: starting event loop");
+        debug1("ossec-maild: DEBUG: starting event loop");
 
         event_dispatch();
     }
-    merror("%s: INFO: post event_dispatch()", ARGV0);
 
     if (os_sock <= 0) {
         ErrorExit("ossec-maild: ERROR: No socket.");

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -150,7 +150,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         
         merror("ossec-maild: DEBUG: pre-strlcpy");
        
-        struct dns_request dnsr; 
+        struct os_dns_request dnsr; 
         dnsr.hostname = mail->smtpserver;
         dnsr.hname_len = strnlen(dnsr.hostname, 256);
         merror("%s: DEBUG: hostname: XXX%sXXX", ARGV0, dnsr.hostname);

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009 Trend Micro Inc.
+/* Copyright (C) 2019 Trend Micro Inc.
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -65,10 +65,10 @@ void os_sendmail_cb(int fd, short ev, void *arg) {
         ErrorExit("%s: ERROR: imsg_read() failed: %s", ARGV0, strerror(errno));
     }
     if (n == 0) {
-        merror("%s: WARN: n == 0", ARGV0);
+        debug2("%s: DEBUG: n == 0", ARGV0);
     }
     if (n == EAGAIN) {
-        merror("%s: DEBUG: n == EAGAIN", ARGV0);
+        debug2("%s: DEBUG: n == EAGAIN", ARGV0);
     }
 
     merror("%s: DEBUG: ibuf->fd: %d", ARGV0, ibuf->fd);
@@ -78,7 +78,7 @@ void os_sendmail_cb(int fd, short ev, void *arg) {
         return;
     }
     if (n == 0) {
-        merror("%s: WARN2: n == 0", ARGV0);
+        debug2("%s: DEBUG: n == 0", ARGV0);
     }
 
     switch(imsg.hdr.type) {
@@ -103,7 +103,6 @@ void os_sendmail_cb(int fd, short ev, void *arg) {
 
 int OS_Sendmail(MailConfig *mail, struct tm *p)
 {
-    merror("ossec-maild: DEBUG: Inside OS_Sendmail()");
     FILE *sendmail = NULL;
     os_sock = -1;
     unsigned int i = 0;
@@ -112,7 +111,6 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
 
     MailNode *mailmsg;
 
-    merror("ossec-maild: DEBUG: OS_PopLastMail()");
     /* If there is no sms message, attempt to get from the email list */
     mailmsg = OS_PopLastMail();
 
@@ -121,7 +119,6 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         return (OS_INVALID);
     }
 
-    merror("ossec-maild: DEBUG: Got the lastmail");
 
     if (mail->smtpserver[0] == '/') {
         sendmail = popen(mail->smtpserver, "w");
@@ -160,8 +157,6 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         if (n == 0) {
             debug2("%s: INFO: (write) n == 0", ARGV0);
         }
-
-        debug1("ossec-maild: DEBUG: starting event loop");
 
         event_dispatch();
     }

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -154,21 +154,17 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         dnsr.hostname = mail->smtpserver;
         dnsr.hname_len = strnlen(dnsr.hostname, 256);
         dnsr.caller = ARGV0;
-        merror("%s: DEBUG: hostname: XXX%sXXX", ARGV0, dnsr.hostname);
-
-        merror("ossec-maild: DEBUG: imsg_compose() (sizeof(hostname): %lu)", sizeof(dnsr.hostname));
+        dnsr.protocol = "smtp";
 
         if ((imsg_compose(&mail->ibuf, DNS_REQ, 0, 0, -1, &dnsr, sizeof(&dnsr))) == -1) {
             merror("%s: ERROR: imsg_compose() error: %s", ARGV0, strerror(errno));
         }
 
-        merror("ossec-maild: DEBUG: msgbuf_write");
-
         if ((n = msgbuf_write(&mail->ibuf.w)) == -1 && errno != EAGAIN) {
             merror("%s: ERROR: msgbuf_write() error: %s", ARGV0, strerror(errno));
         }
         if (n == 0) {
-            merror("%s: INFO: (write) n == 0", ARGV0);
+            debug2("%s: INFO: (write) n == 0", ARGV0);
         }
 
         merror("ossec-maild: DEBUG: starting event loop");

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -153,6 +153,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         struct os_dns_request dnsr; 
         dnsr.hostname = mail->smtpserver;
         dnsr.hname_len = strnlen(dnsr.hostname, 256);
+        dnsr.caller = ARGV0;
         merror("%s: DEBUG: hostname: XXX%sXXX", ARGV0, dnsr.hostname);
 
         merror("ossec-maild: DEBUG: imsg_compose() (sizeof(hostname): %lu)", sizeof(dnsr.hostname));

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -65,7 +65,7 @@ void os_sendmail_cb(int fd, short ev, void *arg) {
     }
     if (n == 0) {
         debug2("%s: DEBUG: n == 0", ARGV0);
-        return;
+        //return; //XXX
     }
     if (n == EAGAIN) {
         debug2("%s: DEBUG: n == EAGAIN", ARGV0);

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -54,7 +54,6 @@ int os_sock;
 void os_sendmail_cb(int fd, short ev, void *arg) {
     if (fd) { }
     if (ev) {}
-    merror("ossec-maild: DEBUG: os_sendmail_cb");
 
     /* Have to get the *arg stuff */
     ssize_t n;
@@ -66,12 +65,12 @@ void os_sendmail_cb(int fd, short ev, void *arg) {
     }
     if (n == 0) {
         debug2("%s: DEBUG: n == 0", ARGV0);
+        return;
     }
     if (n == EAGAIN) {
         debug2("%s: DEBUG: n == EAGAIN", ARGV0);
+        return; //XXX
     }
-
-    merror("%s: DEBUG: ibuf->fd: %d", ARGV0, ibuf->fd);
 
     if ((n = imsg_get(ibuf, &imsg)) == -1) {
         merror("%s: ERROR: imsg_get() failed: %s", ARGV0, strerror(errno));
@@ -79,16 +78,16 @@ void os_sendmail_cb(int fd, short ev, void *arg) {
     }
     if (n == 0) {
         debug2("%s: DEBUG: n == 0", ARGV0);
+        return;
     }
 
     switch(imsg.hdr.type) {
         case DNS_RESP:
             os_sock = imsg.fd;
-            merror("%s: DEBUG: os_sock: %d", ARGV0, os_sock);
             break;
         case DNS_FAIL:
             merror("%s: ERROR: DNS failure for smtpserver", ARGV0);
-            return;
+            break;;
         default:
             merror("%s: ERROR Wrong imsg type.", ARGV0);
             break;

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -836,3 +836,17 @@ char *DecodeProtocol (int val) {
     return (buf);
 }
 
+/* Set a socket to be non-blocking */
+int setnonblock(int fd) {
+    int flags;
+
+    flags = fcntl(fd, F_GETFL);
+    if (flags < 0)
+        return flags;
+    flags |= O_NONBLOCK;
+    if (fcntl(fd, F_SETFL, flags) < 0)
+        return -1;
+
+        return 0;
+}
+

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -836,6 +836,7 @@ char *DecodeProtocol (int val) {
     return (buf);
 }
 
+#ifndef WIN32
 /* Set a socket to be non-blocking */
 int setnonblock(int fd) {
     int flags;
@@ -850,4 +851,5 @@ int setnonblock(int fd) {
 
     return 0;
 }
+#endif //WIN32
 

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -844,9 +844,10 @@ int setnonblock(int fd) {
     if (flags < 0)
         return flags;
     flags |= O_NONBLOCK;
-    if (fcntl(fd, F_SETFL, flags) < 0)
+    if (fcntl(fd, F_SETFL, flags) < 0) {
         return -1;
+    }
 
-        return 0;
+    return 0;
 }
 

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -34,6 +34,10 @@ typedef uint16_t u_int16_t;
 typedef uint32_t u_int32_t;
 #endif
 
+#ifndef WIN32
+#include <imsg.h>
+#endif //WIN32
+
 /*
  * OSNetInfo is used to exchange a set of bound sockets for use with the
  * select() function for monitoring incoming packets on multiple interfaces.

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -118,5 +118,8 @@ int satop(struct sockaddr *sa, char *dst, socklen_t size);
  */
 int OS_CloseSocket(int socket);
 
+/* Set a socket to be non-blocking */
+int setnonblock(int fd);
+
 #endif /* __OS_NET_H */
 


### PR DESCRIPTION
After a number of networking changes were made to better handle IPv6, some hosts
(linux specifically) seem to have issues with networking. This seems to be more
prevalent on systems where IPv6 has been disabled. The `chroot(8)` has also added
complications.
One work-around has been to copy the `/etc/resolv.conf` to `ossec/etc` which has
helped a number of people, but it doesn't seem to work for everyone.

Proposed solution:
Fork off a second `maild`/`agentd` process for DNS lookups. This process would run as
the OSSEC user the original process runs as (`ossecm` for `maild`, `ossec` for `agentd`
by default). It will not be chrooted.
The 2 processes communicate via a socketpair(2) and the OpenBSD
[imsg(3)](http://man.openbsd.org/imsg_init) framework. This is currently being used in
a number of OpenBSD utilities for communicating between processes that require different
privileges.

ossec-agentd:
`ossec-agentd` will fork off the dns process. When a connection is attempted, it forwards
the information to the dns process. This process will then use `OS_ConnectUDP()` to attempt
communication with the OSSEC server, just like `ossec-agentd` did previously. The socket
created for this is then passed back to the original agentd process for use.

ossec-maild:
`ossec-maild` will fork off the dns process, and periodically fork `OS_Sendmail()` processes
to send alert emails. This sendmail process would then communicate with the dns process, sending
it the `mail->smtpserver`. The dns process will perform the getaddrinfo, connect to the server,
and pass the connected socket back to the sendmail process for actually sending the mail.

All of this does add complexity and [libevent](http://libevent.org/) has been added as a dependency.

Other possible solutions that I did not explore:

- Remove the chroot(8). This isn't going to happen, it's an important part of the
privilege separation scheme in use by OSSEC.

- Static compilation. This doesn't help with the `/etc/resolv.conf` issue, but
would help with making sure the processes can perform a getaddrinfo(3) even in the
chroot (after `/etc/resolv.conf` is copied to the chroot). Unfortunately, I don't
think this is possible on Linux due to its support for various things (nss switch
maybe?). Statically linking against [musl](https://www.musl-libc.org/) might work, but I haven't looked into it.


Tested on:
- OpenBSD/amd64 (various versions)
- OpenBSD/arm64 (various versions)
- CentOS 7.x/amd64
- OpenSuse 15.0

I'm sure there are bugs, edge cases, and other oddities in the code. It's been running successfully for me,
but I don't have a huge variety of systems in use. I'm also sure there are places that just need to be cleaned
up. Error messages should probably go in `src/error_messages/error_messages.h`, there's probably some left over
debugging stuff in there, etc.

```
[ddp@c7-0 ~]$ uname -a
Linux c7-0 3.10.0-693.el7.x86_64 #1 SMP Tue Aug 22 21:09:27 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
[ddp@c7-0 ~]$ cat /etc/redhat-release
CentOS Linux release 7.4.1708 (Core)

ddp@suse:~> uname -a
Linux suse 4.12.14-lp150.12.48-default #1 SMP Tue Feb 12 14:01:48 UTC 2019 (268f014) x86_64 x86_64 x86_64 GNU/Linux
ddp@suse:/etc> cat SUSE-brand
openSUSE
VERSION = 15.0
```

Should fix Issue #1145 and probably others.