### PR TITLE
Fix agent getaddrinfo failures on RHEL 8+ by retrying with IPv4

### DIFF
--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -379,6 +379,15 @@ int OS_Connect(char *_port, unsigned int protocol, const char *_ip)
     hints.ai_flags = 0;
 
     s = getaddrinfo(_ip, _port, &hints, &result);
+
+    /* Retry with IPv4-only hints when dual-stack lookup fails. OS_Bindport()
+     * has had this fallback since PR #1259; agents use OS_Connect() and hit
+     * the same resolver failures on RHEL 8+ (issue #2046). */
+    if (s == EAI_FAMILY || s == EAI_NONAME || s == EAI_SYSTEM) {
+        hints.ai_family = AF_INET;
+        s = getaddrinfo(_ip, _port, &hints, &result);
+    }
+
     if (s != 0) {
         verbose("getaddrinfo: %s", gai_strerror(s));
         if(result) {

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -383,7 +383,11 @@ int OS_Connect(char *_port, unsigned int protocol, const char *_ip)
     /* Retry with IPv4-only hints when dual-stack lookup fails. OS_Bindport()
      * has had this fallback since PR #1259; agents use OS_Connect() and hit
      * the same resolver failures on RHEL 8+ (issue #2046). */
-    if (s == EAI_FAMILY || s == EAI_NONAME || s == EAI_SYSTEM) {
+    if (s == EAI_FAMILY || s == EAI_NONAME
+#ifdef EAI_SYSTEM
+        || s == EAI_SYSTEM
+#endif
+    ) {
         hints.ai_family = AF_INET;
         s = getaddrinfo(_ip, _port, &hints, &result);
     }


### PR DESCRIPTION
OS_Connect() used AF_UNSPEC for manager lookups but lacked the IPv4 fallback that OS_Bindport() gained in PR #1259. On RHEL 8 family systems, agentd can fail hostname resolution with EAI_SYSTEM or EAI_FAMILY, exit before the local queue is ready, and leave logcollector/syscheckd reporting "Connection refused" on /queue/ossec/queue (issue #2046).

Retry getaddrinfo() with AF_INET when the initial dual-stack lookup fails with EAI_FAMILY, EAI_NONAME, or EAI_SYSTEM.

Closes issue #2046