### PR TITLE
Backport CVE-2020-24370's patch

### DIFF
--- a/src/external/lua-5.2.3/src/ldebug.c
+++ b/src/external/lua-5.2.3/src/ldebug.c
@@ -106,10 +106,11 @@ static const char *upvalname (Proto *p, int uv) {
 
 static const char *findvararg (CallInfo *ci, int n, StkId *pos) {
   int nparams = clLvalue(ci->func)->p->numparams;
-  if (n >= ci->u.l.base - ci->func - nparams)
+  int nvararg = cast_int(ci->u.l.base - ci->func) - nparams;
+  if (n <= -nvararg)
     return NULL;  /* no such vararg */
   else {
-    *pos = ci->func + nparams + n;
+    *pos = ci->func + nparams - n;
     return "(*vararg)";  /* generic name for any vararg */
   }
 }
@@ -121,7 +122,7 @@ static const char *findlocal (lua_State *L, CallInfo *ci, int n,
   StkId base;
   if (isLua(ci)) {
     if (n < 0)  /* access to vararg values? */
-      return findvararg(ci, -n, pos);
+      return findvararg(ci, n, pos);
     else {
       base = ci->u.l.base;
       name = luaF_getlocalname(ci_func(ci)->p, n, currentpc(ci));


### PR DESCRIPTION
[CVE-2020-24370](https://github.com/advisories/GHSA-gfr4-c37g-mm3v) is a security vulnerability in lua. Although the CVE decription in [CVE-2020-24370](https://nvd.nist.gov/vuln/detail/CVE-2020-24370) said that this CVE only affected [lua](https://www.lua.org/bugs.html#5.4.0-11) 5.4.0, according to lua this CVE actually existed since lua 5.2. The root cause of this CVE is the negation overflow that occurs when you try to take the negative of 0x80000000. Thus, this CVE also exists in ossec-hids.
Try to backport the [fix](https://github.com/lua/lua/commit/a585eae6e7ada1ca9271607a4f48dfb17868ab7b) to the lua in ossec-hids since the original fix is for 5.4 and several functions have been changed.