### PR TITLE
Silence a warning in json output

### DIFF
--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -275,6 +275,9 @@ void W_JSON_ParseAgentIP(cJSON* root, const Eventinfo* lf)
  // The file location usually comes with more information about the alert (like hostname or ip) we will extract just the "/var/folder/file.log".
 void W_JSON_ParseLocation(cJSON* root, const Eventinfo* lf, int archives)
 {
+    if (archives != 0) {
+        debug1("ossec-analysisd: DEBUG: archives != 0");
+    }
     if(lf->location[0] == '(') {
         char* search;
         char string[MAX_STRING];


### PR DESCRIPTION
I don't know what the archives variable is supposed to represent.
It's currently set at 0 in everything that calls this, so I'm just checking for 0 to silence a build time warning.