### PR TITLE
Clean up redundant NULL checks in report filter function

### DIFF
--- a/src/shared/report_op.c
+++ b/src/shared/report_op.c
@@ -116,38 +116,26 @@ static int _os_report_check_filters(const alert_data *al_data, const report_filt
         }
     }
     if (r_filter->srcip) {
-        if(!al_data->srcip) {
-            return(0);
+        if (!al_data->srcip) {
+            return (0);
         }
-        if (al_data->srcip) {
-            if (!strstr(al_data->srcip, r_filter->srcip)) {
-                return (0);
-            }
-        } else {
+        if (!strstr(al_data->srcip, r_filter->srcip)) {
             return (0);
         }
     }
     if (r_filter->user) {
-        if(!al_data->user) {
-            return(0);
+        if (!al_data->user) {
+            return (0);
         }
-        if (al_data->user) {
-            if (!strstr(al_data->user, r_filter->user)) {
-                return (0);
-            }
-        } else {
+        if (!strstr(al_data->user, r_filter->user)) {
             return (0);
         }
     }
     if (r_filter->files) {
-        if(!al_data->filename) {
-            return(0);
+        if (!al_data->filename) {
+            return (0);
         }
-        if (al_data->filename) {
-            if (!strstr(al_data->filename, r_filter->files)) {
-                return (0);
-            }
-        } else {
+        if (!strstr(al_data->filename, r_filter->files)) {
             return (0);
         }
     }


### PR DESCRIPTION
Removed redundant NULL checks and unreachable else branches in _os_report_check_filters() for srcip, user, and filename filters.

The pattern was:
  if (ptr) { ... } else { return 0; }  // else is unreachable

Simplified to:
  // ptr is guaranteed non-NULL here

This removes 18 lines of dead code and improves readability.

Addresses issue #2133  raised by alexismailov2.