### PR TITLE
Restore rule.group in JSON alert output (#1838).

### DIFF
--- a/src/analysisd/format/json_extended.c
+++ b/src/analysisd/format/json_extended.c
@@ -151,6 +151,7 @@ void W_JSON_ParseGroups(cJSON* root, const Eventinfo* lf, int nested)
     else
         rule = cJSON_GetObjectItem(root, "rule");
 
+    cJSON_AddStringToObject(rule, "group", lf->generated_rule->group);
     cJSON_AddItemToObject(rule, "groups", groups = cJSON_CreateArray());
     strncpy(buffer, lf->generated_rule->group, sizeof(buffer) - 1);
 


### PR DESCRIPTION
W_JSON_ParseGroups() populates rule.groups and compliance arrays but stopped emitting the raw rule.group string after 487708e removed it from Eventinfo_to_jsonstr(). Add the field back in W_JSON_ParseGroups() so both Eventinfo and Archive JSON paths expose the original comma-separated group value alongside the parsed groups array.

Closes issue #1838