### PR TITLE
Fix regexp import in ossec-batch-manager.pl

### DIFF
--- a/contrib/ossec-batch-manager.pl
+++ b/contrib/ossec-batch-manager.pl
@@ -64,7 +64,7 @@ require 5.8.2; # Time::HiRes is standard from this version forth
 use MIME::Base64;
 use Digest::MD5 qw(md5_hex);
 use Getopt::Long;
-use Regexp::Common::net;
+use Regexp::Common qw(net);
 
 use constant AUTH_KEY_FILE => "/var/ossec/etc/client.keys";
 use constant RIDS_PATH => "/var/ossec/queue/rids/";


### PR DESCRIPTION
Hi, this fixes what appears to be a syntax error in the user-contributed file `ossec-batch-manager.pl`. Currently it produces the error:

```
Global symbol "%RE" requires explicit package name (did you forget to declare "my %RE"?) at ./ossec-batch-manager.pl line 105.
Global symbol "%RE" requires explicit package name (did you forget to declare "my %RE"?) at ./ossec-batch-manager.pl line 107.
BEGIN not safe after errors--compilation aborted at ./ossec-batch-manager.pl line 139.
```

Fixes https://github.com/ossec/ossec-hids/issues/1914