### PR TITLE
Fix false dpkg install alert when removing packages.

### DIFF
--- a/etc/rules/syslog_rules.xml
+++ b/etc/rules/syslog_rules.xml
@@ -605,7 +605,7 @@
 
  <rule id="2902" level="7">
     <if_sid>2900</if_sid>
-    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} status installed</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (install|upgrade|configure)</pcre2>
     <description>New dpkg (Debian Package) installed.</description>
     <group>config_changed,</group>
   </rule>


### PR DESCRIPTION
Rule 2902 matched any "status installed" line in /var/log/dpkg.log. During apt remove, dpkg logs the pre-removal state that way, so uninstalls incorrectly triggered "New dpkg (Debian Package) installed" before the expected remove/purge alerts.

Match install, upgrade, and configure action lines instead of status snapshots. Rule 2903 (remove/purge) is unchanged.

Closes #2141.

Assisted-By: Fable 5