### PR TITLE
Fix incomplete syscheck baseline database population (#1248).

### DIFF
--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -19,6 +19,11 @@
 #include <sqlite3.h>
 #endif
 
+typedef struct _sk_db_entry {
+    fpos_t pos;
+    char prefix_sum[OS_MAXSTR + 1];
+} sk_db_entry;
+
 typedef struct __sdb {
     char buf[OS_MAXSTR + 1];
     char comment[OS_MAXSTR + 1];
@@ -34,6 +39,7 @@ typedef struct __sdb {
     char agent_cp[MAX_AGENTS + 1][1];
     char *agent_ips[MAX_AGENTS + 1];
     FILE *agent_fps[MAX_AGENTS + 1];
+    OSHash *agent_index[MAX_AGENTS + 1];
 
     int db_err;
 
@@ -97,6 +103,7 @@ void SyscheckInit()
     for (; i <= MAX_AGENTS; i++) {
         sdb.agent_ips[i] = NULL;
         sdb.agent_fps[i] = NULL;
+        sdb.agent_index[i] = NULL;
         sdb.agent_cp[i][0] = '0';
     }
 
@@ -246,15 +253,101 @@ static FILE *DB_File(const char *agent, int *agent_id)
     return (sdb.agent_fps[i]);
 }
 
+/* Parse a syscheck db line and return the filename within line_buf. */
+static int DB_ParseEntryFilename(char *line_buf, char **fname_out)
+{
+    char *saved_name;
+
+    if (line_buf[0] == '\n' || line_buf[0] == '#') {
+        return (-1);
+    }
+
+    saved_name = strchr(line_buf, ' ');
+    if (saved_name == NULL) {
+        return (-1);
+    }
+
+    *saved_name = '\0';
+    saved_name++;
+
+    if (*saved_name == '!') {
+        saved_name = strchr(saved_name, ' ');
+        if (saved_name == NULL) {
+            return (-1);
+        }
+        saved_name++;
+    }
+
+    if (saved_name[0] != '\0' && saved_name[strlen(saved_name) - 1] == '\n') {
+        saved_name[strlen(saved_name) - 1] = '\0';
+    }
+
+    *fname_out = saved_name;
+    return (0);
+}
+
+/* Build an in-memory index for O(1) syscheck db lookups per agent. */
+static void DB_BuildIndex(int agent_id, FILE *fp)
+{
+    fpos_t line_pos;
+    char line_copy[OS_MAXSTR + 1];
+
+    if (sdb.agent_index[agent_id] != NULL) {
+        return;
+    }
+
+    sdb.agent_index[agent_id] = OSHash_Create();
+    if (!sdb.agent_index[agent_id]) {
+        merror("%s: Unable to create syscheck index for agent.", ARGV0);
+        return;
+    }
+
+    if (!OSHash_setSize(sdb.agent_index[agent_id], 4096)) {
+        merror("%s: Unable to size syscheck index for agent.", ARGV0);
+    }
+
+    fseek(fp, 0, SEEK_SET);
+    while (fgetpos(fp, &line_pos) == 0 && fgets(sdb.buf, OS_MAXSTR, fp) != NULL) {
+        char *fname;
+        sk_db_entry *ent;
+
+        if (sdb.buf[0] == '\n' || sdb.buf[0] == '#') {
+            continue;
+        }
+
+        strncpy(line_copy, sdb.buf, OS_MAXSTR);
+        line_copy[OS_MAXSTR] = '\0';
+        if (DB_ParseEntryFilename(line_copy, &fname) != 0) {
+            continue;
+        }
+
+        ent = (sk_db_entry *)OSHash_Get(sdb.agent_index[agent_id], fname);
+        if (!ent) {
+            ent = (sk_db_entry *)calloc(1, sizeof(sk_db_entry));
+            if (!ent) {
+                continue;
+            }
+            if (OSHash_Add(sdb.agent_index[agent_id], fname, ent) != 2) {
+                free(ent);
+                continue;
+            }
+        }
+
+        ent->pos = line_pos;
+        strncpy(ent->prefix_sum, line_copy, OS_MAXSTR);
+        ent->prefix_sum[OS_MAXSTR] = '\0';
+    }
+
+    fseek(fp, 0, SEEK_SET);
+}
+
 /* Search the DB for any entry related to the file being received */
 static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
 {
     int p = 0;
-    size_t sn_size;
     int agent_id;
 
     char *saved_sum;
-    char *saved_name;
 
     FILE *fp;
 
@@ -272,59 +365,20 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
         return (0);
     }
 
-    /* Read the integrity file and search for a possible entry */
-    if (fgetpos(fp, &sdb.init_pos) == -1) {
-        merror("%s: Error handling integrity database (fgetpos).", ARGV0);
-        return (0);
-    }
+    DB_BuildIndex(agent_id, fp);
 
-    /* Loop over the file */
-    while (fgets(sdb.buf, OS_MAXSTR, fp) != NULL) {
-        /* Ignore blank lines and lines with a comment */
-        if (sdb.buf[0] == '\n' || sdb.buf[0] == '#') {
-            fgetpos(fp, &sdb.init_pos); /* Get next location */
-            continue;
+    {
+        sk_db_entry *db_entry = NULL;
+
+        if (sdb.agent_index[agent_id]) {
+            db_entry = (sk_db_entry *)OSHash_Get(sdb.agent_index[agent_id], f_name);
         }
 
-        /* Get name */
-        saved_name = strchr(sdb.buf, ' ');
-        if (saved_name == NULL) {
-            merror("%s: Invalid integrity message in the database.", ARGV0);
-            fgetpos(fp, &sdb.init_pos); /* Get next location */
-            continue;
-        }
-        *saved_name = '\0';
-        saved_name++;
-
-        /* New format - with a timestamp */
-        if (*saved_name == '!') {
-            saved_name = strchr(saved_name, ' ');
-            if (saved_name == NULL) {
-                merror("%s: Invalid integrity message in the database", ARGV0);
-                fgetpos(fp, &sdb.init_pos); /* Get next location */
-                continue;
-            }
-            saved_name++;
-        }
-
-        /* Remove newline from saved_name */
-        sn_size = strlen(saved_name);
-        sn_size -= 1;
-        if (saved_name[sn_size] == '\n') {
-            saved_name[sn_size] = '\0';
-        }
-
-        /* If name is different, go to next one */
-        if (strcmp(f_name, saved_name) != 0) {
-            /* Save current location */
-            fgetpos(fp, &sdb.init_pos);
-            continue;
-        }
-
-        saved_sum = sdb.buf;
-
-        /* First three bytes are for frequency check */
-        saved_sum += 3;
+        if (db_entry) {
+            strncpy(sdb.buf, db_entry->prefix_sum, OS_MAXSTR);
+            sdb.buf[OS_MAXSTR] = '\0';
+            sdb.init_pos = db_entry->pos;
+            saved_sum = sdb.buf + 3;
 
         /* Checksum match, we can just return and keep going */
         if (strcmp(saved_sum, c_sum) == 0) {
@@ -390,6 +444,14 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
                 (long int)lf->time,
                 f_name);
         fflush(fp);
+
+        snprintf(db_entry->prefix_sum, OS_MAXSTR, "%c%c%c%s",
+                 '!',
+                 p >= 1 ? '!' : '+',
+                 p == 2 ? '!' : (p > 2) ? '?' : '+',
+                 c_sum);
+        fseek(fp, 0, SEEK_END);
+        fgetpos(fp, &db_entry->pos);
 
         /* File deleted */
         if (c_sum[0] == '-' && c_sum[1] == '1') {
@@ -630,10 +692,27 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
 
         return (1);
 
-    } /* Continue */
+        }
+    }
 
     /* If we reach here, this file is not present in our database */
     fseek(fp, 0, SEEK_END);
+    if (sdb.agent_index[agent_id]) {
+        sk_db_entry *db_entry = (sk_db_entry *)OSHash_Get(sdb.agent_index[agent_id], f_name);
+
+        if (!db_entry) {
+            db_entry = (sk_db_entry *)calloc(1, sizeof(sk_db_entry));
+            if (db_entry && OSHash_Add(sdb.agent_index[agent_id], f_name, db_entry) != 2) {
+                free(db_entry);
+                db_entry = NULL;
+            }
+        }
+
+        if (db_entry && fgetpos(fp, &db_entry->pos) == 0) {
+            snprintf(db_entry->prefix_sum, OS_MAXSTR, "+++%s", c_sum);
+        }
+    }
+
     fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name);
     fflush(fp);
 

--- a/src/remoted/secure.c
+++ b/src/remoted/secure.c
@@ -256,6 +256,12 @@ void HandleSecure()
                     if ((logr.m_queue = StartMQ(DEFAULTQUEUE, WRITE)) < 0) {
                         ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQUEUE);
                     }
+
+                    if (SendMSG(logr.m_queue, tmp_msg, srcmsg,
+                                SECURE_MQ) < 0) {
+                        merror("%s: ERROR: Message from agent '%s' was lost "
+                               "after queue reconnect.", ARGV0, srcmsg);
+                    }
                 }
             } /* if socket active */
         } /* for() loop on sockets */

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -176,7 +176,9 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
         buf = (char *) OSHash_Get(syscheck.fp, file_name);
         if (!buf) {
             char alert_msg[916 + 1];    /* to accommodate a long */
+            char hash_entry[916 + 1];
             alert_msg[916] = '\0';
+            hash_entry[916] = '\0';
 
 #ifndef WIN32
             if (opts & CHECK_SEECHANGES) {
@@ -188,7 +190,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
             }
 #endif
 
-            snprintf(alert_msg, 916, "%c%c%c%c%c%c%c%ld:%d:%d:%d:%s:%s:%s",
+            snprintf(hash_entry, 916, "%c%c%c%c%c%c%c%ld:%d:%d:%d:%s:%s:%s",
                      opts & CHECK_SIZE ? '+' : '-',
                      opts & CHECK_PERM ? '+' : '-',
                      opts & CHECK_OWNER ? '+' : '-',
@@ -203,10 +205,6 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                      opts & CHECK_MD5SUM ? mf_sum : "xxx",
                      opts & CHECK_SHA1SUM ? sf_sum : "xxx",
                      opts & CHECK_SHA256SUM ? sha256_sum : "xxx");
-
-            if (OSHash_Add(syscheck.fp, file_name, strdup(alert_msg)) <= 0) {
-                merror("%s: ERROR: Unable to add file to db: %s", ARGV0, file_name);
-            }
 
             /* Send the new checksum to the analysis server */
             alert_msg[916] = '\0';
@@ -267,7 +265,14 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                      file_name);
             free(st_uid);
 #endif
-            send_syscheck_msg(alert_msg);
+            if (send_syscheck_msg(alert_msg) == 0) {
+                if (OSHash_Add(syscheck.fp, file_name, strdup(hash_entry)) <= 0) {
+                    merror("%s: ERROR: Unable to add file to db: %s", ARGV0, file_name);
+                }
+            } else {
+                merror("%s: WARN: Failed to send syscheck baseline for '%s'. "
+                      "File will be retried on the next scan.", ARGV0, file_name);
+            }
         } else {
             char alert_msg[OS_MAXSTR + 1];
             char c_sum[OS_MAXSTR + 1];
@@ -302,7 +307,10 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                     snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
                 }
                 #endif
