### PR TITLE
2 fixes for Solaris

### DIFF
--- a/src/external/compat/imsg-buffer.c
+++ b/src/external/compat/imsg-buffer.c
@@ -33,6 +33,10 @@
 #endif
 #include <unistd.h>
 
+#ifdef SOLARIS
+#include <limits.h>
+#endif
+
 #include "imsg.h"
 
 int	ibuf_realloc(struct ibuf *, size_t);

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -727,7 +727,7 @@ char *OS_DecodeSockaddr (struct sockaddr *sa) {
     char ipport[NI_MAXSERV];		/* printed port */
     static char buf[256];		/* message buffer */
 
-#if defined(__linux__) || defined (WIN32)
+#if defined(__linux__) || defined (WIN32) || defined (SOLARIS)
     /* most Linux systems do not have sa_len in the sockaddr struct */
     socklen_t slen = 0;
     switch(sa->sa_family) {


### PR DESCRIPTION
IOV_MAX: defined in sys/limits.h. Conditionally include sys/limits.h. Reported in issue #1860 . Build tested on OpenBSD, Linux, and Solaris
sa_len: Solaris does not have sa_len, so include it with WIN32 and Linux calculating slen. Reported with fix in issue #1877 . Build tested on OpenBSD and Linux.