### PR TITLE
Set PCRE2_SYSTEM=no earlier in the build for winagent

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -157,6 +157,10 @@ ifneq (${ZLIB_SYSTEM},no)
 	DEFINES+=-DZLIB_SYSTEM
 endif
 
+ifeq (${TARGET}, winagent)
+	PCRE2_SYSTEM=no
+endif
+
 ifeq (${PCRE2_SYSTEM},no)
 	PCRE2_INCLUDE=-I./${EXTERNAL_PCRE2}/install/include/
 	DEFINES+=${PCRE2_INCLUDE}


### PR DESCRIPTION
If winagent set PCRE2_SYSTEM=no earlier.
Missing the defines when PCRE2_SYSTEM=no was making my windows builds fail.
Setting this to no earlier clears it right up.
Travis-ci already explicitly set this to no, so that's why my builds were different and travis's builds didn't fail.