### PR TITLE
Little fix for AppArmor rules

### DIFF
--- a/etc/rules/apparmor_rules.xml
+++ b/etc/rules/apparmor_rules.xml
@@ -14,6 +14,7 @@
 <group name="local,syslog,apparmor">
 
   <rule id="52000" level="3">
+    <if_sid>1002</if_sid>
     <decoded_as>iptables</decoded_as>
     <pcre2> apparmor=</pcre2>
     <description>Apparmor grouping</description>


### PR DESCRIPTION
Found a little bug in AppArmor rules:

```
2020/12/09 13:45:14 ossec-testrule: INFO: Reading local decoder file.
2020/12/09 13:45:14 ossec-testrule: INFO: Started (pid: 12629).
ossec-testrule: Type one log per line.

Dec  9 13:03:30 testing_server kernel: [1736294.389703] audit: type=1400 audit(1607519010.253:322): apparmor="ALLOWED" operation="open" profile="libreoffice-soffice" name="/var/www/moodle_testing/temp/core_file/conversions/23fa780e-0c2f-4cec-b023-e150dc78929b/11630.docx" pid=29328 comm="cppu_threadpool" requested_mask="r" denied_mask="r" fsuid=33 ouid=33


**Phase 1: Completed pre-decoding.
       full event: 'Dec  9 13:03:30 testing_server kernel: [1736294.389703] audit: type=1400 audit(1607519010.253:322): apparmor="ALLOWED" operation="open" profile="libreoffice-soffice" name="/var/www/moodle_testing/temp/core_file/conversions/23fa780e-0c2f-4cec-b023-e150dc78929b/11630.docx" pid=29328 comm="cppu_threadpool" requested_mask="r" denied_mask="r" fsuid=33 ouid=33'
       hostname: 'testing_server'
       program_name: 'kernel'
       log: '[1736294.389703] audit: type=1400 audit(1607519010.253:322): apparmor="ALLOWED" operation="open" profile="libreoffice-soffice" name="/var/www/moodle_testing/temp/core_file/conversions/23fa780e-0c2f-4cec-b023-e150dc78929b/11630.docx" pid=29328 comm="cppu_threadpool" requested_mask="r" denied_mask="r" fsuid=33 ouid=33'

**Phase 2: Completed decoding.
       decoder: 'iptables'
       status: 'ALLOWED'
       extra_data: 'open'

**Rule debugging:
    Trying rule: 1 - Generic template for all syslog rules.
       *Rule 1 matched.
       *Trying child rules.
    Trying rule: 5500 - Grouping of the pam_unix rules.
    Trying rule: 5700 - SSHD messages grouped.
    Trying rule: 5600 - Grouping for the telnetd rules
    Trying rule: 2100 - NFS rules grouped.
    Trying rule: 2507 - OpenLDAP group.
    Trying rule: 2550 - rshd messages grouped.
    Trying rule: 2701 - Ignoring procmail messages.
    Trying rule: 2800 - Pre-match rule for smartd.
    Trying rule: 5100 - Pre-match rule for kernel messages
       *Rule 5100 matched.
       *Trying child rules.
    Trying rule: 5101 - Informative message from the kernel.
    Trying rule: 5102 - Informative message from the kernel
    Trying rule: 5104 - Interface entered in promiscuous(sniffing) mode.
    Trying rule: 5105 - Invalid request to /dev/fd0 (bug on the kernel).
...
    Trying rule: 1002 - Unknown problem somewhere in the system.
       *Rule 1002 matched.
       *Trying child rules.
    Trying rule: 1009 - Ignoring known false positives on rule 1002..
    Trying rule: 2942 - Uninteresting gnome error.
...

**Phase 3: Completed filtering (rules).
       Rule id: '1002'
       Level: '7'
       Description: 'Unknown problem somewhere in the system.'
**Alert to be generated.
```

And after little changes everything work as expected.