### PR TITLE
Set PCRE2_SYSTEM to no by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,20 @@ notifications:
     secure: Cz1InEL5G+z2huuzilXe7BqfxlEjN4io5ylJa5jgPvGMlB5sIQZTQQ7PDrzcK0iwn+5xgDkXKwbNPV2k+NHNTtNFiuBrcnJbyeA8PjghtAw4hg/Vpl5+5ovySZT9pGSV7ySsA8nGD73hlcQFgWnYDhsugQ6UZyRXAN8vLLCLjPg=
 
 env:
-- DB=mysql OSSEC_TYPE=server GEOIP=yes
-- DB=mysql OSSEC_TYPE=server GEOIP=no
-- DB=pgsql OSSEC_TYPE=server GEOIP=yes
-- DB=pgsql OSSEC_TYPE=server GEOIP=no
-- DB=none OSSEC_TYPE=server GEOIP=yes
-- DB=none OSSEC_TYPE=server GEOIP=no
-- DB=none OSSEC_TYPE=server PRELUDE=yes ZEROMQ=yes
-- DB=none OSSEC_TYPE=server ZLIB_SYSTEM=yes LUA_ENABLE=no
-- DB=none OSSEC_TYPE=local GEOIP=no
-- DB=none OSSEC_TYPE=hybrid GEOIP=no
-- DB=none OSSEC_TYPE=agent GEOIP=no
-- DB=none OSSEC_TYPE=winagent GEOIP=no
-- OSSEC_TYPE=test
-- OSSEC_TYPE=server RULES=test
+- DB=mysql OSSEC_TYPE=server GEOIP=yes PCRE2_SYSTEM=no
+- DB=mysql OSSEC_TYPE=server GEOIP=no PCRE2_SYSTEM=no
+- DB=pgsql OSSEC_TYPE=server GEOIP=yes PCRE2_SYSTEM=no
+- DB=pgsql OSSEC_TYPE=server GEOIP=no PCRE2_SYSTEM=no
+- DB=none OSSEC_TYPE=server GEOIP=yes PCRE2_SYSTEM=no
+- DB=none OSSEC_TYPE=server GEOIP=no PCRE2_SYSTEM=no
+- DB=none OSSEC_TYPE=server PRELUDE=yes ZEROMQ=yes PCRE2_SYSTEM=no
+- DB=none OSSEC_TYPE=server ZLIB_SYSTEM=yes LUA_ENABLE=no PCRE2_SYSTEM=no
+- DB=none OSSEC_TYPE=local GEOIP=no PCRE2_SYSTEM=no
+- DB=none OSSEC_TYPE=hybrid GEOIP=no PCRE2_SYSTEM=no
+- DB=none OSSEC_TYPE=agent GEOIP=no PCRE2_SYSTEM=no
+- DB=none OSSEC_TYPE=winagent GEOIP=no PCRE2_SYSTEM=no
+- OSSEC_TYPE=test PCRE2_SYSTEM=no
+- OSSEC_TYPE=server RULES=test PCRE2_SYSTEM=no
 
 
 compiler:

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ EXTERNAL_LUA=external/lua-5.2.3/
 EXTERNAL_ZLIB=external/zlib-1.2.11/
 EXTERNAL_PCRE2=external/pcre2-10.32/
 ZLIB_SYSTEM?=yes
-PCRE2_SYSTEM?=no
+PCRE2_SYSTEM?=yes
 LUA_PLAT=posix
 LUA_ENABLE?=no
 MAXAGENTS?=2048
@@ -109,6 +109,7 @@ ifeq (${uname_S},OpenBSD)
 		LUA_PLAT=posix
 		CFLAGS+=-I/usr/local/include
 		OSSEC_LDFLAGS+=-L/usr/local/lib
+		USE_PCRE2_JIT=n
 else
 ifeq (${uname_S},HP-UX)
 		DEFINES+=-DHPUX


### PR DESCRIPTION
pcre2 has been a problem for people. So instead of relying on them
to download the tarball and extract it in the correct place, let's
default to using a system provided pcre2 library.
Disable JIT by default on OpenBSD. It would be a bunch of work to
make it actually work, so skip it for now.

Documentation updates should happen.