### PR TITLE
Add some basic error handling to syscheck_control

### DIFF
--- a/src/shared/fs_op.c
+++ b/src/shared/fs_op.c
@@ -101,10 +101,12 @@ short skipFS(const char *dir_name)
         return(-1);
     }
 #else
-    verbose(
+#ifndef WIN32
+    debug2(
         "INFO: Attempted to check FS status for '%s', but we don't know how on this OS.",
         dir_name
     );
+#endif
 #endif
     return(0);
 }

--- a/src/util/syscheck_control.c
+++ b/src/util/syscheck_control.c
@@ -234,9 +234,13 @@ int main(int argc, char **argv)
                 fp = fopen(full_path, "w");
                 if (fp) {
                     fclose(fp);
+                } else {
+                    ErrorExit("%s: ERROR: Cannot open %s: %s", ARGV0, full_path, strerror(errno));
                 }
                 if (entry->d_name[0] == '.') {
-                    unlink(full_path);
+                    if ((unlink(full_path)) != 0) {
+                        ErrorExit("%s: ERROR: Cannot delete %s: %s", ARGV0, full_path, strerror(errno));
+                    }
                 }
             }
 
@@ -261,8 +265,12 @@ int main(int argc, char **argv)
             fp = fopen(final_dir, "w");
             if (fp) {
                 fclose(fp);
+            } else {
+                ErrorExit("%s: ERROR: Cannot open %s: %s", ARGV0, final_dir, strerror(errno));
             }
-            unlink(final_dir);
+            if ((unlink(final_dir)) != 0) {
+                ErrorExit("%s: ERROR: Cannot delete %s: %s", ARGV0, final_dir, strerror(errno));
+            }
 
 
             /* Deleting cpt file */
@@ -271,8 +279,12 @@ int main(int argc, char **argv)
             fp = fopen(final_dir, "w");
             if (fp) {
                 fclose(fp);
+            } else {
+                ErrorExit("%s: ERROR: Cannot open %s: %s", ARGV0, final_dir, strerror(errno));
             }
-            unlink(final_dir);
+            if ((unlink(final_dir)) != 0) {
+                ErrorExit("%s: ERROR: Cannot delete %s: %s", ARGV0, final_dir, strerror(errno));
+            }
 
             if (json_output) {
                 cJSON_AddNumberToObject(json_root, "error", 0);


### PR DESCRIPTION
Mostly providing log messages when `fopen` or `unlink` fail. 
There are so many instances of unhandled errors throughout the tree. If someone wants a place to get started with the code, looking for those and dealing with errors is a good one.