### PR TITLE
Adjust pix decoder and a firewall rule

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1461,8 +1461,8 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <parent>pix</parent>
   <type>firewall</type>
   <prematch_pcre2 offset="after_parent">^6-106015</prematch_pcre2>
-  <pcre2 offset="after_parent">^(\S+): ([A-Za-z0-9@_-]+) ([A-Za-z0-9@_-]+) \S+ \S+ (\S+) from </pcre2>
-  <pcre2>(\S+)/(\S+) to (\S+)/(\S+)</pcre2>
+  <pcre2 offset="after_parent">^(\S+): ([A-Za-z0-9@_-]+) ([A-Za-z0-9@_-]+) \(no connection\) from (\S+)/</pcre2>
+  <pcre2>(\d+) to (\S+)/(\d+)</pcre2>
   <order>id, action, protocol, srcip, srcport, dstip, dstport</order>
 </decoder>
 

--- a/etc/rules/firewall_rules.xml
+++ b/etc/rules/firewall_rules.xml
@@ -31,6 +31,14 @@
     <group>firewall_drop,</group>
   </rule>
 
+  <rule id="4102" level="5">
+    <if_sid>4100</if_sid>
+    <action>Deny</action>
+    <options>no_log</options>
+    <description>Firewall drop event.</description>
+    <group>firewall_drop,</group>
+  </rule>
+
   <rule id="4151" level="10" frequency="16" timeframe="45" ignore="240">
     <if_matched_sid>4101</if_matched_sid>
     <same_source_ip />


### PR DESCRIPTION
The pix decoder for event 6-106015 did not always decode the various fields.
PIX vs ASA might have been part of the issue, not sure. It works now.
Also create a `firewall_drop` rule (4102) for these events. Cisco used `Deny` instead of `DROP`, and I apparently can't do `DROP|Deny` in the rule.