### PR TITLE
Fix ossec-authd failure under modern Linux crypto policies (RHEL 8+) …

### DIFF
--- a/src/os_auth/ssl.c
+++ b/src/os_auth/ssl.c
@@ -184,6 +184,20 @@ SSL_CTX *get_ssl_context(const char *ciphers)
 #endif
 
     /* Initialize Diffie-Hellman parameters */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    /* Let OpenSSL select DH parameters that comply with the active
+     * system crypto policy / security level. Required for RHEL 8+ and
+     * other distributions whose default policies reject hardcoded DH
+     * groups at security level >= 2, even when those groups are 2048-bit
+     * and cryptographically valid (e.g. RFC 3526 MODP-2048).
+     *
+     * OpenSSL 1.1.0 introduced both security levels and
+     * SSL_CTX_set_dh_auto(); OpenSSL 1.0.2 (e.g. CentOS 7) lacks a
+     * reliable linkable SSL_CTX_set_dh_auto() and does not enforce
+     * security-level DH checks, so keep the hardcoded group there. */
+    SSL_CTX_set_dh_auto(ctx, 1);
+    (void)dh; /* silence unused-variable warning on this code path */
+#else
     if ((dh = get_dh2048())) {
         if (!SSL_CTX_set_tmp_dh(ctx, dh)) {
             merror("%s: ERROR: Unable to set temporary DH parameters", ARGV0);
@@ -195,6 +209,7 @@ SSL_CTX *get_ssl_context(const char *ciphers)
         merror("%s: ERROR: Unable to load DH parameters", ARGV0);
         goto CONTEXT_ERR;
     }
+#endif
 
     return ctx;
 


### PR DESCRIPTION
…by using SSL_CTX_set_dh_auto()

Fix for issue #2213
Original work by @tmeader