### PR TITLE
csyslogd CEF – Remove duplicate parameters and fix discarded hashes

### DIFF
--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -145,8 +145,6 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=SrcCity cs4=%s", al_data->srcgeoip );
         field_add_string(syslog_msg, OS_SIZE_2048, " cs5Label=DstCity cs5=%s", al_data->dstgeoip );
 #endif
-        field_add_string(syslog_msg, OS_SIZE_2048, " suser=%s", al_data->user );
-        field_add_string(syslog_msg, OS_SIZE_2048, " dst=%s", al_data->dstip );
         field_add_truncated(syslog_msg, OS_SIZE_2048, " msg=%s", al_data->log[0], 2 );
         if (al_data->new_md5 && al_data->new_sha1) {
             field_add_string(syslog_msg, OS_SIZE_2048, " cs2Label=OldMD5 cs2=%s", al_data->old_md5);

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -145,7 +145,6 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=SrcCity cs4=%s", al_data->srcgeoip );
         field_add_string(syslog_msg, OS_SIZE_2048, " cs5Label=DstCity cs5=%s", al_data->dstgeoip );
 #endif
-        field_add_truncated(syslog_msg, OS_SIZE_2048, " msg=%s", al_data->log[0], 2 );
         if (al_data->new_md5 && al_data->new_sha1) {
             field_add_string(syslog_msg, OS_SIZE_2048, " cs2Label=OldMD5 cs2=%s", al_data->old_md5);
             field_add_string(syslog_msg, OS_SIZE_2048, " cs3Label=NewMD5 cs3=%s", al_data->new_md5);
@@ -153,6 +152,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
             field_add_string(syslog_msg, OS_SIZE_2048, " fhash=%s", al_data->new_sha1 );
             field_add_string(syslog_msg, OS_SIZE_2048, " fileHash=%s", al_data->new_sha1 );
         }
+        field_add_truncated(syslog_msg, OS_SIZE_2048, " msg=%s", al_data->log[0], 2 );
     } else if (syslog_config->format == JSON_CSYSLOG) {
         /* Build a JSON Object for logging */
         cJSON *root;


### PR DESCRIPTION
I was playing around with a few log collectors that support CEF, so I decided to give it a try. While debugging a few issues I noticed that some parameters were duplicated, so I looked into the sources and found out that:

* `suser` and `dst` are added twice for each CEF message;
* the truncated `msg` is not added to the string as the last parameter, possibly causing file hashes to be discarded when combined with a large enough message;
* the current implementation of CEF is broken and non compliant with the standard.

This PR fixes the first two points, while the third one is a bit more complex so I'm gonna open an issue before tinkering around too much, being new to this code base and all.