### PR TITLE
Remove leading space from field names

### DIFF
--- a/src/analysisd/decoders/decode-xml.c
+++ b/src/analysisd/decoders/decode-xml.c
@@ -566,7 +566,9 @@ int ReadDecodeXML(const char *file)
                     } else {
                         pi->order[order_int] = DynamicField_FP;
                         pi->fields[order_int] = strdup(*norder);
-
+                        if (pi->fields[order_int][0] == ' ') {
+                            pi->fields[order_int]++;
+                        }
                     }
 
                     free(*norder);


### PR DESCRIPTION
Remove the leading space in dynamic decoder field names in ossec-logtest output if a space exists in the decoder between the field names.
This hasn't been tested with anything except logtest. Needs to be tested with analysisd before merging.
Fixes issue #1740