-                send_syscheck_msg(alert_msg);
+                if (send_syscheck_msg(alert_msg) != 0) {
+                    merror("%s: WARN: Failed to send syscheck update for '%s'. "
+                          "Change will be retried on the next scan.", ARGV0, file_name);
+                }
             }
         }
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -28,9 +28,15 @@
 
 /* Prototypes */
 static void send_sk_db(void);
+static void syscheck_log_send_failures(void);
+
+/* Count of baseline/update messages that could not reach the agent queue. */
+static unsigned int syscheck_send_failures = 0;
 
 
-/* Send a message related to syscheck change/addition */
+/* Send a message related to syscheck change/addition.
+ * Returns 0 on success, -1 if the message could not be delivered.
+ */
 int send_syscheck_msg(const char *msg)
 {
     if (SendMSG(syscheck.queue, msg, SYSCHECK, SYSCHECK_MQ) < 0) {
@@ -41,9 +47,22 @@ int send_syscheck_msg(const char *msg)
         }
 
         /* Try to send it again */
-        SendMSG(syscheck.queue, msg, SYSCHECK, SYSCHECK_MQ);
+        if (SendMSG(syscheck.queue, msg, SYSCHECK, SYSCHECK_MQ) < 0) {
+            syscheck_send_failures++;
+            return (-1);
+        }
     }
     return (0);
