### PR TITLE
Additional ownCloud decoder fix

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -3130,7 +3130,7 @@ s=2 SFwdQ=0 SDupQ=0 SErr=0 RQ=2 RIQ=0 RFwdQ=0 RDupQ=0 RTCP=0 SFwdR=0 SFail=0 SFE
 <decoder name="owncloud-failed2">
   <parent>owncloud</parent>
   <prematch>Login failed: </prematch>
-  <regex offset="after_prematch">^'(\w+)' \(Remote IP: '(\S+)'</regex>
+  <regex offset="after_prematch">^'(\w+)' \(Remote IP: '(\S+)'|\)</regex>
   <order>user, srcip</order>
 </decoder>
 


### PR DESCRIPTION
Follow-up of: https://github.com/ossec/ossec-hids/pull/1697 + https://github.com/ossec/ossec-hids/pull/1724

The decoder.xml shows the following two different lines, seems some ownCloud versions had a different (broken) syntax:

```
(Remote IP: '127.0.0.1')",
```

and

```
(Remote IP: '127.0.0.1)",
```