### PR TITLE
analysisd: fix off-by-one in OS_CleanMSG.

### DIFF
--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -335,8 +335,8 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
                     (pieces[3] == ' ')) {
                 pieces += 4;
 
-                /* Going after the ] */
-                pieces = strchr(pieces, ']');
+                /* Going after the "] " */
+                pieces = strstr(pieces, "] ");
                 if (pieces) {
                     pieces += 2;
                     lf->log = pieces;


### PR DESCRIPTION
When removing the `"[ID xx facility.severity] "` substring of a syslog message in `OS_CleanMSG` care needs to be taken to stay within the bounds of the msg buffer when advancing past the `"] "` in the msg.

Prev. to this commit the `pieces` pointer is incremented by 2 when there may be only 1 character remaining before the null terminator.

Resolves https://github.com/ossec/ossec-hids/issues/1816