### PR TITLE
* dovecot decoder fix

### DIFF
--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -971,7 +971,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="dovecot-disconnect">
   <parent>dovecot</parent>
   <prematch_pcre2 offset="after_parent">^\w{4}-login: Disconnected: </prematch_pcre2>
-  <pcre2 offset="after_prematch">^rip=(\S+), lip=(\S+)</pcre2>
+  <pcre2 offset="after_prematch">^rip=(\S+), lip=(\S+)(?:,|$)</pcre2>
   <order>srcip, dstip</order>
 </decoder>
 


### PR DESCRIPTION
This patch fixes incorrect capture of "local ip" address in dovecot decoder. Example line from logs:

`dovecot: imap-login: Login: user=<admin@example.com>, method=PLAIN, rip=1.2.3.4, lip=4.5.6.7, mpid=8303, session=<0d/WNNoKGMjAqDr9>`

Old regex captures "4.5.6.7," (extra comma at end).