### PR TITLE
rootcheck: append MD5/SHA1/SHA256 hashes of detected files to alerts

### DIFF
--- a/src/analysisd/decoders/rootcheck.c
+++ b/src/analysisd/decoders/rootcheck.c
@@ -112,6 +112,52 @@ static FILE *RK_File(const char *agent, int *agent_id)
     return (NULL);
 }
 
+/* Parse MD5/SHA1/SHA256 values appended by rk_append_file_hash into lf.
+ * Also extracts the detected file path into lf->filename.
+ * All rootcheck alert messages share the pattern: file 'PATH'
+ */
+static void rk_extract_hashes(Eventinfo *lf)
+{
+    const char *p;
+    char val[65];
+
+    /* Extract file path from message (pattern: file 'PATH') */
+    p = strstr(lf->log, " file '");
+    if (p) {
+        const char *start = p + 7;
+        const char *end = strchr(start, '\'');
+        if (end && end > start) {
+            size_t len = (size_t)(end - start);
+            lf->filename = (char *)malloc(len + 1);
+            if (lf->filename) {
+                memcpy(lf->filename, start, len);
+                lf->filename[len] = '\0';
+            }
+        }
+    }
+
+    p = strstr(lf->log, " MD5=");
+    if (p && sscanf(p + 5, "%64s", val) == 1 && strcmp(val, "n/a") != 0 && strlen(val) == 32) {
+        free(lf->md5_after);
+        lf->md5_after = NULL;
+        os_strdup(val, lf->md5_after);
+    }
+
+    p = strstr(lf->log, " SHA1=");
+    if (p && sscanf(p + 6, "%64s", val) == 1 && strcmp(val, "n/a") != 0 && strlen(val) == 40) {
+        free(lf->sha1_after);
+        lf->sha1_after = NULL;
+        os_strdup(val, lf->sha1_after);
+    }
+
+    p = strstr(lf->log, " SHA256=");
+    if (p && sscanf(p + 8, "%64s", val) == 1 && strcmp(val, "n/a") != 0 && strlen(val) == 64) {
+        free(lf->sha256_after);
+        lf->sha256_after = NULL;
+        os_strdup(val, lf->sha256_after);
+    }
+}
+
 /* Special decoder for rootcheck
  * Not using the default rendering tools for simplicity
  * and to be less resource intensive
@@ -121,7 +167,7 @@ int DecodeRootcheck(Eventinfo *lf)
     int agent_id;
 
     char *tmpstr;
-    char rk_buf[OS_SIZE_2048 + 1];
+    char rk_buf[OS_SIZE_4096 + 1];
 
     FILE *fp;
 
@@ -129,7 +175,7 @@ int DecodeRootcheck(Eventinfo *lf)
 
     /* Zero rk_buf */
     rk_buf[0] = '\0';
-    rk_buf[OS_SIZE_2048] = '\0';
+    rk_buf[OS_SIZE_4096] = '\0';
 
     fp = RK_File(lf->location, &agent_id);
 
@@ -148,7 +194,7 @@ int DecodeRootcheck(Eventinfo *lf)
 
 
     /* Reads the file and search for a possible entry */
-    while (fgets(rk_buf, OS_SIZE_2048 - 1, fp) != NULL) {
+    while (fgets(rk_buf, OS_SIZE_4096 - 1, fp) != NULL) {
         /* Ignore blank lines and lines with a comment */
         if (rk_buf[0] == '\n' || rk_buf[0] == '#') {
             if (fgetpos(fp, &fp_pos) == -1) {
@@ -171,6 +217,7 @@ int DecodeRootcheck(Eventinfo *lf)
             if (strcmp(lf->log, rk_buf) == 0) {
                 rootcheck_dec->fts = 0;
                 lf->decoder_info = rootcheck_dec;
+                rk_extract_hashes(lf);
                 return (1);
             }
         }
@@ -189,6 +236,7 @@ int DecodeRootcheck(Eventinfo *lf)
                 fprintf(fp, "!%ld", (long int)lf->time);
                 rootcheck_dec->fts = 0;
                 lf->decoder_info = rootcheck_dec;
+                rk_extract_hashes(lf);
                 return (1);
             }
         }
@@ -208,6 +256,7 @@ int DecodeRootcheck(Eventinfo *lf)
     rootcheck_dec->fts = 0;
     rootcheck_dec->fts |= FTS_DONE;
     lf->decoder_info = rootcheck_dec;
+    rk_extract_hashes(lf);
     return (1);
 }
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -554,6 +554,8 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->md5_after = NULL;
     lf->sha1_before = NULL;
     lf->sha1_after = NULL;
