### PR TITLE
Fix wrong CloseHandle on Windows realtime duplicate hash path.

### DIFF
--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -396,7 +396,7 @@ int realtime_adddir(const char *dir)
     if (OSHash_Get(syscheck.realtime->dirtb, wdchar)) {
         merror("%s: ERROR: Entry already in the real time hash: %s",
                ARGV0, wdchar);
-        CloseHandle(rtlocald->overlap.hEvent);
+        CloseHandle(rtlocald->h);
         free(rtlocald);
         rtlocald = NULL;
         return (0);


### PR DESCRIPTION
Close the CreateFile directory handle instead of the uninitialized overlap.hEvent when a duplicate realtime hash entry is detected. Fixes #1072.