### PR TITLE
Fix issue #2020

### DIFF
--- a/src/rootcheck/db/rootkit_trojans.txt
+++ b/src/rootcheck/db/rootkit_trojans.txt
@@ -36,7 +36,7 @@ sudo        !satori|vejeta|conf\.inv!
 crond       !/dev/[^nt]|bash!
 gpm         !bash|mingetty!
 ifconfig    !bash|^/bin/sh|/dev/tux|session.null|/dev/[^cludisopt]!
-diff        !bash|^/bin/sh|file\.h|proc\.h|/dev/[^n]|^/bin/.*sh!
+diff        !bash|^/bin/sh|file\.h|proc\.h|^/bin/.*sh!
 md5sum      !bash|^/bin/sh|file\.h|proc\.h|/dev/|^/bin/.*sh!
 hdparm      !bash|/dev/ida!
 ldd         !/dev/[^n]|proc\.h|libshow.so|libproc.a!


### PR DESCRIPTION
/bin/diff returns /dev/full on fedora, so remove the /dev check