### PR TITLE
Indicate when report_changes diffs are truncated (#455).

### DIFF
--- a/src/agentlessd/agentlessd.c
+++ b/src/agentlessd/agentlessd.c
@@ -95,6 +95,7 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
     char *tmp_str;
     char buf[2048 + 1];
     char diff_alert[4096 + 1];
+    int truncated = 0;
 
     buf[2048] = '\0';
     diff_alert[4096] = '\0';
@@ -114,6 +115,7 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
         fclose(fp);
         return (0);
     } else if (n >= 2040) {
+        truncated = 1;
         /* We need to clear the last newline */
         buf[n] = '\0';
         tmp_str = strrchr(buf, '\n');
@@ -127,6 +129,10 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
         buf[n] = '\0';
     }
 
+    if (!feof(fp)) {
+        truncated = 1;
+    }
+
     n = 0;
 
     /* Get up to 8 line changes */
@@ -138,6 +144,7 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
             break;
         } else if (n >= 7) {
             *tmp_str = '\0';
+            truncated = 1;
             break;
         }
         n++;
@@ -146,8 +153,8 @@ static int gen_diff_alert(const char *host, const char *script, time_t alert_dif
 
     /* Create alert */
     snprintf(diff_alert, 4096 - 1, "ossec: agentless: Change detected:\n%s%s",
-             buf, n >= 7 ?
-             "\nMore changes.." :
+             buf, truncated ?
+             "\n... diff was truncated ..." :
              "");
 
     snprintf(buf, 1024, "(%s) %s->agentless", script, host);

--- a/src/syscheckd/seechanges.c
+++ b/src/syscheckd/seechanges.c
@@ -73,6 +73,7 @@ static char *gen_diff_alert(const char *filename, time_t alert_diff_time)
     char *tmp_str;
     char buf[OS_MAXSTR + 1];
     char diff_alert[OS_MAXSTR + 1];
+    int truncated = 0;
 
     buf[OS_MAXSTR] = '\0';
     diff_alert[OS_MAXSTR] = '\0';
@@ -92,6 +93,7 @@ static char *gen_diff_alert(const char *filename, time_t alert_diff_time)
         fclose(fp);
         return (NULL);
     } else if (n >= 4000) {
+        truncated = 1;
         /* Clear the last newline */
         buf[n] = '\0';
         tmp_str = strrchr(buf, '\n');
@@ -105,6 +107,10 @@ static char *gen_diff_alert(const char *filename, time_t alert_diff_time)
         buf[n] = '\0';
     }
 
+    if (!feof(fp)) {
+        truncated = 1;
+    }
+
     n = 0;
 
     /* Get up to 20 line changes */
@@ -116,6 +122,7 @@ static char *gen_diff_alert(const char *filename, time_t alert_diff_time)
             break;
         } else if (n >= 19) {
             *tmp_str = '\0';
+            truncated = 1;
             break;
         }
         n++;
@@ -124,8 +131,8 @@ static char *gen_diff_alert(const char *filename, time_t alert_diff_time)
 
     /* Create alert */
     snprintf(diff_alert, 4096 - 1, "%s%s",
-             buf, n >= 19 ?
-             "\nMore changes.." :
+             buf, truncated ?
+             "\n... diff was truncated ..." :
              "");
 
     fclose(fp);


### PR DESCRIPTION
When syscheck or agentless monitoring includes a diff in an alert, users had no reliable way to tell if more changes were omitted. Line- limited truncation only appended a vague "More changes.." suffix, and byte-limit truncation was not flagged at all.

Track truncation explicitly in gen_diff_alert() for both syscheckd and agentlessd, including when the diff file exceeds the read buffer, and append a clear "... diff was truncated ..." notice to the notification.

Closes Issue #455