### PR TITLE
Write md5 and sha1 checksums for newly added files.

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -600,11 +600,53 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
     if (Config.syscheck_alert_new == 1)  {
         sdb.syscheck_dec->id = sdb.idn;
 
+        char *newfilec_sum = NULL;
+        char *newfilemd5 = NULL;
+        char *newfilesha1 = NULL;
+
+        os_strdup(c_sum, newfilec_sum);
+
+        char *token = strtok(newfilec_sum, ":");
+
+        int tok_count = 1;
+
+        while (token != NULL)
+        {
+            if(tok_count == 5)
+            {
+                newfilemd5 = token;
+            }
+            if(tok_count == 6)
+            {
+                newfilesha1 = token;
+            }
+
+            token = strtok(NULL, ":");
+            tok_count++;
+        }
+
+        /* SHA-1 message */
+        snprintf(sdb.sha1, OS_FLSIZE,
+                 "New sha1sum is : '%s'\n",
+                 newfilesha1);
+        os_strdup(newfilesha1, lf->sha1_after);
+
+        /* MD5 message */
+        snprintf(sdb.md5, OS_FLSIZE,
+                 "New md5sum is : '%s'\n",
+                 newfilemd5);
+        os_strdup(newfilemd5, lf->md5_after);
+
         /* New file message */
         snprintf(sdb.comment, OS_MAXSTR,
                  "New file '%.756s' "
-                 "added to the file system.", f_name);
-
+                 "added to the file system.\n"
+                 "%s"
+                 "%s",
+                 f_name,
+                 sdb.sha1,
+                 sdb.md5
+                );
 
         /* Create a new log message */
         free(lf->full_log);


### PR DESCRIPTION
Naive solution for https://github.com/ossec/ossec-hids/issues/314 - Write md5 and sha1 checksums for newly added files.

I am not very familiar with the OSSEC code base but this seems to work. Very open to making changes to align with code organization / quality standards or other feedback!

Summary:
OSSEC records checksums (both old and new) for files it is configured to monitor via syscheck.

Example:
```** Alert 1589082701.1481730: mail  - ossec,syscheck,
2020 May 09 23:51:41 localhost->syscheck
Rule: 550 (level 7) -> 'Integrity checksum changed.'
Integrity checksum changed for: '/etc/yum.conf'
Size changed from '978' to '970'
Old md5sum was: 'c9db7a8874a8d889fa9b6336a4a7ea04'
New md5sum is : 'a7dc0d7b8902e9c8c096c93eb431d19e'
Old sha1sum was: 'b02997d3c3fa9322132c8cf1e42f4462ddcda362'
New sha1sum is : 'e0637e631f4ab0aaebef1a6b8822a36f031f332e'```

When configured to alert on new file creation, it does not record similar checksums. We would like these so we can record them in our SIEM and attempt to determine if they are known malicious via threat intelligence systems.

Example before this change:

```** Alert 1589082690.1481191: - ossec,syscheck,
2020 May 09 23:51:30 localhost->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
New file '/etc/.yum.conf.swp' added to the file system.```

Example after this change:

```** Alert 1589082690.1481191: - ossec,syscheck,
2020 May 09 23:51:30 localhost->syscheck
Rule: 554 (level 5) -> 'File added to the system.'
New file '/etc/.yum.conf.swp' added to the file system.
New sha1sum is : '1cf120af022f6acc955a5ef70e74f1f7eb604c3f'
New md5sum is : 'bd00d635ca6302c622968688760993d8'```

Test Plan: Confirmed that new file alerts include sha1 and md5 checksums both in OSSEC's alerts.log and also in syslog data OSSEC can be optionally configured to generate.