### PR TITLE
Poll journald continuously instead of on command frequency (#2110).

### DIFF
--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -358,16 +358,21 @@ void LogCollectorStart()
         /* Check which file is available */
         for (i = 0; i <= max_file; i++) {
             if (!logff[i].fp) {
-                /* Run the command */
-                if (logff[i].read &&
-                    (logff[i].command || (logff[i].logformat && !strncmp(logff[i].logformat, "journald", 7))) &&
-                    (f_check % 2)) {
+                /* Run periodic commands on the configured frequency. */
+                if (logff[i].read && logff[i].command && (f_check % 2)) {
                     curr_time = time(0);
                     if ((curr_time - logff[i].size) >= logff[i].ign) {
                         logff[i].size = curr_time;
                         logff[i].read(i, &r, 0);
                     }
                 }
+#ifdef HAVE_SYSTEMD
+                /* Journald is polled every loop; it is not a file or command. */
+                else if (logff[i].read && logff[i].logformat &&
+                         strcmp(logff[i].logformat, "journald") == 0) {
+                    logff[i].read(i, &r, 0);
+                }
+#endif
                 continue;
             }
 
@@ -459,6 +464,14 @@ void LogCollectorStart()
             if (!logff[i].file) {
                 continue;
             }
+
+#ifdef HAVE_SYSTEMD
+            /* Journald locations are unit names, not filesystem paths. */
+            if (logff[i].logformat &&
+                strcmp(logff[i].logformat, "journald") == 0) {
+                continue;
+            }
+#endif
 
             /* Files with date -- check for day change */
             if (logff[i].ffile) {

--- a/src/logcollector/read_journald.c
+++ b/src/logcollector/read_journald.c
@@ -4,129 +4,149 @@
 #include <systemd/sd-journal.h>
 
 void *prime_sd_journal(int pos) {
-  int ret;
-  sd_journal *jrn;
-  ret = sd_journal_open(&jrn, SD_JOURNAL_LOCAL_ONLY);
-  if (ret < 0) {
-    merror("%s: ERROR: Unable to open journal", ARGV0);
-    return NULL;
-  }
-  // For future use
-  logff[pos].fd = sd_journal_get_fd(jrn);
-  if (ret < 0) {
-    merror("%s: ERROR: Unable to get journal fd", ARGV0);
-    return NULL;
-  }
-  ret = sd_journal_seek_tail(jrn);
-  if (ret < 0) {
-    merror("%s: ERROR: Unable to seek journal tail", ARGV0);
-    return NULL;
-  }
-  // prime sd_journal_next before the reader loop
-  ret = sd_journal_previous(jrn);
-  if (ret < 0) {
-    merror("%s: ERROR: Unable to seek journal previous", ARGV0);
-  }
-  return (void *)jrn;
+    int ret;
+    sd_journal *jrn;
+
+    int jfd;
+
+    ret = sd_journal_open(&jrn, SD_JOURNAL_LOCAL_ONLY);
+    if (ret < 0) {
+        merror("%s: ERROR: Unable to open journal", ARGV0);
+        return NULL;
+    }
+
+    jfd = sd_journal_get_fd(jrn);
+    if (jfd < 0) {
+        merror("%s: ERROR: Unable to get journal fd", ARGV0);
+        sd_journal_close(jrn);
+        logff[pos].fd = 0;
+        return NULL;
+    }
+    logff[pos].fd = jfd;
+
+    ret = sd_journal_seek_tail(jrn);
+    if (ret < 0) {
+        merror("%s: ERROR: Unable to seek journal tail", ARGV0);
+        sd_journal_close(jrn);
+        logff[pos].ptr = NULL;
+        logff[pos].fd = 0;
+        return NULL;
+    }
+
+    /* Prime sd_journal_next before the reader loop. */
+    ret = sd_journal_previous(jrn);
+    if (ret < 0) {
+        merror("%s: ERROR: Unable to seek journal previous", ARGV0);
+    }
+
+    return (void *)jrn;
 }
 
 void *sd_read_journal(int pos, int *rc, int drop_it) {
-  sd_journal *jrn = (sd_journal *) logff[pos].ptr;
-  char *unit = logff[pos].file;
-  int ret;
-  const char *jmsg = NULL, *jsrc = NULL, *jhst = NULL;
-  size_t len;
-  struct timeval tv;
-  uint64_t curr_timestamp;
-  time_t nowtime;
-  struct tm *nowtm;
-  char tmbuf[64], final_msg[OS_MAXSTR], sunitid[128];
-  *rc = 0;
+    sd_journal *jrn = (sd_journal *) logff[pos].ptr;
+    const char *unit = logff[pos].file;
+    int ret;
+    const char *jmsg = NULL;
+    const char *jsrc = NULL;
+    const char *jhst = NULL;
+    size_t len;
+    struct timeval tv;
+    uint64_t curr_timestamp;
+    time_t nowtime;
+    struct tm *nowtm;
+    char tmbuf[64];
+    char final_msg[OS_MAXSTR];
+    char sunitid[128];
 
-  if (jrn == NULL) {
-     jrn = logff[pos].ptr = prime_sd_journal(pos);
-     if (jrn == NULL) {
-        merror("%s: ERROR: Unable to prime journal", ARGV0);
-        return NULL;
-     }
-  }
+    (void)drop_it;
+    *rc = 0;
 
-  if (unit == NULL) {
-      unit = logff[pos].file = "all";
-  }
+    if (jrn == NULL) {
+        jrn = logff[pos].ptr = prime_sd_journal(pos);
+        if (jrn == NULL) {
+            *rc = -1;
+            return NULL;
+        }
+    }
 
-  // Anything negative is an error
-  while (ret > 0) {
-      ret = sd_journal_next(jrn);
-      // below 0 Means problem or journal file vanished. Open it again next time and
-      // try again
-      // 0 means there is no new messages
-      if (ret < 0) {
-         sd_journal_close(jrn);
-         logff[pos].ptr = NULL;
-         *rc = -1;
-         continue;
-      } else if (!ret) {
-         continue;
-      }
-      // Check if data is coming from the unit starting with our passed selector
-      ret = sd_journal_get_data(
-        jrn,
-        "SYSLOG_IDENTIFIER",
-        (const void **)&jsrc,
-        &len
-      );
-      // Strip off "SYSLOG_IDENTIFIER=" prefix for unit comparison inline
-      memset(sunitid, 0x00, 128);
-      strncpy(sunitid, (jsrc + 18), 128);
-      // If incoming systemd unit is unit or unit is 'all' which means log everything
-      // or unit starts which char '/' which means unit is directory and
-      // user have malconfigured journald
-      if (!strncmp(sunitid, unit, 128) || !strncmp(unit, "all", 3) || unit[0] == '/') {
-        // Read hostname
+    if (unit == NULL) {
+        unit = "all";
+    }
+
+    while ((ret = sd_journal_next(jrn)) > 0) {
+        ret = sd_journal_get_data(
+            jrn,
+            "SYSLOG_IDENTIFIER",
+            (const void **)&jsrc,
+            &len
+        );
+        if (ret < 0 || jsrc == NULL) {
+            continue;
+        }
+
+        /* Strip off "SYSLOG_IDENTIFIER=" prefix for unit comparison inline. */
+        memset(sunitid, 0x00, sizeof(sunitid));
+        strncpy(sunitid, (jsrc + 18), sizeof(sunitid) - 1);
+
+        if (strncmp(sunitid, unit, sizeof(sunitid)) != 0 &&
+                strncmp(unit, "all", 3) != 0 &&
+                unit[0] != '/') {
+            continue;
+        }
+
         ret = sd_journal_get_data(jrn, "_HOSTNAME", (const void **)&jhst, &len);
-        // Read data
+        if (ret < 0 || jhst == NULL) {
+            continue;
+        }
+
         ret = sd_journal_get_data(jrn, "MESSAGE", (const void **)&jmsg, &len);
-        // Read timestamp and format it
+        if (ret < 0 || jmsg == NULL || len <= 8) {
+            continue;
+        }
+
         ret = sd_journal_get_realtime_usec(jrn, &curr_timestamp);
+        if (ret < 0) {
+            continue;
+        }
+
         tv.tv_sec  = curr_timestamp / 1000000;
         tv.tv_usec = curr_timestamp % 1000000;
         nowtime = tv.tv_sec;
         nowtm = localtime(&nowtime);
-        // We have to mimic syslog-ng for time and date for OSSEC-HIDS
-        // time and date parser.
-        // Syslog-ng It produces broken ISO8601 strings like
-        // 2020-04-01T12:00:00+03:00
-        // Journald reader triest to mimics it.
-        strftime(tmbuf, sizeof tmbuf, "%Y-%m-%dT%T%z", nowtm);
-        tmbuf[strlen(tmbuf) - 2] = '\0';
-        // Build and send message
+        if (nowtm == NULL) {
+            continue;
+        }
+
+        /* Mimic syslog-ng ISO8601 timestamps for analysisd parsing. */
+        strftime(tmbuf, sizeof(tmbuf), "%Y-%m-%dT%T%z", nowtm);
+        if (strlen(tmbuf) >= 2) {
+            tmbuf[strlen(tmbuf) - 2] = '\0';
+        }
+
         snprintf(
-          final_msg,
-          sizeof(final_msg),
-          "%s:00 %s %s: %.*s\n",
-          tmbuf,
-          // Strip the "_HOSTNAME", "SYSLOG_IDENTIFIER=" and "MESSAGE=" prefixes
-          (char *)(jhst + 10),
-          sunitid,
-          (int) len,
-          (char *)(jmsg + 8)
+            final_msg,
+            sizeof(final_msg),
+            "%s:00 %s %s: %.*s\n",
+            tmbuf,
+            (char *)(jhst + 10),
+            sunitid,
+            (int)(len - 8),
+            (char *)(jmsg + 8)
         );
+
         if (SendMSG(logr_queue, final_msg, "journald", LOCALFILE_MQ) < 0) {
             merror(QUEUE_SEND, ARGV0);
         }
-        // These pointers are only valid until next one
-        // So it's safe to just to NULL them
-        jhst = NULL;
-        jmsg = NULL;
     }
-    // This pointer is only valid until next one
-    // So it's safe to just to NULL them
-    jsrc = NULL;
-    // Prime next iteration condition & journal position
-    ret = sd_journal_next(jrn);
-  }
-  return NULL;
+
+    if (ret < 0) {
+        sd_journal_close(jrn);
+        logff[pos].ptr = NULL;
+        logff[pos].fd = 0;
+        *rc = -1;
+    }
+
+    return NULL;
 }
 
 #endif //HAVE_SYSTEMD


### PR DESCRIPTION
Journald localfiles were handled like command sources: reads ran only when the configured frequency elapsed and f_check was even, producing ~1000 second bursts of delayed alerts. Journal locations such as "all" were also checked as filesystem paths, triggering "File not available, ignoring it" messages.

Poll journald every logcollector loop iteration, skip journald entries in the file maintenance path, and fix sd_read_journal() to validate sd_journal_get_fd(), read entries once per next call, and handle journal errors cleanly.

closes issue #2110