### PR TITLE
Update stale IIS and Windows doc URLs in setup helpers (#1975).

### DIFF
--- a/contrib/iis-logs.bat
+++ b/contrib/iis-logs.bat
@@ -8,7 +8,7 @@ rem Example of log to look: nc060215.log or ex060723.log
 echo.
 echo Looking for IIS log files to monitor.
 echo For more information visit:
-echo http://www.ossec.net/en/manual.html#iis
+echo https://www.ossec.net/docs/docs/manual/monitoring/file-log-monitoring.html#iis-logs-example
 echo.
 echo.
 

--- a/src/win32/setup-iis.c
+++ b/src/win32/setup-iis.c
@@ -107,7 +107,7 @@ int config_dir(char *name, char *dir, char *vfile)
     printf("%s: You may have it configured in a format different\n"
            "               than W3C Extended or you just don't have today's\n"
            "               log available.\n", name);
-    printf("%s: http://www.ossec.net/en/manual.html#iis\n\n", name);
+    printf("%s: https://www.ossec.net/docs/docs/manual/monitoring/file-log-monitoring.html#iis-logs-example\n\n", name);
 
     /* Add IIS config */
     fp = fopen(OSSECCONF, "a");
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
 
     printf("%s: Looking for IIS log files to monitor.\r\n",
            argv[0]);
-    printf("%s: For more information: http://www.ossec.net/en/win.html\r\n",
+    printf("%s: For more information: https://www.ossec.net/docs/docs/manual/installation/installation-windows.html\r\n",
            argv[0]);
     printf("\r\n");
 


### PR DESCRIPTION
Replace dead ossec.net/en/manual.html#iis and ossec.net/en/win.html links in contrib/iis-logs.bat and src/win32/setup-iis.c with current Sphinx documentation URLs so Windows IIS setup tools point users to the right pages.

closes issue #1975