### PR TITLE
Build amd64 and arm64 debian packages on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ arch:
 
 matrix:
   fast_finish: true
+  include:
+    - arch: amd64
+      compiler: gcc
+      env: OSSEC_TYPE=agent RULES=debian PCRE2_SYSTEM=no
   exclude:
     - arch: arm64
       env: DB=none OSSEC_TYPE=winagent GEOIP=no PCRE2_SYSTEM=no
@@ -55,6 +59,7 @@ before_script:
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi
 - if [[ "${OSSEC_TYPE}" == "server" ]]; then ( sudo apt-get install libsqlite3-dev sqlite3 ); fi
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then if [ `uname -m` = "aarch64" ]; then (sudo apt-get install check libc6-dbg && wget -q http://ports.ubuntu.com/pool/main/v/valgrind/valgrind_3.15.0-1ubuntu3.1_arm64.deb && sudo dpkg -i valgrind_3.15.0-1ubuntu3.1_arm64.deb ) ; else ( sudo apt-get install check valgrind ); fi; fi
+- if [[ "${RULES}" == "debian" ]]; then ( sudo apt-get install pbuilder qemu-user-static ) fi
 
 
 script:
@@ -72,6 +77,7 @@ script:
 
 - if [[ "${OSSEC_TYPE}" == "test" ]]; then ( cd src/ && make --warn-undefined-variables test_valgrind ) fi
 - if [[ "${RULES}" == "test" ]]; then ( cd src/ && sudo make V=1 TARGET=server test-rules ) fi
+- if [[ "${RULES}" == "debian" ]]; then ( sudo mkdir -p /home/ubuntu/debian_files && sudo cp -r contrib/debian-packages /home/ubuntu/debian_files/3.6.0 && cd contrib/debian-packages && ./generate_ossec.sh -d && ./generate_ossec.sh -u && ./generate_ossec.sh -b && ls /var/cache/pbuilder/*/result/*/*.deb) fi
 
 
 deploy:

--- a/contrib/debian-packages/generate_ossec.sh
+++ b/contrib/debian-packages/generate_ossec.sh
@@ -347,36 +347,8 @@ do
         echo " + Package ${results_dir}/${deb_file} ${codename}-${arch} contains ${files} files" | write_log
       fi
 
-      # Signing Debian package
-      if [ ! -f "${results_dir}/${changes_file}" ] || [ ! -f "${results_dir}/${dsc_file}" ] ; then
-        echo "Error: Could not find dsc and changes file in ${results_dir}" | write_log
-        exit 1
-      fi
-      sudo /usr/bin/expect -c "
-        spawn sudo debsign --re-sign -k${signing_key} ${results_dir}/${changes_file}
-        expect -re \".*Enter passphrase:.*\"
-        send \"${signing_pass}\r\"
-        expect -re \".*Enter passphrase:.*\"
-        send \"${signing_pass}\r\"
-        expect -re \".*Successfully signed dsc and changes files.*\"
-      "
-      if [ $? -eq 0 ] ; then
-        echo " + Successfully signed Debian package ${changes_file} ${codename}-${arch}" | write_log
-      else
-        echo "Error: Could not sign Debian package ${changes_file} ${codename}-${arch}" | write_log
-        exit 1
-      fi
-
-      # Verifying signed changes and dsc files
-      if sudo gpg --verify "${results_dir}/${dsc_file}" && sudo gpg --verify "${results_dir}/${changes_file}" ; then
-        echo " + Successfully verified GPG signature for files ${dsc_file} and ${changes_file}" | write_log
-      else
-        echo "Error: Could not verify GPG signature for ${dsc_file} and ${changes_file}" | write_log
-        exit 1
-      fi
-
-      echo "Successfully built and signed Debian package ${package} ${codename}-${arch}" | write_log
-
+      echo "Successfully built Debian package ${package} ${codename}-${arch}" | write_log
+      ls /var/cache/pbuilder/*/result/*/*.deb
     done
   done
 done

--- a/contrib/debian-packages/generate_ossec.sh
+++ b/contrib/debian-packages/generate_ossec.sh
@@ -240,7 +240,7 @@ download_source()
   done
 
   # Downloading file
-  if wget -O $scriptpath/${source_file} -U ossec https://github.com/ossec/ossec-hids/archive/${ossec_version}.tar.gz ; then
+  if wget -q -O $scriptpath/${source_file} -U ossec https://github.com/ossec/ossec-hids/archive/${ossec_version}.tar.gz ; then
     echo "Successfully downloaded source file ${source_file} from ossec.net" | write_log
   else
     echo "Error: File ${source_file} was could not be downloaded" | write_log

--- a/contrib/debian-packages/generate_ossec.sh
+++ b/contrib/debian-packages/generate_ossec.sh
@@ -20,21 +20,21 @@
 # CONFIGURATION VARIABLES
 #
 
-ossec_version='2.8.2'
+ossec_version='3.6.0'
 source_file="ossec-hids-${ossec_version}.tar.gz"
 #packages=(ossec-hids ossec-hids-agent) # only options available
-packages=(ossec-hids ossec-hids-agent)
+packages=(ossec-hids-agent)
 
-# codenames=(sid jessie wheezy precise trusty utopic) 
-codenames=(sid jessie wheezy precise trusty utopic) 
+# codenames=(sid jessie wheezy precise trusty utopic)
+codenames=(xenial)
 
 # For Debian use: sid, jessie or wheezy (hardcoded in update_changelog function)
-# For Ubuntu use: lucid, precise, trusty or utopic
-codenames_ubuntu=(precise trusty utopic)
+# For Ubuntu use: xenial, bionic, or focal
+codenames_ubuntu=(xenial bionic focal)
 codenames_debian=(sid jessie wheezy)
 
 # architectures=(amd64 i386) only options available
-architectures=(amd64 i386)
+architectures=(amd64 arm64)
 
 # GPG key
 signing_key='XXXX'

--- a/contrib/debian-packages/ossec-hids-agent/debian/changelog
+++ b/contrib/debian-packages/ossec-hids-agent/debian/changelog
@@ -1,3 +1,9 @@
+ossec-hids-agent (3.6.0-1) unstable; urgency=medium
+
+  * support arm64 package
+
+ -- Santiago Bassett <santiago.bassett@gmail.com>  Wed, 08 Jan 2020 19:45:23 +0000
+
 ossec-hids-agent (2.8.2-2) unstable; urgency=low
 
   * Set ossec user home to /var/ossec/

--- a/contrib/debian-packages/ossec-hids-agent/debian/control
+++ b/contrib/debian-packages/ossec-hids-agent/debian/control
@@ -2,13 +2,13 @@ Source: ossec-hids-agent
 Section: admin 
 Priority: extra
 Maintainer: Santiago Bassett <santiago.bassett@gmail.com>
-Build-Depends: debhelper (>= 7.0.50~), libssl-dev, linux-libc-dev
+Build-Depends: debhelper (>= 7.0.50~), libssl-dev, linux-libc-dev, libpcre2-dev, libevent-dev
 Standards-Version: 3.8.4
 Homepage: http://www.ossec.net
 
 Package: ossec-hids-agent
 Architecture: any
-Depends: ${shlibs:Depends}, libc6 (>= 2.7), libssl1.0.0, expect, debconf
+Depends: ${shlibs:Depends}, libc6 (>= 2.7), libssl1.0.0, debconf, libevent-2.0-5, libpcre2-8-0, zlib1g
 Conflicts: ossec-hids
 Description: OSSEC Agent - Host Based Intrusion Detection System
  OSSEC HIDS for log analysis, integrity checking, rootkits detection and

--- a/contrib/debian-packages/ossec-hids-agent/debian/patches/01_makefile.patch
+++ b/contrib/debian-packages/ossec-hids-agent/debian/patches/01_makefile.patch
@@ -14,7 +14,7 @@ Index: ossec-hids-agent-2.8.2/Makefile
 +CEXTRA="-DCLIENT"
 +all:
 +	echo "CEXTRA=$(CEXTRA)" >> src/Config.OS
-+	(cd src; make all)
++	(cd src; make TARGET=agent PCRE2_SYSTEM=yes)
 +
 +clean:
 +	rm bin/* || /bin/true
@@ -39,13 +39,13 @@ Index: ossec-hids-agent-2.8.2/Makefile
 +	cp -pr etc/local_internal_options.conf $(DIR)/etc/ > /dev/null 2>&1 || /bin/true
 +	cp -pr etc/client.keys $(DIR)/etc/ > /dev/null 2>&1 ||/bin/true
 +	cp -pr src/agentlessd/scripts/* $(DIR)/agentless/
-+	cp -pr src/client-agent/ossec-agentd ${DIR}/bin/
-+	cp -pr src/os_auth/agent-auth ${DIR}/bin/
-+	cp -pr src/logcollector/ossec-logcollector ${DIR}/bin/
-+	cp -pr src/syscheckd/ossec-syscheckd ${DIR}/bin/
-+	cp -pr src/os_execd/ossec-execd ${DIR}/bin/
++	cp -pr src/ossec-agentd ${DIR}/bin/
++	cp -pr src/agent-auth ${DIR}/bin/
++	cp -pr src/ossec-logcollector ${DIR}/bin/
++	cp -pr src/ossec-syscheckd ${DIR}/bin/
++	cp -pr src/ossec-execd ${DIR}/bin/
 +	cp -pr src/init/ossec-client.sh ${DIR}/bin/ossec-control
-+	cp -pr src/addagent/manage_agents ${DIR}/bin/
++	cp -pr src/manage_agents ${DIR}/bin/
 +	cp -pr contrib/util.sh ${DIR}/bin/
 +	sh src/init/fw-check.sh execute > /dev/null
 +	cp -pr active-response/*.sh ${DIR}/active-response/bin/
@@ -54,6 +54,6 @@ Index: ossec-hids-agent-2.8.2/Makefile
 +	chmod -x $(DIR)/etc/ossec.conf
 +	cp -p src/init/ossec-hids-debian.init $(DIR)/etc/init.d/ossec
 +	echo "DIRECTORY=\"/var/ossec\"" > $(OSSEC_INIT)
-+	echo "VERSION=\"v2.8.2\"" >> $(OSSEC_INIT)
++	echo "VERSION=\"v3.6.0\"" >> $(OSSEC_INIT)
 +	echo "DATE=\"`date`\"" >> $(OSSEC_INIT)
 +	echo "TYPE=\"agent\"" >> $(OSSEC_INIT)

--- a/contrib/debian-packages/ossec-hids-agent/debian/patches/02_ossec-agent.conf.patch
+++ b/contrib/debian-packages/ossec-hids-agent/debian/patches/02_ossec-agent.conf.patch
@@ -1,8 +1,6 @@
-Index: ossec-hids-2.8.2/etc/ossec-agent.conf
-===================================================================
---- ossec-hids-2.8.2.orig/etc/ossec-agent.conf	2015-06-10 15:38:32.000000000 +0000
-+++ ossec-hids-2.8.2/etc/ossec-agent.conf	2015-07-12 18:54:10.859134760 +0000
-@@ -25,40 +25,46 @@
+--- a/etc/ossec-agent.conf.orig	2020-01-19 03:45:09.184090231 +0900
++++ b/etc/ossec-agent.conf	2020-01-19 03:44:15.844760722 +0900
+@@ -29,16 +29,12 @@
    <rootcheck>
      <rootkit_files>/var/ossec/etc/shared/rootkit_files.txt</rootkit_files>
      <rootkit_trojans>/var/ossec/etc/shared/rootkit_trojans.txt</rootkit_trojans>
@@ -12,14 +10,16 @@ Index: ossec-hids-2.8.2/etc/ossec-agent.conf
    <localfile>
      <log_format>syslog</log_format>
 -    <location>/var/log/messages</location>
+-  </localfile>
+-
+-  <localfile>
+-    <log_format>syslog</log_format>
+-    <location>/var/log/authlog</location>
 +    <location>/var/log/syslog</location>
    </localfile>
  
    <localfile>
-     <log_format>syslog</log_format>
--    <location>/var/log/authlog</location>
-+    <location>/var/log/auth.log</location>
-   </localfile>
+@@ -48,26 +44,31 @@
  
    <localfile>
      <log_format>syslog</log_format>

--- a/contrib/debian-packages/pbuilderrc
+++ b/contrib/debian-packages/pbuilderrc
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Codenames for Debian suites according to their alias. Update these when
+# needed.
+UNSTABLE_CODENAME="sid"
+TESTING_CODENAME="bullseye"
+STABLE_CODENAME="buster"
+STABLE_BACKPORTS_SUITE="$STABLE_CODENAME-backports"
+
+# List of Debian suites.
+DEBIAN_SUITES=($UNSTABLE_CODENAME $TESTING_CODENAME $STABLE_CODENAME
+    "unstable" "testing" "stable")
+
+# List of Ubuntu suites. Update these when needed.
+UBUNTU_SUITES=("eoan" "bionic" "xenial")
+
+# Mirrors to use. Update these to your preferred mirror.
+DEBIAN_MIRROR="ftp.us.debian.org"
+UBUNTU_MIRROR="ftp.ubuntu.com"
+UBUNTU_PORTS_MIRROR="ports.ubuntu.com"
+
+# Optionally use the changelog of a package to determine the suite to use if
+# none set.
+if [ -z "${DIST}" ] && [ -r "debian/changelog" ]; then
+    DIST=$(dpkg-parsechangelog | awk '/^Distribution: / {print $2}')
+    DIST="${DIST%%-*}"
+    # Use the unstable suite for certain suite values.
+    if $(echo "experimental UNRELEASED" | grep -q $DIST); then
+        DIST="$UNSTABLE_CODENAME"
+    fi
+fi
+
+# Optionally set a default distribution if none is used. Note that you can set
+# your own default (i.e. ${DIST:="unstable"}).
+: ${DIST:="$(lsb_release --short --codename)"}
+
+# Optionally change Debian release states in $DIST to their names.
+case "$DIST" in
+    unstable)
+        DIST="$UNSTABLE_CODENAME"
+        ;;
+    testing)
+        DIST="$TESTING_CODENAME"
+        ;;
+    stable)
+        DIST="$STABLE_CODENAME"
+        ;;
+esac
+
+# Optionally set the architecture to the host architecture if none set. Note
+# that you can set your own default (i.e. ${ARCH:="i386"}).
+: ${ARCH:="$(dpkg --print-architecture)"}
+
+NAME="$DIST"
+if [ -n "${ARCH}" ]; then
+    NAME="$NAME-$ARCH"
+    DEBOOTSTRAPOPTS=("--arch" "$ARCH" "${DEBOOTSTRAPOPTS[@]}")
+fi
+BASETGZ="/var/cache/pbuilder/$NAME-base.tgz"
+# Optionally, set BASEPATH (and not BASETGZ) if using cowbuilder
+# BASEPATH="/var/cache/pbuilder/$NAME/base.cow/"
+DISTRIBUTION="$DIST"
+BUILDRESULT="/var/cache/pbuilder/$NAME/result/"
+APTCACHE="/var/cache/pbuilder/$NAME/aptcache/"
+BUILDPLACE="/var/cache/pbuilder/build/"
+
+if $(echo ${DEBIAN_SUITES[@]} | grep -q $DIST); then
+    # Debian configuration
+    MIRRORSITE="http://$DEBIAN_MIRROR/debian/"
+    COMPONENTS="main contrib non-free"
+    DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/debian-archive-keyring.gpg")
+
+elif $(echo ${UBUNTU_SUITES[@]} | grep -q $DIST); then
+    # Ubuntu configuration
+    case "$ARCH" in
+        i386|amd64)
+            MIRRORSITE="http://$UBUNTU_MIRROR/ubuntu/"
+            ;;
+        arm64)
+            MIRRORSITE="http://$UBUNTU_PORTS_MIRROR/ubuntu-ports/"
+            DEBOOTSTRAP="qemu-debootstrap"
+            # pbuilder-satisfydepends-aptitude SEGVs on arm64 qemu env.
+            PBUILDERSATISFYDEPENDSCMD=/usr/lib/pbuilder/pbuilder-satisfydepends-experimental
+            ;;
+    esac
+    COMPONENTS="main restricted universe multiverse"
+    DEBOOTSTRAPOPTS=("${DEBOOTSTRAPOPTS[@]}" "--keyring=/usr/share/keyrings/ubuntu-archive-keyring.gpg")
+else
+    echo "Unknown distribution: $DIST"
+    exit 1
+fi


### PR DESCRIPTION
Build amd64 and arm64 debian packages on travis.

The task `env: OSSEC_TYPE=agent RULES=debian PCRE2_SYSTEM=no` builds debian packages with pbuilder and qemu-user-static.

The files are placed at
> /var/cache/pbuilder/xenial-amd64/result/ossec-hids-agent/ossec-hids-agent_3.6.0-1xenial_amd64.deb
/var/cache/pbuilder/xenial-arm64/result/ossec-hids-agent/ossec-hids-agent_3.6.0-1xenial_arm64.deb

You can upload them on S3 or something as described in [Uploading Artifacts on Travis CI](https://docs.travis-ci.com/user/uploading-artifacts/)
Then you can fetch them and upload on your apt repo.