### PR TITLE
Fix for change in named query log format

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1007,8 +1007,8 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 
 <decoder name="named-query">
   <parent>named</parent>
-  <prematch_pcre2>: query </prematch_pcre2>
-  <pcre2>client (\S+)#\d+[ ]*?\S*: </pcre2>
+  <prematch_pcre2>: query:? </prematch_pcre2>
+  <pcre2>client @\S+ (\S+)#\d+[ ]*?\S*: </pcre2>
   <order>srcip,url</order>
 </decoder>
 


### PR DESCRIPTION
This decoder correctly decodes the src ip again.
It ignores older logs though, we could probably devise a way to cover
both, but I'm not convinced it is worth it.
from @ogmueller in issue #1927