### PR TITLE
Fix: csyslogd – CEF escaping / multi-line syslog

### DIFF
--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -29,7 +29,7 @@ char *cefescape(const char *msg, const bool header)
         buffer = NULL;
     }
 
-    /* Test if the string needs escaping in the first place */
+    /* Test if the string needs escaping */
     if ((NULL == msg) ||                            /* Cleanup call or empty string */
         ((header && (NULL == strchr(msg, '|'))) &&  /* | in the header must be escaped */
         (!header && (NULL == strchr(msg, '='))) &&  /* = in the extension must be escaped */
@@ -41,12 +41,16 @@ char *cefescape(const char *msg, const bool header)
 
     verbose("%s", msg);  //@REMOVE
 
-    /* Calculate the size of the escaped message */
+    /* Calculate the size of the escaped message
+     * 
+     * In the header we replace \r and \n with a
+     * space, so there's no change in size.
+     */
     ptr = msg;
     size = 1;
     while (*ptr) {
         if (('\\' == *ptr) ||
-            (header && ('|' == *ptr)) ||  /* For headers we replace \r\n with spaces */
+            (header && ('|' == *ptr)) ||
             (!header && (
                 ('=' == *ptr) ||
                 ('\r' == *ptr) ||
@@ -212,25 +216,25 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                  al_data->rule, al_data->comment,
                  al_data->location
                 );
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification: %s;", al_data->group );
-        field_add_string(syslog_msg, OS_SIZE_2048, " srcip: %s;", al_data->srcip );
+        field_add_string(syslog_msg, OS_SIZE_2048, " classification: %s;", al_data->group);
+        field_add_string(syslog_msg, OS_SIZE_2048, " srcip: %s;", al_data->srcip);
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " srccity: %s;", al_data->srcgeoip );
-        field_add_string(syslog_msg, OS_SIZE_2048, " dstcity: %s;", al_data->dstgeoip );
+        field_add_string(syslog_msg, OS_SIZE_2048, " srccity: %s;", al_data->srcgeoip);
+        field_add_string(syslog_msg, OS_SIZE_2048, " dstcity: %s;", al_data->dstgeoip);
 #endif
-        field_add_string(syslog_msg, OS_SIZE_2048, " dstip: %s;", al_data->dstip );
-        field_add_string(syslog_msg, OS_SIZE_2048, " user: %s;", al_data->user );
-        field_add_string(syslog_msg, OS_SIZE_2048, " Previous MD5: %s;", al_data->old_md5 );
-        field_add_string(syslog_msg, OS_SIZE_2048, " Current MD5: %s;", al_data->new_md5 );
-        field_add_string(syslog_msg, OS_SIZE_2048, " Previous SHA1: %s;", al_data->old_sha1 );
-        field_add_string(syslog_msg, OS_SIZE_2048, " Current SHA1: %s;", al_data->new_sha1 );
-     /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-        field_add_string(syslog_msg, OS_SIZE_2048, " Size changed: from %s;", al_data->file_size );
-        field_add_string(syslog_msg, OS_SIZE_2048, " User ownership: was %s;", al_data->owner_chg );
-        field_add_string(syslog_msg, OS_SIZE_2048, " Group ownership: was %s;", al_data->group_chg );
-        field_add_string(syslog_msg, OS_SIZE_2048, " Permissions changed: from %s;", al_data->perm_chg );
-     /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-        field_add_truncated(syslog_msg, OS_SIZE_2048, " %s", al_data->log[0], 2 );
+        field_add_string(syslog_msg, OS_SIZE_2048, " dstip: %s;", al_data->dstip);
+        field_add_string(syslog_msg, OS_SIZE_2048, " user: %s;", al_data->user);
+        field_add_string(syslog_msg, OS_SIZE_2048, " Previous MD5: %s;", al_data->old_md5);
+        field_add_string(syslog_msg, OS_SIZE_2048, " Current MD5: %s;", al_data->new_md5);
+        field_add_string(syslog_msg, OS_SIZE_2048, " Previous SHA1: %s;", al_data->old_sha1);
+        field_add_string(syslog_msg, OS_SIZE_2048, " Current SHA1: %s;", al_data->new_sha1);
+        /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
+        field_add_string(syslog_msg, OS_SIZE_2048, " Size changed: from %s;", al_data->file_size);
+        field_add_string(syslog_msg, OS_SIZE_2048, " User ownership: was %s;", al_data->owner_chg);
+        field_add_string(syslog_msg, OS_SIZE_2048, " Group ownership: was %s;", al_data->group_chg);
+        field_add_string(syslog_msg, OS_SIZE_2048, " Permissions changed: from %s;", al_data->perm_chg);
+        /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
+        field_add_truncated(syslog_msg, OS_SIZE_2048, " %s", al_data->log[0], 2);
     } else if (syslog_config->format == CEF_CSYSLOG) {
         snprintf(syslog_msg, OS_SIZE_2048,
                  "<%u>%s CEF:0|%s|%s|%s|%u|%s|%u|dvc=%s cs1=%s cs1Label=Location",
@@ -243,25 +247,25 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                  al_data->comment,
                  (al_data->level > 10) ? 10 : al_data->level,
                  hostname, al_data->location);
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification=%s", al_data->group );
-        field_add_string(syslog_msg, OS_SIZE_2048, " src=%s", al_data->srcip );
-        field_add_int(syslog_msg, OS_SIZE_2048, " dpt=%d", al_data->dstport );
-        field_add_int(syslog_msg, OS_SIZE_2048, " spt=%d", al_data->srcport );
-        field_add_string(syslog_msg, OS_SIZE_2048, " fname=%s", al_data->filename );
-        field_add_string(syslog_msg, OS_SIZE_2048, " dhost=%s", al_data->dstip );
-        field_add_string(syslog_msg, OS_SIZE_2048, " shost=%s", al_data->srcip );
-        field_add_string(syslog_msg, OS_SIZE_2048, " suser=%s", al_data->user );
-        field_add_string(syslog_msg, OS_SIZE_2048, " dst=%s", al_data->dstip );
+        field_add_string(syslog_msg, OS_SIZE_2048, " classification=%s", al_data->group);
+        field_add_string(syslog_msg, OS_SIZE_2048, " src=%s", al_data->srcip);
+        field_add_int(syslog_msg, OS_SIZE_2048, " dpt=%d", al_data->dstport);
+        field_add_int(syslog_msg, OS_SIZE_2048, " spt=%d", al_data->srcport);
+        field_add_string(syslog_msg, OS_SIZE_2048, " fname=%s", al_data->filename);
+        field_add_string(syslog_msg, OS_SIZE_2048, " dhost=%s", al_data->dstip);
+        field_add_string(syslog_msg, OS_SIZE_2048, " shost=%s", al_data->srcip);
+        field_add_string(syslog_msg, OS_SIZE_2048, " suser=%s", al_data->user);
+        field_add_string(syslog_msg, OS_SIZE_2048, " dst=%s", al_data->dstip);
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=SrcCity cs4=%s", al_data->srcgeoip );
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs5Label=DstCity cs5=%s", al_data->dstgeoip );
+        field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=SrcCity cs4=%s", al_data->srcgeoip);
+        field_add_string(syslog_msg, OS_SIZE_2048, " cs5Label=DstCity cs5=%s", al_data->dstgeoip);
 #endif
         if (al_data->new_md5 && al_data->new_sha1) {
             field_add_string(syslog_msg, OS_SIZE_2048, " cs2Label=OldMD5 cs2=%s", al_data->old_md5);
             field_add_string(syslog_msg, OS_SIZE_2048, " cs3Label=NewMD5 cs3=%s", al_data->new_md5);
-            field_add_string(syslog_msg, OS_SIZE_2048, " oldFileHash=%s", al_data->old_sha1 );
-            field_add_string(syslog_msg, OS_SIZE_2048, " fhash=%s", al_data->new_sha1 );
-            field_add_string(syslog_msg, OS_SIZE_2048, " fileHash=%s", al_data->new_sha1 );
+            field_add_string(syslog_msg, OS_SIZE_2048, " oldFileHash=%s", al_data->old_sha1);
+            field_add_string(syslog_msg, OS_SIZE_2048, " fhash=%s", al_data->new_sha1);
+            field_add_string(syslog_msg, OS_SIZE_2048, " fileHash=%s", al_data->new_sha1);
         }
         field_add_truncated(syslog_msg, OS_SIZE_2048, " msg=%s", cefescape(logmsg, false), 2);
         cefescape(NULL,0);  /* Clean up the escaping buffer */
@@ -286,39 +290,39 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
 
         /* Raw log message generating event */
         if (al_data->log && al_data->log[0]) {
-            cJSON_AddStringToObject(root, "message",        al_data->log[0]);
+            cJSON_AddStringToObject(root, "message",  al_data->log[0]);
         }
 
         /* Add data if it exists */
         if (al_data->user) {
-            cJSON_AddStringToObject(root,   "acct",       al_data->user);
+            cJSON_AddStringToObject(root, "acct",     al_data->user);
         }
         if (al_data->srcip) {
-            cJSON_AddStringToObject(root,   "src_ip",     al_data->srcip);
+            cJSON_AddStringToObject(root, "src_ip",   al_data->srcip);
         }
         if (al_data->srcport) {
-            cJSON_AddNumberToObject(root,   "src_port",   al_data->srcport);
+            cJSON_AddNumberToObject(root, "src_port", al_data->srcport);
         }
         if (al_data->dstip) {
-            cJSON_AddStringToObject(root,   "dst_ip",     al_data->dstip);
+            cJSON_AddStringToObject(root, "dst_ip",   al_data->dstip);
         }
         if (al_data->dstport) {
-            cJSON_AddNumberToObject(root,   "dst_port",   al_data->dstport);
+            cJSON_AddNumberToObject(root, "dst_port", al_data->dstport);
         }
         if (al_data->filename) {
-            cJSON_AddStringToObject(root,   "file",       al_data->filename);
+            cJSON_AddStringToObject(root, "file",     al_data->filename);
         }
         if (al_data->old_md5) {
-            cJSON_AddStringToObject(root,   "md5_old",    al_data->old_md5);
+            cJSON_AddStringToObject(root, "md5_old",  al_data->old_md5);
         }
         if (al_data->new_md5) {
-            cJSON_AddStringToObject(root,   "md5_new",    al_data->new_md5);
+            cJSON_AddStringToObject(root, "md5_new",  al_data->new_md5);
         }
         if (al_data->old_sha1) {
-            cJSON_AddStringToObject(root,   "sha1_old",   al_data->old_sha1);
+            cJSON_AddStringToObject(root, "sha1_old", al_data->old_sha1);
         }
         if (al_data->new_sha1) {
-            cJSON_AddStringToObject(root,   "sha1_new",   al_data->new_sha1);
+            cJSON_AddStringToObject(root, "sha1_new", al_data->new_sha1);
         }
 #ifdef LIBGEOIP_ENABLED
         if (al_data->srcgeoip) {
@@ -358,29 +362,29 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                  al_data->location
                 );
         /* Event specifics */
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification=\"%s\",", al_data->group );
+        field_add_string(syslog_msg, OS_SIZE_2048, " classification=\"%s\",", al_data->group);
 
-        if ( field_add_string(syslog_msg, OS_SIZE_2048, " src_ip=\"%s\",", al_data->srcip ) > 0 ) {
-            field_add_int(syslog_msg, OS_SIZE_2048, " src_port=%d,", al_data->srcport );
+        if (field_add_string(syslog_msg, OS_SIZE_2048, " src_ip=\"%s\",", al_data->srcip) > 0) {
+            field_add_int(syslog_msg, OS_SIZE_2048, " src_port=%d,", al_data->srcport);
         }
 
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " src_city=\"%s\",", al_data->srcgeoip );
-        field_add_string(syslog_msg, OS_SIZE_2048, " dst_city=\"%s\",", al_data->dstgeoip );
+        field_add_string(syslog_msg, OS_SIZE_2048, " src_city=\"%s\",", al_data->srcgeoip);
+        field_add_string(syslog_msg, OS_SIZE_2048, " dst_city=\"%s\",", al_data->dstgeoip);
 #endif
 
-        if ( field_add_string(syslog_msg, OS_SIZE_2048, " dst_ip=\"%s\",", al_data->dstip ) > 0 ) {
-            field_add_int(syslog_msg, OS_SIZE_2048, " dst_port=%d,", al_data->dstport );
+        if (field_add_string(syslog_msg, OS_SIZE_2048, " dst_ip=\"%s\",", al_data->dstip) > 0) {
+            field_add_int(syslog_msg, OS_SIZE_2048, " dst_port=%d,", al_data->dstport);
         }
 
-        field_add_string(syslog_msg, OS_SIZE_2048, " file=\"%s\",", al_data->filename );
-        field_add_string(syslog_msg, OS_SIZE_2048, " acct=\"%s\",", al_data->user );
-        field_add_string(syslog_msg, OS_SIZE_2048, " md5_old=\"%s\",", al_data->old_md5 );
-        field_add_string(syslog_msg, OS_SIZE_2048, " md5_new=\"%s\",", al_data->new_md5 );
-        field_add_string(syslog_msg, OS_SIZE_2048, " sha1_old=\"%s\",", al_data->old_sha1 );
-        field_add_string(syslog_msg, OS_SIZE_2048, " sha1_new=\"%s\",", al_data->new_sha1 );
+        field_add_string(syslog_msg, OS_SIZE_2048, " file=\"%s\",", al_data->filename);
+        field_add_string(syslog_msg, OS_SIZE_2048, " acct=\"%s\",", al_data->user);
+        field_add_string(syslog_msg, OS_SIZE_2048, " md5_old=\"%s\",", al_data->old_md5);
+        field_add_string(syslog_msg, OS_SIZE_2048, " md5_new=\"%s\",", al_data->new_md5);
+        field_add_string(syslog_msg, OS_SIZE_2048, " sha1_old=\"%s\",", al_data->old_sha1);
+        field_add_string(syslog_msg, OS_SIZE_2048, " sha1_new=\"%s\",", al_data->new_sha1);
         /* Message */
-        field_add_truncated(syslog_msg, OS_SIZE_2048, " message=\"%s\"", al_data->log[0], 2 );
+        field_add_truncated(syslog_msg, OS_SIZE_2048, " message=\"%s\"", al_data->log[0], 2);
     }
 
     OS_SendUDPbySize(syslog_config->socket, strlen(syslog_msg), syslog_msg);

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -236,29 +236,32 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
         field_add_truncated(syslog_msg, OS_SIZE_2048, " %s", al_data->log[0], 2);
     } else if (syslog_config->format == CEF_CSYSLOG) {
+        /* Start with headers */
         snprintf(syslog_msg, OS_SIZE_2048,
-                 "<%u>%s CEF:0|%s|%s|%s|%u|%s|%u|dvc=%s cs1=%s cs1Label=Location",
+                 "<%u>%s CEF:0|%s|%s|%s|%u|%s|%u|",
                  syslog_config->priority,
                  tstamp,
                  __author,
                  __ossec_name,
                  __version,
                  al_data->rule,
-                 al_data->comment,
-                 (al_data->level > 10) ? 10 : al_data->level,
-                 hostname, al_data->location);
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification=%s", al_data->group);
+                 cefescape(al_data->comment, true),
+                 (al_data->level > 10) ? 10 : al_data->level);
+        /* Add extensions */
+        field_add_string(syslog_msg, OS_SIZE_2048, "dvc=%s", cefescape(hostname, false));
+        field_add_string(syslog_msg, OS_SIZE_2048, " cs1Label=Location cs1=%s", cefescape(al_data->location, false));
+        field_add_string(syslog_msg, OS_SIZE_2048, " classification=%s", cefescape(al_data->group, false));
         field_add_string(syslog_msg, OS_SIZE_2048, " src=%s", al_data->srcip);
         field_add_int(syslog_msg, OS_SIZE_2048, " dpt=%d", al_data->dstport);
         field_add_int(syslog_msg, OS_SIZE_2048, " spt=%d", al_data->srcport);
-        field_add_string(syslog_msg, OS_SIZE_2048, " fname=%s", al_data->filename);
+        field_add_string(syslog_msg, OS_SIZE_2048, " fname=%s", cefescape(al_data->filename, false));
         field_add_string(syslog_msg, OS_SIZE_2048, " dhost=%s", al_data->dstip);
         field_add_string(syslog_msg, OS_SIZE_2048, " shost=%s", al_data->srcip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " suser=%s", al_data->user);
-        field_add_string(syslog_msg, OS_SIZE_2048, " dst=%s", al_data->dstip);
+        field_add_string(syslog_msg, OS_SIZE_2048, " suser=%s", cefescape(al_data->user, false));
+        field_add_string(syslog_msg, OS_SIZE_2048, " dst=%s", cefescape(al_data->dstip, false));
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=SrcCity cs4=%s", al_data->srcgeoip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs5Label=DstCity cs5=%s", al_data->dstgeoip);
+        field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=SrcCity cs4=%s", cefescape(al_data->srcgeoip, false));
+        field_add_string(syslog_msg, OS_SIZE_2048, " cs5Label=DstCity cs5=%s", cefescape(al_data->dstgeoip, false));
 #endif
         if (al_data->new_md5 && al_data->new_sha1) {
             field_add_string(syslog_msg, OS_SIZE_2048, " cs2Label=OldMD5 cs2=%s", al_data->old_md5);

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -48,9 +48,9 @@ char *cefescape(const char *msg, const bool header)
         if (('\\' == *ptr) ||
             (header && ('|' == *ptr)) ||  /* For headers we replace \r\n with spaces */
             (!header && (
-                ('=' == *ptr)/* ||
+                ('=' == *ptr) ||
                 ('\r' == *ptr) ||
-                ('\n' == *ptr)*/
+                ('\n' == *ptr)
             )))
         {
             size += 2;
@@ -70,7 +70,7 @@ char *cefescape(const char *msg, const bool header)
             *buffptr = '\\';
             *(buffptr + 1) = '\\';
             buffptr += 2;
-        /*} else if ('\r' == *ptr) {
+        } else if ('\r' == *ptr) {
             *buffptr = header ? ' ' : '\\';
             buffptr++;
             if (!header) {
@@ -83,7 +83,7 @@ char *cefescape(const char *msg, const bool header)
             if (!header) {
                 *buffptr = 'n';
                 buffptr++;
-            }*/
+            }
         } else if (header && ('|' == *ptr)) {
             *buffptr = '\\';
             *(buffptr + 1) = '|';
@@ -193,6 +193,11 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
             i++;
             if (NULL != al_data->log[i]) {
                 logmsg = os_LoadString(logmsg, "\n");
+            }
+            /* Save on memory and processing since it's going to get truncated anyway */
+            if (OS_SIZE_2048 <= strlen(logmsg))
+            {
+                break;
             }
         }
     }


### PR DESCRIPTION
Fixes #1715
Fixes #1716

As previously mentioned in #1713 there were several problems in how OSSEC built the CEF messages, that this PR fixes. It mainly involved selective escaping where appropriate. Also, while at it, I decided to fix the other annoyance that was present since forever, the lack of multi-line log report, which kind of made the whole aggregation affair pointless in several cases.

I've tested all formats (Syslog, CEF, JSON, Splunk) on a combination of servers (Graylog, LogStash, Splunk) and custom endpoints.

## About multiline change

There are behavioural changes to keep into consideration, for example in order to properly get multiline syslog data, the `props.conf` for `[syslog]` must be reconfigured to [accept multiline and split on timestamp](https://answers.splunk.com/comments/21546/view.html). These decisions are a bit beyond me, so I just provided the general fix without considering the case-by-case consequences.

Reverting these changes for Syslong and/or Splunk is fairly straightforward, while they should not be necessary for CEF and JSON.

## Cleanups

While working on the file I made a few changes mainly regarding white-spaces and alignment, to improve readability and uniformity.