### PR TITLE
Fix using a program to send mail

### DIFF
--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -158,11 +158,10 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         }
 
         event_dispatch();
-    }
 
-    if (os_sock <= 0) {
-        ErrorExit("ossec-maild: ERROR: No socket.");
-    }
+        if (os_sock <= 0) {
+            ErrorExit("ossec-maild: ERROR: No socket.");
+        }
 
         /* Receive the banner */
         msg = OS_RecvTCP(os_sock, OS_SIZE_1024);
@@ -305,6 +304,7 @@ int OS_Sendmail(MailConfig *mail, struct tm *p)
         }
         MAIL_DEBUG("DEBUG: Sent '%s', received: '%s'", DATAMSG, msg);
         free(msg);
+    }
 
     /* Building "From" and "To" in the e-mail header */
     memset(snd_msg, '\0', 128);


### PR DESCRIPTION
Extend the check for cases where mail->smtpserver[0] != '/'.
If forking a program to send email instead of sending it directly,
don't expect there to be a network socket. Don't try to use that
socket. Just use the program.

Compile tested only, I don't have this setup.

From issue #1781