### PR TITLE
Fix NetBSD build.  Without this analysisd can't understand regex.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -101,6 +101,7 @@ ifeq (${uname_S},NetBSD)
 		LUA_PLAT=posix
 		CFLAGS+=-I/usr/local/include
 		OSSEC_LDFLAGS+=-L/usr/local/lib
+		USE_PCRE2_JIT=n
 else
 ifeq (${uname_S},OpenBSD)
 #		DEFINES+=-DOpenBSD


### PR DESCRIPTION
Borrowing from OpenBSD block.  Fixes build on NetBSD.  Without this analysisd can't understand regex.