### PR TITLE
Fix Issue #162: use_own_name doesn't work in ossec-logtest

### DIFF
--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -71,11 +71,6 @@ void DecodeEvent(Eventinfo *lf)
             }
         }
 
-#ifdef TESTRULE
-        if (!alert_only) {
-            print_out("       decoder: '%s'", nnode->name);
-        }
-#endif
 
         lf->decoder_info = nnode;
         child_node = node->child;
@@ -160,7 +155,7 @@ void DecodeEvent(Eventinfo *lf)
         /* If we have an external decoder, execute it */
         if (nnode->plugindecoder) {
             nnode->plugindecoder(lf);
-            return;
+            goto out;
         }
 
         /* Get the regex */
@@ -198,7 +193,7 @@ void DecodeEvent(Eventinfo *lf)
                         nnode = child_node->osdecoder;
                         continue;
                     }
-                    return;
+                    goto out;
                 }
 
                 lf->decoder_info = nnode;
@@ -259,7 +254,7 @@ void DecodeEvent(Eventinfo *lf)
                         nnode = child_node->osdecoder;
                         continue;
                     }
-                    return;
+                    goto out;
                 }
 
 
@@ -290,12 +285,13 @@ void DecodeEvent(Eventinfo *lf)
             }
 
 
+
             /* If we don't have a regex, we may leave now */
-            return;
+            goto out;
         }
 
         /* ok to return  */
-        return;
+        goto out;
     } while ((node = node->next) != NULL);
 
 #ifdef TESTRULE
@@ -303,6 +299,15 @@ void DecodeEvent(Eventinfo *lf)
         print_out("       No decoder matched.");
     }
 #endif
+    return;
+
+out:
+#ifdef TESTRULE
+    if (!alert_only && lf->decoder_info) {
+        print_out("       decoder: '%s'", lf->decoder_info->name);
+    }
+#endif
+    return;
 }
 
 /*** Event decoders ****/

--- a/src/tests/regressions/issue_162
+++ b/src/tests/regressions/issue_162
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Regression test for Issue #162 - use_own_name doesn't work in ossec-logtest
+# https://github.com/ossec/ossec-hids/issues/162
+#
+# This test verifies that child decoders with use_own_name=true correctly
+# display their own name instead of inheriting the parent decoder's name.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OSSEC_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+echo "Regression Test: Issue #162 - use_own_name decoder option"
+echo "=========================================================="
+echo ""
+
+# Test 1: postfix-reject decoder (has use_own_name=true)
+echo "Test 1: postfix-reject decoder should show 'postfix-reject', not 'postfix'"
+echo "Log: Feb  1 14:53:00 hostname postfix/smtpd[32297]: NOQUEUE: reject: RCPT from unknown[213.255.237.245]: 554"
+echo ""
+
+# Find ossec-logtest binary
+if [ -n "$OSSEC_LOGTEST" ] && [ -x "$OSSEC_LOGTEST" ]; then
+    LOGTEST_BIN="$OSSEC_LOGTEST"
+elif [ -x "$OSSEC_ROOT/src/ossec-logtest" ]; then
+    LOGTEST_BIN="$OSSEC_ROOT/src/ossec-logtest"
+elif [ -x "$OSSEC_ROOT/bin/ossec-logtest" ]; then
+    LOGTEST_BIN="$OSSEC_ROOT/bin/ossec-logtest"
+elif command -v ossec-logtest >/dev/null 2>&1; then
+    LOGTEST_BIN="$(command -v ossec-logtest)"
+else
+    echo "ERROR: ossec-logtest binary not found. Set OSSEC_LOGTEST env var."
+    exit 1
+fi
+
+RESULT=$(echo "Feb  1 14:53:00 hostname postfix/smtpd[32297]: NOQUEUE: reject: RCPT from unknown[213.255.237.245]: 554" | \
+    "$LOGTEST_BIN" -v 2>&1)
+
+DECODER_NAME=$(echo "$RESULT" | grep "decoder:" | head -1 | sed "s/.*decoder: '//;s/'.*//")
+
+if [ "$DECODER_NAME" = "postfix-reject" ]; then
+    echo "✓ PASS: Decoder name is 'postfix-reject' (use_own_name working)"
+    exit 0
+elif [ "$DECODER_NAME" = "postfix" ]; then
+    echo "✗ FAIL: Decoder name is 'postfix' (use_own_name NOT working - BUG)"
+    echo ""
+    echo "Expected: postfix-reject"
+    echo "Got:      $DECODER_NAME"
+    exit 1
+else
+    echo "? UNKNOWN: Decoder name is '$DECODER_NAME'"
+    echo ""
+    echo "Full output:"
+    echo "$RESULT" | head -30
+    exit 2
+fi


### PR DESCRIPTION
The use_own_name decoder option was not working correctly in ossec-logtest. Child decoders with use_own_name=true were incorrectly displaying the parent decoder's name instead of their own name.

Root cause: The decoder name was being printed before child decoder matching completed, so it always showed the parent decoder name.

Fix: Moved the decoder name print statement to after child decoder matching completes, ensuring lf->decoder_info->name contains the correct decoder (child with use_own_name=true, or parent otherwise).

Changes:
- src/analysisd/decoders/decoder.c: Moved decoder print from line 76 to line 159 (after child matching)
- src/tests/regressions/issue_162: Added regression test to verify postfix-reject decoder correctly shows its own name

Tested on remote server with postfix-reject decoder - PASSED

Fixes #162