### PR TITLE
Makefile: fix DEBUGAD defines adjustment.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -135,7 +135,7 @@ ifneq (${uname_S},OpenBSD)
 endif
 
 ifdef DEBUGAD
-	DEFINES+=+DDEBUGAD
+	DEFINES+=-DDEBUGAD
 endif
 
 OSSEC_CFLAGS=${CFLAGS}


### PR DESCRIPTION
Providing `DEBUGAD=1` to the Makefile environment should add `-DDEBUGAD` to the `DEFINES` used when building the `ossec-analysisd` binary. Prev. to this commit a typo in the makefile would result in an error in compilation when using `DEBUGAD=1`:

```
~/Code/ossec-hids-clean/src$ make -j4 V=1 DEBUG=1 DEBUGAD=1 TARGET=server PREFIX=/tmp/ossec-rootdir
cc -I./external/compat -g -DMAX_AGENTS=2048 -DOSSECHIDS -DDEFAULTDIR=\"/tmp/ossec-rootdir\" -DUSER=\"ossec\" -DREMUSER=\"ossecr\" -DGROUPGLOBAL=\"ossec\" -DMAILUSER=\"ossecm\" -DLinux -DINOTIFY_ENABLED +DDEBUGAD -DZLIB_SYSTEM -DUSE_PCRE2_JIT -DLIBOPENSSL_ENABLED -Wall -Wextra -I./ -I./headers/ -c external/cJSON/cJSON.c -o external/cJSON/cJSON.o
cc -I./external/compat -g -DMAX_AGENTS=2048 -DOSSECHIDS -DDEFAULTDIR=\"/tmp/ossec-rootdir\" -DUSER=\"ossec\" -DREMUSER=\"ossecr\" -DGROUPGLOBAL=\"ossec\" -DMAILUSER=\"ossecm\" -DLinux -DINOTIFY_ENABLED +DDEBUGAD -DZLIB_SYSTEM -DUSE_PCRE2_JIT -DLIBOPENSSL_ENABLED -Wall -Wextra -I./ -I./headers/ -DARGV0=\"ossec-maild\" -c os_maild/maild.c -o os_maild/maild.o
cc -I./external/compat -g -DMAX_AGENTS=2048 -DOSSECHIDS -DDEFAULTDIR=\"/tmp/ossec-rootdir\" -DUSER=\"ossec\" -DREMUSER=\"ossecr\" -DGROUPGLOBAL=\"ossec\" -DMAILUSER=\"ossecm\" -DLinux -DINOTIFY_ENABLED +DDEBUGAD -DZLIB_SYSTEM -DUSE_PCRE2_JIT -DLIBOPENSSL_ENABLED -Wall -Wextra -I./ -I./headers/ -DARGV0=\"ossec-maild\" -c os_maild/sendmail.c -o os_maild/sendmail.o
cc -I./external/compat -g -DMAX_AGENTS=2048 -DOSSECHIDS -DDEFAULTDIR=\"/tmp/ossec-rootdir\" -DUSER=\"ossec\" -DREMUSER=\"ossecr\" -DGROUPGLOBAL=\"ossec\" -DMAILUSER=\"ossecm\" -DLinux -DINOTIFY_ENABLED +DDEBUGAD -DZLIB_SYSTEM -DUSE_PCRE2_JIT -DLIBOPENSSL_ENABLED -Wall -Wextra -I./ -I./headers/ -DARGV0=\"ossec-maild\" -c os_maild/sendcustomemail.c -o os_maild/sendcustomemail.o
cc: error: +DDEBUGAD: No such file or directory
cc: error: +DDEBUGAD: No such file or directory
cc: error: +DDEBUGAD: No such file or directory
cc: error: +DDEBUGAD: No such file or directory
Makefile:752: recipe for target 'external/cJSON/cJSON.o' failed
make: *** [external/cJSON/cJSON.o] Error 1
make: *** Waiting for unfinished jobs....
Makefile:926: recipe for target 'os_maild/maild.o' failed
make: *** [os_maild/maild.o] Error 1
Makefile:926: recipe for target 'os_maild/sendmail.o' failed
make: *** [os_maild/sendmail.o] Error 1
Makefile:926: recipe for target 'os_maild/sendcustomemail.o' failed
make: *** [os_maild/sendcustomemail.o] Error 1
```