### PR TITLE
Fix false CIS apt sources alert on Ubuntu 24.04.

### DIFF
--- a/src/rootcheck/db/cis_debian_linux_rcl.txt
+++ b/src/rootcheck/db/cis_debian_linux_rcl.txt
@@ -79,8 +79,7 @@ f:/etc/ssh/sshd_config -> !r:^# && r:PermitRootLogin\.+yes;
 
 # Section 2.6 Ensure sources.list Sanity
 [CIS - Debian Linux - 2.6 - Sources list sanity - Security updates not enabled {CIS: 2.6 Debian Linux} {PCI_DSS: 6.2}] [any] [https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf]
-f:!/etc/apt/sources.list;
-f:!/etc/apt/sources.list -> !r:^# && r:http://security.debian|http://security.ubuntu;
+f:!/etc/apt/sources.list,/etc/apt/sources.list.d/ubuntu.sources -> !r:^# && r:http://security.debian|http://security.ubuntu;
 
 
 # Section 3 - Minimize inetd services


### PR DESCRIPTION
Ubuntu 24.04 moved repository configuration to
/etc/apt/sources.list.d/ubuntu.sources (DEB822 format), leaving sources.list empty. Extend the CIS 2.6 rootcheck to accept security repos from either file.

Closes #2140.

Assisted-By: Fable 5