### PR TITLE
Stop maild from getting stuck after max emails reached.

### DIFF
--- a/src/os_maild/maild.c
+++ b/src/os_maild/maild.c
@@ -277,6 +277,7 @@ static void OS_Run(MailConfig *mail)
         }
         else if ((mailtosend > mail->maxperhour) && (mailtosend != 0)) {
             merror("%s: INFO: Max emails per hour reached.", ARGV0);
+            goto snd_check_hour;
         }
         /* Hour changed: send all suppressed mails */
         else if (((mailtosend < mail->maxperhour) && (mailtosend != 0)) ||


### PR DESCRIPTION
Add a goto snd_check_hour when max emails per hour is reached.
This will check to see if the hour has changed and reset the emails
sent count.
I don't know if this is the proper fix, but it seems to be working in testing,
and I haven't had the time to try and figure it out any better.