### PR TITLE
Honor localfile command frequency after logcollector restart (#1415).

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -195,7 +195,7 @@ void LogCollectorStart()
             logff[i].file = NULL;
             logff[i].fp = NULL;
             logff[i].ptr = NULL;
-            logff[i].size = 0;
+            logff[i].size = (off_t)time(0);
 
             if (logff[i].command) {
                 logff[i].read = read_command;
@@ -213,7 +213,7 @@ void LogCollectorStart()
             logff[i].file = NULL;
             logff[i].fp = NULL;
             logff[i].ptr = NULL;
-            logff[i].size = 0;
+            logff[i].size = (off_t)time(0);
             if (logff[i].command) {
                 logff[i].read = read_fullcommand;
 


### PR DESCRIPTION
For command and full_command localfiles, logcollector stores the last run time in logff[i].size and compares it against the configured frequency (logff[i].ign). On startup that field was zero, so the interval check always passed and the command ran immediately on every restart.

Initialize size to the current time when registering command-based localfiles so the configured frequency is respected from the first daemon loop.

Closes issue #1415