### PR TITLE
Try to silence the "Attempted to check FS status for" message.

### DIFF
--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -101,10 +101,12 @@ short skipFS(const char *dir_name)
         return(-1);
     }
 #else
-    verbose(
+#ifndef WIN32
+    debug2(
         "INFO: Attempted to check FS status for '%s', but we don't know how on this OS.",
         dir_name
     );
+#endif
 #endif
     return(0);
 }


### PR DESCRIPTION
It isn't really needed on Windows, so it just clutters up the log.
I really hate this error message.
Hopefully fixes issue #1699 