### PR TITLE
Fix Windows agent ignoring configured notify_time for keep-alives.

### DIFF
--- a/src/win32/win_agent.c
+++ b/src/win32/win_agent.c
@@ -405,7 +405,7 @@ int SendMSG(__attribute__((unused)) int queue, const char *message, const char *
 #endif
 
     /* Send notification */
-    else if ((cu_time - __win32_curr_time) > (NOTIFY_TIME - 200)) {
+    else if ((cu_time - __win32_curr_time) > (agt->notify_time - 200)) {
         debug1("%s: DEBUG: Sending info to server (ctime2)...", ARGV0);
         send_win32_info(cu_time);
     }


### PR DESCRIPTION
SendMSG() used the compile-time NOTIFY_TIME constant for periodic send_win32_info() instead of agt->notify_time from ossec.conf, so a custom <notify_time> had no effect on that code path.

Fix for #879; timer-based notify in the receiver thread remains future work.