### PR TITLE
Validate agent keys with OS_IsValidIP for IPv6 authd -i keys

### DIFF
--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -33,6 +33,7 @@ int k_bulkload(const char *cmdbulk);
 /* Validation functions */
 int OS_IsValidName(const char *u_name);
 int OS_IsValidID(const char *id);
+int OS_IsValidAgentKey(const char *key);
 int IDExist(const char *id);
 int NameExist(const char *u_name);
 char *IPExist(const char *u_name);

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -360,16 +360,107 @@ int OS_IsValidName(const char *u_name)
         return (0);
     }
 
-    /* Check if it contains any non-alphanumeric characters */
+    /* Agent names must not look like addresses; IPs are validated separately. */
     for (i = 0; i < uname_length; i++) {
-        if ( !( isalnum((int)u_name[i]) || (u_name[i] == '-') ||
-                (u_name[i] == '_') || (u_name[i] == '.') ||
-                (u_name[i] == ':') ) ) {
+        if (!isalnum((int)u_name[i]) && (u_name[i] != '-') &&
+                (u_name[i] != '_') && (u_name[i] != '.')) {
             return (0);
         }
     }
 
     return (1);
+}
+
+/* Validate the authentication hash portion of an agent key line. */
+static int OS_IsValidAgentKeyHash(const char *hash)
+{
+    size_t i;
+    size_t len;
+
+    if (!hash) {
+        return (0);
+    }
+
+    len = strlen(hash);
+    if (len != 64) {
+        return (0);
+    }
+
+    for (i = 0; i < len; i++) {
+        if (!isxdigit((int)hash[i])) {
+            return (0);
+        }
+    }
+
+    return (1);
+}
+
+/* Validate a full agent key line received from ossec-authd. */
+int OS_IsValidAgentKey(const char *key)
+{
+    char *copy = NULL;
+    char *name;
+    char *ip;
+    char *hash;
+    int rc = 0;
+
+    if (!key || !*key) {
+        return (0);
+    }
+
+    os_strdup(key, copy);
+    if (!copy) {
+        return (0);
+    }
+
+    name = strchr(copy, ' ');
+    if (!name) {
+        goto cleanup;
+    }
+    *name++ = '\0';
+    while (*name == ' ') {
+        name++;
+    }
+
+    ip = strchr(name, ' ');
+    if (!ip) {
+        goto cleanup;
+    }
+    *ip++ = '\0';
+    while (*ip == ' ') {
+        ip++;
+    }
+
+    hash = strchr(ip, ' ');
+    if (!hash) {
+        goto cleanup;
+    }
+    *hash++ = '\0';
+    while (*hash == ' ') {
+        hash++;
+    }
+
+    if (*hash == '\0' || strchr(hash, ' ') != NULL) {
+        goto cleanup;
+    }
+
+    if (!OS_IsValidID(copy) || !OS_IsValidName(name)) {
+        goto cleanup;
+    }
+
+    if (strcmp(ip, "any") != 0 && OS_IsValidIP(ip, NULL) != 1) {
+        goto cleanup;
+    }
+
+    if (!OS_IsValidAgentKeyHash(hash)) {
+        goto cleanup;
+    }
+
+    rc = 1;
+
+cleanup:
+    free(copy);
+    return (rc);
 }
 
 int NameExist(const char *u_name)

--- a/src/os_auth/main-client.c
+++ b/src/os_auth/main-client.c
@@ -346,6 +346,11 @@ int main(int argc, char **argv)
                     }
                     *tmpstr = '\0';
 
+                    if (!OS_IsValidAgentKey(key)) {
+                        printf("ERROR: Invalid key received (2). Closing connection.\n");
+                        exit(1);
+                    }
+
                     FILE *fp = fopen(KEYSFILE_PATH, "w");
                     if (!fp) {
                         printf("ERROR: Unable to open key file: %s", KEYSFILE_PATH);

--- a/src/win32/agent_auth.c
+++ b/src/win32/agent_auth.c
@@ -278,7 +278,6 @@ void InstallAuthKeys(char *msg)
     {
         char *key;
         char *tmpstr;
-        char **entry;
         FILE *fp;
 
         printf("INFO: Received response with agent key\n");
@@ -290,11 +289,9 @@ void InstallAuthKeys(char *msg)
             ErrorExit("%s: Invalid key received. Closing connection.", ARGV0);
 
         *tmpstr = '\0';
-        entry = OS_StrBreak(' ', key, 4);
-
-        if (!OS_IsValidID(entry[0]) || !OS_IsValidName(entry[1]) ||
-            !OS_IsValidName(entry[2]) || !OS_IsValidName(entry[3]))
+        if (!OS_IsValidAgentKey(key)) {
             ErrorExit("%s: Invalid key received (2). Closing connection.", ARGV0);
+        }
 
         fp = fopen(KEYSFILE_PATH, "w");
 


### PR DESCRIPTION
OS_IsValidName is for agent names only; IPv6 source-IP keys from ossec-authd -i must be checked with OS_IsValidIP. Restore agent-auth key validation on Linux and unify both clients on OS_IsValidAgentKey().

closes issue #1274