### PR TITLE
os_regex: refuse to compile empty PCRE2 pattern.

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -51,7 +51,6 @@
 </decoder>
 
 <decoder name="pam">
-  <program_name_pcre2></program_name_pcre2>
   <prematch_pcre2>^pam_unix|^\(pam_unix\)|^pam_succeed_if</prematch_pcre2>
 </decoder>
 

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -51,6 +51,8 @@
 </decoder>
 
 <decoder name="pam">
+  <!-- allow any program name if the prematch_pcre2 regex matches -->
+  <program_name_pcre2>.*<program_name_pcre2>
   <prematch_pcre2>^pam_unix|^\(pam_unix\)|^pam_succeed_if</prematch_pcre2>
 </decoder>
 

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -52,7 +52,7 @@
 
 <decoder name="pam">
   <!-- allow any program name if the prematch_pcre2 regex matches -->
-  <program_name_pcre2>.*<program_name_pcre2>
+  <program_name_pcre2>.*</program_name_pcre2>
   <prematch_pcre2>^pam_unix|^\(pam_unix\)|^pam_succeed_if</prematch_pcre2>
 </decoder>
 

--- a/src/os_regex/os_pcre2_compile.c
+++ b/src/os_regex/os_pcre2_compile.c
@@ -51,7 +51,6 @@ int OSPcre2_Compile(const char *pattern, OSPcre2 *reg, int flags)
         goto compile_error;
     }
 
-
     /* Maximum size of the pattern */
     pattern_len = strlen(pattern);
 #if 0

--- a/src/os_regex/os_pcre2_compile.c
+++ b/src/os_regex/os_pcre2_compile.c
@@ -51,6 +51,7 @@ int OSPcre2_Compile(const char *pattern, OSPcre2 *reg, int flags)
         goto compile_error;
     }
 
+
     /* Maximum size of the pattern */
     pattern_len = strlen(pattern);
 #if 0
@@ -59,6 +60,12 @@ int OSPcre2_Compile(const char *pattern, OSPcre2 *reg, int flags)
         goto compile_error;
     }
 #endif
+
+    /* The pattern can't be empty */
+    if (pattern_len == 0) {
+        reg->error = OS_REGEX_PATTERN_EMPTY;
+        goto compile_error;
+    }
 
     if (OSPcre2_CouldBeOptimized(pattern)) {
         first_char = pattern[0];

--- a/src/os_regex/os_regex.h
+++ b/src/os_regex/os_regex.h
@@ -35,6 +35,7 @@
 #define OS_REGEX_BADPARENTHESIS 7
 #define OS_REGEX_NO_MATCH       8
 #define OS_REGEX_NO_JIT         9
+#define OS_REGEX_PATTERN_EMPTY  10
 
 #define OS_CONVERT_REGEX        1
 #define OS_CONVERT_MATCH        2


### PR DESCRIPTION
The `OSPcre2_Compile` function should refuse to compile empty patterns and instead return an error. This avoids an off-by-one error that can occur later in the function when an assumption is made that the pattern is always >= 1 characters long.

A distinct error code `OS_REGEX_PATTERN_EMPTY` (10) is added to `os_regex/os_regex.h` to be returned by `OSPcre2_Compile` for empty patterns similar to the `OS_REGEX_PATTERN_NULL` error.

Since the `os_regex` PCRE2 code is updated to return an error when asked to compile an empty pattern the empty `<program_name_pcre2>` element in the example `decoder.xml` config for
the `"pam"` decoder also needs to be updated or it will prompt an error from `ossec-analysisd` when it tries to compile the PCRE2 pattern. Using `.*` as the program name PCRE2 regex has (what I think is) the intended effect of the two PAM decoders.

Resolves https://github.com/ossec/ossec-hids/issues/1811