### PR TITLE
Fix NULL pointer dereference in logcollector when no logfiles configured

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -289,7 +289,9 @@ void LogCollectorStart()
         for (i = 0; i <= max_file; i++) {
             if (!logff[i].fp) {
                 /* Run the command */
-                if ((logff[i].command || (logff[i].logformat && !strncmp(logff[i].logformat, "journald", 7))) && (f_check % 2)) {
+                if (logff[i].read &&
+                    (logff[i].command || (logff[i].logformat && !strncmp(logff[i].logformat, "journald", 7))) &&
+                    (f_check % 2)) {
                     curr_time = time(0);
                     if ((curr_time - logff[i].size) >= logff[i].ign) {
                         logff[i].size = curr_time;

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -289,7 +289,7 @@ void LogCollectorStart()
         for (i = 0; i <= max_file; i++) {
             if (!logff[i].fp) {
                 /* Run the command */
-                if ((logff[i].command || !strncmp(logff[i].logformat, "journald", 7)) && (f_check % 2)) {
+                if ((logff[i].command || (logff[i].logformat && !strncmp(logff[i].logformat, "journald", 7))) && (f_check % 2)) {
                     curr_time = time(0);
                     if ((curr_time - logff[i].size) >= logff[i].ign) {
                         logff[i].size = curr_time;


### PR DESCRIPTION
When all logfile tags are removed from ossec.conf, logcollector would segfault due to a NULL pointer dereference on line 292. The code was calling strncmp() on logff[i].logformat without checking if it was NULL.

This fix adds a NULL check before the strncmp() call to prevent the segfault when no logfiles are configured.

Fixes segfault reported on Ubuntu 22.04 (Jammy) with version 3.8.0. Closes issue #2156 