### PR TITLE
Added non-standard Sophos UTM syslog timestamp format to pre-decoding.

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -155,6 +155,17 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
             (pieces[17] == ':') &&
             (pieces[20] == ' ') && (lf->log += 21)
         )
+        ||
+        (
+            /* ex: 2019:11:06-00:08:03 */
+            (loglen > 20) &&
+            (isdigit(pieces[0])) &&
+            (pieces[4] == ':') &&
+            (pieces[7] == ':') &&
+            (pieces[10] == '-') &&
+            (pieces[13] == ':') &&
+            (pieces[16] == ':') && (lf->log += 20)
+        )
     ) {
         /* Check for an extra space in here */
         if (*lf->log == ' ') {


### PR DESCRIPTION
The Sophos UTM firewall uses syslog to transmit data but uses a non-standard timestamp format that looks like: 2019:11:06-00:08:03.  Outside of the timestamp, all other aspects appear to be the same as regular syslog entries so it makes sense to me to parse it as such.