### PR TITLE
analysisd: fix possible null ptr deref in OS_CleanMSG.

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -45,7 +45,12 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     /* Is this from an agent? */
     if ( *msg == '(' )
     {   /* look past '->' for the first ':' */
-        pieces = strchr(strstr(msg, "->"), ':');
+        pieces = strstr(msg, "->");
+        if(!pieces) {
+            merror(FORMAT_ERROR, ARGV0);
+            return(-1);
+        }
+        pieces = strchr(pieces, ':');
         if(!pieces)
         {
             merror(FORMAT_ERROR, ARGV0);


### PR DESCRIPTION
If the `msg` provided to `OS_CleanMSG` has a `(` after the ID, but doesn't not contain a `->` or `:` it should be rejected with a `FORMAT_ERROR`.

Prev. to this commit nesting `strstr` for `->` as the first argument to `strchr` for `:` results in a null ptr deref when the message is malformed.

Resolves https://github.com/ossec/ossec-hids/issues/1815