### PR TITLE
Fix frequency rule alert context showing unrelated log lines (#1079)

### DIFF
--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -156,7 +156,7 @@ void OS_LogOutput(Eventinfo *lf)
             printf("%.1256s\n", *lasts);
             lasts++;
         }
-        lf->generated_rule->last_events[0] = NULL;
+        OS_FreeRuleLastEvents(lf->generated_rule);
     }
 
     printf("\n");
@@ -241,7 +241,7 @@ void OS_Log(Eventinfo *lf)
             fprintf(_aflog, "%.1256s\n", *lasts);
             lasts++;
         }
-        lf->generated_rule->last_events[0] = NULL;
+        OS_FreeRuleLastEvents(lf->generated_rule);
     }
 
     fprintf(_aflog, "\n");

--- a/src/analysisd/dodiff.c
+++ b/src/analysisd/dodiff.c
@@ -10,6 +10,7 @@
 #include "dodiff.h"
 
 #include "shared.h"
+#include "eventinfo.h"
 
 static int _add2last(const char *str, size_t strsize, const char *file)
 {
@@ -76,7 +77,7 @@ int doDiff(RuleInfo *rule, const Eventinfo *lf)
     /* Clean up global */
     flastcontent[0] = '\0';
     flastcontent[OS_SIZE_8192] = '\0';
-    rule->last_events[0] = NULL;
+    OS_FreeRuleLastEvents(rule);
 
     if (lf->hostname[0] == '(') {
         htpt = strchr(lf->hostname, ')');

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -19,6 +19,50 @@ int alert_only;
 #endif
 
 
+/* Free heap-owned frequency context log lines */
+void OS_FreeRuleLastEvents(RuleInfo *rule)
+{
+    int ii;
+
+    if (!rule || !rule->last_events || !rule->last_events_copied) {
+        return;
+    }
+
+    for (ii = 0; ii <= MAX_LAST_EVENTS; ii++) {
+        if (rule->last_events[ii]) {
+            free(rule->last_events[ii]);
+            rule->last_events[ii] = NULL;
+        }
+    }
+
+    rule->last_events_copied = 0;
+}
+
+/* Store a copy of a log line in the rule frequency context buffer */
+void OS_SetRuleLastEvent(RuleInfo *rule, int idx, const char *log)
+{
+    if (!rule || !rule->last_events || !log) {
+        return;
+    }
+
+    if (idx < 0 || idx > MAX_LAST_EVENTS) {
+        return;
+    }
+
+    if (rule->last_events_copied && rule->last_events[idx]) {
+        free(rule->last_events[idx]);
+        rule->last_events[idx] = NULL;
+    }
+
+    os_strdup(log, rule->last_events[idx]);
+    rule->last_events_copied = 1;
+
+    if (idx < MAX_LAST_EVENTS) {
+        rule->last_events[idx + 1] = NULL;
+    }
+}
+
+
 /* Search last times a signature fired
  * Will look for only that specific signature.
  */
@@ -30,6 +74,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
 
     /* Set frequency to 0 */
     rule->__frequency = 0;
+    OS_FreeRuleLastEvents(rule);
 
     /* Checking if sid search is valid */
     if (!rule->sid_search) {
@@ -159,10 +204,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
 
         /* Check if the number of matches worked */
         if (rule->__frequency <= 10) {
-            rule->last_events[rule->__frequency]
-                = lf->full_log;
-            rule->last_events[rule->__frequency + 1]
-                = NULL;
+            OS_SetRuleLastEvent(rule, rule->__frequency, lf->full_log);
         }
 
         if (rule->__frequency < rule->frequency) {
@@ -195,6 +237,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
 
     /* Set frequency to 0 */
     rule->__frequency = 0;
+    OS_FreeRuleLastEvents(rule);
 
     /* Check if sid search is valid */
     if (!rule->group_search) {
@@ -326,10 +369,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
         /* Check if the number of matches worked */
         if (rule->__frequency < rule->frequency) {
             if (rule->__frequency <= 10) {
-                rule->last_events[rule->__frequency]
-                    = lf->full_log;
-                rule->last_events[rule->__frequency + 1]
-                    = NULL;
+                OS_SetRuleLastEvent(rule, rule->__frequency, lf->full_log);
             }
 
             rule->__frequency++;
@@ -360,6 +400,8 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
     Eventinfo *lf;
     Eventinfo *first_lf;
 
+    rule->__frequency = 0;
+    OS_FreeRuleLastEvents(rule);
 
     /* Last events */
     eventnode_pt = OS_GetLastEvent();
@@ -368,8 +410,6 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
         return (NULL);
     }
 
-    /* Set frequency to 0 */
-    rule->__frequency = 0;
     first_lf = (Eventinfo *)eventnode_pt->event;
 
     /* Search all previous events */
@@ -470,10 +510,7 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
         /* Check if the number of matches worked */
         if (rule->__frequency < rule->frequency) {
             if (rule->__frequency <= 10) {
-                rule->last_events[rule->__frequency]
-                    = lf->full_log;
-                rule->last_events[rule->__frequency + 1]
-                    = NULL;
+                OS_SetRuleLastEvent(rule, rule->__frequency, lf->full_log);
             }
 
             rule->__frequency++;

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -131,6 +131,10 @@ Eventinfo *Search_LastEvents(Eventinfo *lf, RuleInfo *currently_rule);
 Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *currently_rule);
 Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule);
 
+/* Frequency rule context log samples (heap-owned copies) */
+void OS_SetRuleLastEvent(RuleInfo *rule, int idx, const char *log);
+void OS_FreeRuleLastEvents(RuleInfo *rule);
+
 /* Zero the eventinfo structure */
 void Zero_Eventinfo(Eventinfo *lf);
 

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -1716,6 +1716,7 @@ RuleInfo *zerorulemember(int id, int level,
     /* Zero last matched events */
     ruleinfo_pt->__frequency = 0;
     ruleinfo_pt->last_events = NULL;
+    ruleinfo_pt->last_events_copied = 0;
 
     /* Zeroing the list of previous matches */
     ruleinfo_pt->sid_prev_matched = NULL;

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -96,6 +96,7 @@ typedef struct _RuleInfo {
 
     int __frequency;
     char **last_events;
+    int last_events_copied;
 
     /* Not an option in the rule */
     u_int16_t alert_opts;

--- a/src/headers/rules_op.h
+++ b/src/headers/rules_op.h
@@ -81,6 +81,7 @@ typedef struct _RuleInfo {
 
     int __frequency;
     char **last_events;
+    int last_events_copied;
 
     /* Not an option in the rule */
     u_int16_t alert_opts;

--- a/src/shared/rules_op.c
+++ b/src/shared/rules_op.c
@@ -962,6 +962,7 @@ static RuleInfo *_OS_AllocateRule()
     /* Zero last matched events */
     ruleinfo_pt->__frequency = 0;
     ruleinfo_pt->last_events = NULL;
+    ruleinfo_pt->last_events_copied = 0;
 
     /* Zero the list of previous matches */
     ruleinfo_pt->sid_prev_matched = NULL;


### PR DESCRIPTION
Frequency rules (e.g. 5712, 5720) store prior matching events in rule->last_events for the alert "Portion of the log(s)" output. Search_LastSids, Search_LastGroups, and Search_LastEvents previously saved raw pointers to Eventinfo->full_log. When those events were freed during global ring eviction, the stored pointers became stale and could show unrelated logs that reused the same memory (often other SSH lines sharing the same source IP).

Copy log lines when building the frequency context and release the copies after alerts are written. Add OS_SetRuleLastEvent() and OS_FreeRuleLastEvents(), track heap ownership with last_events_copied, and reset copied context at the start of each frequency search. doDiff() clears prior copied context before assigning its static diff pointers.

Closes issue #1079