### PR TITLE
analysisd: fix heap overflow in rootkit decoder.

### DIFF
--- a/src/analysisd/decoders/rootcheck.c
+++ b/src/analysisd/decoders/rootcheck.c
@@ -56,7 +56,7 @@ static FILE *RK_File(const char *agent, int *agent_id)
     int i = 0;
     char rk_buf[OS_SIZE_1024 + 1];
 
-    while (rk_agent_ips[i] != NULL) {
+    while (i < MAX_AGENTS && rk_agent_ips[i] != NULL) {
         if (strcmp(rk_agent_ips[i], agent) == 0) {
             /* Pointing to the beginning of the file */
             fseek(rk_agent_fps[i], 0, SEEK_SET);
@@ -65,6 +65,12 @@ static FILE *RK_File(const char *agent, int *agent_id)
         }
 
         i++;
+    }
+
+    /* If here, our agent wasn't found */
+    if (i == MAX_AGENTS) {
+        merror("%s: Unable to open rootcheck file. Increase MAX_AGENTS.", ARGV0);
+        return (NULL);
     }
 
     /* If here, our agent wasn't found */


### PR DESCRIPTION
The `RK_File` function of the rootcheck decoder needs to ensure it doesn't index outside of `MAX_AGENTS` when trying to find/open a rootcheck file for a given agent.

Prev. to this change the value of `i` could exceed `MAX_AGENTS` resulting in a heap buffer overflow accessing `rk_agent_ips[i]` or `rk_agent_fps[i]`.

The fix is adapted from similar logic in the syscheck decoder, added as a response to a matching vulnerability in that decoder patched in 2012.

Resolves https://github.com/ossec/ossec-hids/issues/1820