+    lf->sha256_before = NULL;
+    lf->sha256_after = NULL;
     lf->size_before = NULL;
     lf->size_after = NULL;
     lf->owner_before = NULL;
@@ -657,6 +659,12 @@ void Free_Eventinfo(Eventinfo *lf)
     }
     if (lf->sha1_after) {
         free(lf->sha1_after);
+    }
+    if (lf->sha256_before) {
+        free(lf->sha256_before);
+    }
+    if (lf->sha256_after) {
+        free(lf->sha256_after);
     }
     if (lf->size_before) {
         free(lf->size_before);

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -134,13 +134,19 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
         if (lf->md5_before && lf->md5_after && strcmp(lf->md5_before, lf->md5_after) != 0  ) {
             cJSON_AddStringToObject(file_diff, "md5_before", lf->md5_before);
             cJSON_AddStringToObject(file_diff, "md5_after", lf->md5_after);
+        } else if (!lf->md5_before && lf->md5_after) {
+            cJSON_AddStringToObject(file_diff, "md5_after", lf->md5_after);
         }
         if(lf->sha1_before && lf->sha1_after && strcmp(lf->sha1_before, lf->sha1_after) != 0) {
             cJSON_AddStringToObject(file_diff, "sha1_before", lf->sha1_before);
             cJSON_AddStringToObject(file_diff, "sha1_after", lf->sha1_after);
+        } else if (!lf->sha1_before && lf->sha1_after) {
+            cJSON_AddStringToObject(file_diff, "sha1_after", lf->sha1_after);
         }
         if(lf->sha256_before && lf->sha256_after && strcmp(lf->sha256_before, lf->sha256_after) != 0) {
             cJSON_AddStringToObject(file_diff, "sha256_before", lf->sha256_before);
+            cJSON_AddStringToObject(file_diff, "sha256_after", lf->sha256_after);
+        } else if (!lf->sha256_before && lf->sha256_after) {
             cJSON_AddStringToObject(file_diff, "sha256_after", lf->sha256_after);
         }
         if(lf->owner_before && lf->owner_after && strcmp(lf->owner_before, lf->owner_after) != 0) {

--- a/src/rootcheck/check_rc_files.c
+++ b/src/rootcheck/check_rc_files.c
@@ -162,11 +162,13 @@ void check_rc_files(const char *basedir, FILE *fp)
         snprintf(file_path, OS_SIZE_1024, "%s/%s", basedir, file);
 
         if (is_file(file_path)) {
-            char op_msg[OS_SIZE_1024 + 1];
+            char op_msg[OS_SIZE_2048 + 1];
 
             _errors = 1;
-            snprintf(op_msg, OS_SIZE_1024, "Rootkit '%s' detected "
+            snprintf(op_msg, OS_SIZE_2048, "Rootkit '%s' detected "
                      "by the presence of file '%s'.", name, file_path);
+            
+            rk_append_file_hash(file_path, op_msg, sizeof(op_msg));
 
             notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
         }

--- a/src/rootcheck/check_rc_sys.c
+++ b/src/rootcheck/check_rc_sys.c
@@ -88,11 +88,12 @@ static int read_sys_file(const char *file_name, int do_read)
                 if ((lstat(file_name, &statbuf2) == 0) &&
                         (total != statbuf2.st_size) &&
                         (statbuf.st_size == statbuf2.st_size)) {
-                    char op_msg[OS_SIZE_1024 + 1];
-                    snprintf(op_msg, OS_SIZE_1024, "Anomaly detected in file "
+                    char op_msg[OS_SIZE_2048 + 1];
+                    snprintf(op_msg, OS_SIZE_2048, "Anomaly detected in file "
                              "'%s'. File size doesn't match what we found. "
                              "Possible kernel level rootkit.",
                              file_name);
+                    rk_append_file_hash(file_name, op_msg, sizeof(op_msg));
                     notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
                     _sys_errors++;
                 }
@@ -275,13 +276,13 @@ static int read_sys_dir(const char *dir_name, int do_read)
             }
 
             if (strcmp(rk_sys_file[i], entry->d_name) == 0) {
-                char op_msg[OS_SIZE_1024 + 1];
+                char op_msg[OS_SIZE_2048 + 1];
 
                 _sys_errors++;
-                snprintf(op_msg, OS_SIZE_1024, "Rootkit '%s' detected "
-                         "by the presence of file '%s/%s'.",
-                         rk_sys_name[i], dir_name, rk_sys_file[i]);
-
+                snprintf(op_msg, OS_SIZE_2048, "Rootkit '%s' detected "
+                         "by the presence of file '%s'.",
+                         rk_sys_name[i], f_name);
+                rk_append_file_hash(f_name, op_msg, sizeof(op_msg));
                 notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
             }
         }

--- a/src/rootcheck/check_rc_trojans.c
+++ b/src/rootcheck/check_rc_trojans.c
@@ -88,16 +88,17 @@ void check_rc_trojans(const char *basedir, FILE *fp)
 
             /* Check if entry is found */
             if (is_file(file_path) && os_string(file_path, string_to_look)) {
-                char op_msg[OS_SIZE_1024 + 1];
+                char op_msg[OS_SIZE_2048 + 1];
                 _errors = 1;
 
-                snprintf(op_msg, OS_SIZE_1024, "Trojaned version of file "
+                snprintf(op_msg, OS_SIZE_2048, "Trojaned version of file "
                          "'%s' detected. Signature used: '%s' (%s).",
                          file_path,
                          string_to_look,
                          *message == '\0' ?
                          "Generic" : message);
 
+                rk_append_file_hash(file_path, op_msg, sizeof(op_msg));
                 notify_rk(ALERT_ROOTKIT_FOUND, op_msg);
             }
 

--- a/src/rootcheck/common.c
+++ b/src/rootcheck/common.c
@@ -10,6 +10,8 @@
 #include "shared.h"
 #include "rootcheck.h"
 #include "os_regex/os_regex.h"
+#include "os_crypto/md5_sha1/md5_sha1_op.h"
+#include "os_crypto/sha256/sha256_op.h"
 
 /* Prototypes */
 static int _is_str_in_array(char *const *ar, const char *str);
@@ -238,6 +240,39 @@ int rk_check_file(char *file, char *pattern)
     } while (split_file);
 
     return (0);
+}
+
+/* Calculate file hash md5, sha1, sha256*/
+void rk_append_file_hash(const char *file_path, char *dest, size_t dest_size)
+{
+    os_md5 md5;
+    os_sha1 sha1;
+    os_sha256 sha256;
+
+    struct stat statbuf;
+    size_t used;
+
+    /* strnlen scans at most dest_size bytes; if it returns dest_size there
+     * is no NUL terminator within the buffer (or the buffer is already full),
+     * so there is nowhere safe to append. */
+    used = strnlen(dest, dest_size);
+    if (used >= dest_size) {
+        return;
+    }
+
+    if (stat(file_path, &statbuf) == 0 && S_ISREG(statbuf.st_mode)) {
+        int md5sha1_ok = (OS_MD5_SHA1_File(file_path, NULL, md5, sha1, OS_BINARY) == 0);
+        int sha256_ok  = (OS_SHA256_File(file_path, sha256, OS_BINARY) == 0);
+
+        snprintf(dest + used, dest_size - used,
+                 " MD5=%s SHA1=%s SHA256=%s",
+                 md5sha1_ok ? md5    : "n/a",
+                 md5sha1_ok ? sha1   : "n/a",
+                 sha256_ok  ? sha256 : "n/a");
+    } else {
+        snprintf(dest + used, dest_size - used,
+                 " MD5=n/a SHA1=n/a SHA256=n/a");
+    }
 }
 
 /* Check if the pattern is all negate values */
@@ -636,4 +671,5 @@ int is_process(char *value, OSList *p_list)
 
     return (0);
 }
+
 

--- a/src/rootcheck/rootcheck.h
+++ b/src/rootcheck/rootcheck.h
@@ -79,6 +79,9 @@ int is_process(char *value, OSList *p_list);
 /*  Delete the process list */
 int del_plist(OSList *p_list);
 
+/* Append MD5/SHA1/SHA256 hashes of file_path to dest */
+void rk_append_file_hash(const char *file_path, char *dest, size_t dest_size);
+
 /* Used to report messages */
 int notify_rk(int rk_type, const char *msg);
 


### PR DESCRIPTION
Detected files in check_rc_files, check_rc_trojans and check_rc_sys now have their hashes computed and appended to the alert message. DecodeRootcheck extracts them into Eventinfo for structured JSON output.

This PR adds hash support mentioned in #2208 
As hashing does not add much overhead especially when only triggered after a rootkit detection, I did not implement a config switch.

Please let me know what you think.