### PR TITLE
Ossec-dbd connector fix

### DIFF
--- a/src/os_dbd/db_op.c
+++ b/src/os_dbd/db_op.c
@@ -124,6 +124,7 @@ static void osdb_checkerror()
 
             /* If we were able to reconnect, keep going */
             if (db_config_pt->conn) {
+                db_config_pt->error_count = 0;
                 break;
             }
             sleep(sleep_time);


### PR DESCRIPTION
ossec-dbd will reset its error_count upon successful reconnection, preventing it from incorrectly hitting the error limit due to accumulated transient failures.