+}
+
+static void syscheck_log_send_failures(void)
+{
+    if (syscheck_send_failures > 0) {
+        merror("%s: WARN: %u syscheck database entries were not delivered to "
+              "the manager and will be retried on the next scan.",
+              ARGV0, syscheck_send_failures);
+        syscheck_send_failures = 0;
+    }
 }
 
 /* Send a message related to rootcheck change/addition */
@@ -73,6 +92,7 @@ static void send_sk_db()
         return;
     }
 
+    syscheck_send_failures = 0;
     create_db();
 
     /* Send scan ending message */
@@ -143,6 +163,7 @@ void start_daemon()
         os_winreg_check();
 #endif
         /* Send database completed message */
+        syscheck_log_send_failures();
         send_syscheck_msg(HC_SK_DB_COMPLETED);
         debug2("%s: DEBUG: Sending database completed message.", ARGV0);
 
@@ -250,6 +271,7 @@ void start_daemon()
 
                 syscheck.scan_on_start = 1;
             } else {
+                syscheck_send_failures = 0;
                 /* Send scan start message */
                 if (syscheck.dir[0]) {
                     merror("%s: INFO: Starting syscheck scan.", ARGV0);
@@ -270,6 +292,7 @@ void start_daemon()
                 send_rootcheck_msg("Ending syscheck scan.");
             }
 
+            syscheck_log_send_failures();
             /* Send database completed message */
             send_syscheck_msg(HC_SK_DB_COMPLETED);
             debug2("%s: DEBUG: Sending database completed message.", ARGV0);


### PR DESCRIPTION
so messages lost under load were never retried on periodic scans. Only a full syscheckd restart (create_db) would backfill missing manager entries.

Defer agent-side hash updates until send_syscheck_msg() succeeds, propagate send failures from the agent queue, and log a summary of undelivered entries before syscheck-db-completed. Retry agent messages in remoted after queue reconnect instead of dropping them. Replace O(n) linear scans in analysisd DB_Search with a per-agent in-memory filename index so the manager can keep up during large initial baselines.

Closes issue #1248