### PR TITLE
Fixed missing same_source_ip in rule 11306

### DIFF
--- a/etc/rules/pure-ftpd_rules.xml
+++ b/etc/rules/pure-ftpd_rules.xml
@@ -47,6 +47,7 @@
 
   <rule id="11306" level="10" frequency="6" timeframe="120">
     <if_matched_sid>11302</if_matched_sid>
+    <same_source_ip />
     <description>FTP brute force (multiple failed logins).</description>
     <group>authentication_failures,</group>
   </rule>


### PR DESCRIPTION
I do not see any reason not to have `<same_source_ip />` in bruteforce rule. Please correct me if I wrong