### PR TITLE
Improve error message in ossec-testrule for missing rule matches

### DIFF
--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -589,7 +589,10 @@ void OS_ReadMSG(char *ut_str)
                     exit_code--;
 
                     if (!currently_rule) {
-                        merror("%s: currently_rule not set!", ARGV0);
+                        merror("%s: No rule matched for decoder '%s'. "
+                               "Verify that rules exist for this decoder and check if rules have "
+                               "required dependencies (if_sid, if_matched_sid, if_matched_group, etc.).",
+                               ARGV0, lf->decoder_info->name);
                         exit(-1);
                     }
                     snprintf(holder, 1023, "%d", currently_rule->sigid);


### PR DESCRIPTION
Changed cryptic error 'currently_rule not set!' to a more helpful message that explains what's actually wrong and how to fix it.

Old message:
  'ossec-testrule: currently_rule not set!'

New message:
  'ossec-testrule: No rule matched for decoder '<decoder_name>'.
   Verify that rules exist for this decoder and check if rules have
   required dependencies (if_sid, if_matched_sid, if_matched_group, etc.).'

This helps users quickly identify that:
1. The decoder matched but no rule matched
2. They should check if rules exist for this decoder
3. Rules may be missing required dependencies like if_sid

Fixes issue #2093 reported by stefanct.