### PR TITLE
Analysisd Threading enhancement

### DIFF
--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -28,6 +28,41 @@ analysisd.fts_min_size_for_str=14
 analysisd.log_fw=1
 # Maximum number of fields in a decoder (order tag)
 analysisd.decoder_order_size=256
+# Max retained events per if_matched_sid correlation list
+analysisd.sid_prev_matched_max=128
+
+# Multi-threaded analysisd pipeline (Linux, always on). Thread knobs: 0 = auto
+# (min of online CPUs and 32). Queue sizes clamp to 128..2000000.
+analysisd.event_threads=0
+analysisd.rule_matching_threads=0
+analysisd.syscheck_threads=0
+analysisd.rootcheck_threads=0
+analysisd.hostinfo_threads=0
+# Input demux workers after the single Unix MQ recv (1..8)
+analysisd.input_demux_threads=2
+analysisd.decode_event_queue_size=16384
+# Front-door raw input backlog (recv → demux)
+analysisd.raw_input_queue_size=16384
+analysisd.decode_syscheck_queue_size=16384
+analysisd.decode_rootcheck_queue_size=16384
+analysisd.decode_hostinfo_queue_size=16384
+analysisd.decode_output_queue_size=16384
+analysisd.alerts_queue_size=16384
+# Dedicated Check_Hour / statistical alert writer backlog
+analysisd.statistical_queue_size=16384
+analysisd.archives_queue_size=16384
+analysisd.firewall_queue_size=16384
+# Async FTS disk persist (first-time-seen) writer backlog
+analysisd.fts_queue_size=16384
+# Mid-pipe push wait before drop (ms). 0 = immediate push/drop (no soak).
+# Clamped 0..5000. Raw defaults slightly lower than demux to shed at the front last.
+# Ops under pressure: raise queue sizes / *_push_wait_ms or lower EPS before accepting drops.
+analysisd.raw_input_push_wait_ms=25
+analysisd.demux_push_wait_ms=50
+analysisd.shard_push_wait_ms=75
+analysisd.alerts_push_wait_ms=100
+# Pipeline metrics file interval in seconds (OS_PIDFILE/ossec-analysisd.state). 0 disables.
+analysisd.state_interval=5
 
 
 # Output GeoIP data at JSON alerts

--- a/etc/rules/msauth_rules.xml
+++ b/etc/rules/msauth_rules.xml
@@ -531,7 +531,7 @@
 
   <rule id="18222" level="12">
     <if_sid>18203,18204</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21\S+-512\}| ID:[ ]+S-1-5-21\S+-512(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21\S+-512\}| ID:[ ]+S-1-5-21\S+-512(?:\D|\z)</pcre2>
     <description>Domain Admins Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -539,7 +539,7 @@
 
   <rule id="18223" level="5">
     <if_sid>18203,18204</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21\S+-513\}| ID:[ ]+S-1-5-21\S+-513(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21\S+-513\}| ID:[ ]+S-1-5-21\S+-513(?:\D|\z)</pcre2>
     <description>Domain Users Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -554,7 +554,7 @@
 
   <rule id="18225" level="12">
     <if_sid>18203,18204</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21\S+-514\}| ID:[ ]+S-1-5-21\S+-514(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21\S+-514\}| ID:[ ]+S-1-5-21\S+-514(?:\D|\z)</pcre2>
     <description>Domain Guests Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -562,7 +562,7 @@
 
   <rule id="18226" level="5">
     <if_sid>18203,18204</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21\S+-515\}| ID:[ ]+S-1-5-21\S+-515(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21\S+-515\}| ID:[ ]+S-1-5-21\S+-515(?:\D|\z)</pcre2>
     <description>Domain Computers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -570,7 +570,7 @@
 
   <rule id="18227" level="12">
     <if_sid>18203,18204</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21\S+-516\}| ID:[ ]+S-1-5-21\S+-516(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21\S+-516\}| ID:[ ]+S-1-5-21\S+-516(?:\D|\z)</pcre2>
     <description>Domain Controllers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -578,7 +578,7 @@
 
   <rule id="18228" level="10">
     <if_sid>18207,18208</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21\S+-517\}| ID:[ ]+S-1-5-21\S+-517(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21\S+-517\}| ID:[ ]+S-1-5-21\S+-517(?:\D|\z)</pcre2>
     <description>Cert Publishers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -586,7 +586,7 @@
 
   <rule id="18229" level="12">
     <if_sid>18213,18214,18215</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21.+-518\}| ID:[ ]+S-1-5-21.+-518(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21.+-518\}| ID:[ ]+S-1-5-21.+-518(?:\D|\z)</pcre2>
     <description>Schema Admins Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -594,7 +594,7 @@
 
   <rule id="18230" level="12">
     <if_sid>18213,18214,18215</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21\S+-519\}| ID:[ ]+S-1-5-21\S+-519(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21\S+-519\}| ID:[ ]+S-1-5-21\S+-519(?:\D|\z)</pcre2>
     <description>Enterprise Admins Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -602,7 +602,7 @@
 
   <rule id="18231" level="10">
     <if_sid>18213,18214,18215</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21\S+-520\}| ID:[ ]+S-1-5-21\S+-520(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21\S+-520\}| ID:[ ]+S-1-5-21\S+-520(?:\D|\z)</pcre2>
     <description>Group Policy Creator Owners Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>
@@ -610,7 +610,7 @@
 
   <rule id="18232" level="10">
     <if_sid>18207,18208</if_sid>
-    <pcre2> ID:[ ]+%\{S-1-5-21\S+-553\}| ID:[ ]+S-1-5-21\S+-553(\D|$)</pcre2>
+    <pcre2> ID:[ ]+%\{S-1-5-21\S+-553\}| ID:[ ]+S-1-5-21\S+-553(?:\D|\z)</pcre2>
     <description>RAS and IAS Servers Group Changed</description>
     <group>group_changed,win_group_changed,</group>
     <info>http://support.microsoft.com/kb/243330</info>

--- a/etc/rules/syslog_rules.xml
+++ b/etc/rules/syslog_rules.xml
@@ -605,7 +605,7 @@
 
  <rule id="2902" level="7">
     <if_sid>2900</if_sid>
-    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} (install|upgrade|configure)</pcre2>
+    <pcre2>^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} status installed</pcre2>
     <description>New dpkg (Debian Package) installed.</description>
     <group>config_changed,</group>
   </rule>

--- a/src/Makefile
+++ b/src/Makefile
@@ -1358,6 +1358,22 @@ test_coverage: build_tests
 	genhtml --branch-coverage --output-directory coverage-report/ --title "ossec test coverage" --show-details --legend --num-spaces 4 --quiet ossec.test
 
 ####################
+#### regression ####
+####################
+
+# Pipeline / analysisd regressions + shared queue/thread tests.
+# Requires a prior server (or hybrid) build so *-live.o and libs exist.
+.PHONY: regression regression-clean
+
+regression:
+	${MAKE} -C shared/tests check
+	${MAKE} -f tests/regressions/Makefile check
+
+regression-clean:
+	${MAKE} -C shared/tests clean
+	${MAKE} -f tests/regressions/Makefile clean
+
+####################
 #### RUule Tests ###
 ####################
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1280,7 +1280,12 @@ ossec-logtest: ${analysisd_test_o} ${output_o} ${format_o} analysisd/testrule-te
 ossec-analysisd: ${analysisd_live_o} analysisd/analysisd-live.o ${output_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS}  $^ ${OSSEC_LDFLAGS} ${ANALYSISD_FLAGS} -o $@
 
-ossec-makelists: analysisd/makelists-live.o ${analysisd_live_o} ${format_o} alerts.a cdb.a decoders-live.a ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
+# makelists only rebuilds CDB lists; do not pull in the threaded pipeline
+# (pipeline/stages/state/fts/...) which references analysisd.c-only symbols.
+makelists_live_o := analysisd/config-live.o analysisd/lists-live.o \
+	analysisd/lists_list-live.o analysisd/lists_make-live.o
+
+ossec-makelists: analysisd/makelists-live.o ${makelists_live_o} cdb.a ${ossec_libs} ${ZLIB_LIB} ${JSON_LIB}
 	${OSSEC_CCBIN} ${OSSEC_CFLAGS}  $^ ${OSSEC_LDFLAGS} -o $@
 
 

--- a/src/analysisd/accumulator.c
+++ b/src/analysisd/accumulator.c
@@ -7,7 +7,14 @@
  * Foundation.
  */
 
-/* Accumulator Functions which accumulate objects based on an ID */
+/* Accumulator Functions which accumulate objects based on an ID.
+ *
+ * Pipeline process workers bind a private OSHash via analysisd_set_acm_store()
+ * (TLS), so Accumulate runs lock-free per shard. Cross-shard accumulation for
+ * the same hostname+decoder+id key is intentional non-sharing (rare). The
+ * global store + accumulate_mutex remain for Accumulate_Init / serial paths
+ * (testrule, non-pipeline) when TLS is unset.
+ */
 
 #include <sys/time.h>
 
@@ -15,12 +22,16 @@
 #include "accumulator.h"
 #include "eventinfo.h"
 
-/* Local variables */
+/* Global fallback store (serial / testrule). */
 static OSHash *acm_store = NULL;
-
-/* Counters for Purging */
-static int    acm_lookups = 0;
+static pthread_mutex_t accumulate_mutex = PTHREAD_MUTEX_INITIALIZER;
+static int acm_lookups = 0;
 static time_t acm_purge_ts = 0;
+
+/* Per-process-thread shard store (pipeline). */
+static __thread OSHash *tls_acm_store = NULL;
+static __thread int tls_acm_lookups = 0;
+static __thread time_t tls_acm_purge_ts = 0;
 
 /* Accumulator Constants */
 #define OS_ACM_EXPIRE_ELM      120
@@ -46,24 +57,73 @@ typedef struct _OS_ACM_Store {
 static int acm_str_replace(char **dst, const char *src);
 static OS_ACM_Store *InitACMStore(void);
 static void FreeACMStore(OS_ACM_Store *obj);
+static void Accumulate_CleanUp_Store(OSHash *store, int *lookups, time_t *purge_ts);
 
-/* Start the Accumulator module */
+void analysisd_set_acm_store(OSHash *store)
+{
+    tls_acm_store = store;
+    tls_acm_lookups = 0;
+    tls_acm_purge_ts = 0;
+}
+
+OSHash *analysisd_get_acm_store(void)
+{
+    return tls_acm_store ? tls_acm_store : acm_store;
+}
+
+OSHash *Accumulate_CreateStore(void)
+{
+    OSHash *store;
+
+    store = OSHash_Create();
+    if (!store) {
+        merror(LIST_ERROR, ARGV0);
+        return NULL;
+    }
+    if (!OSHash_setSize(store, 2048)) {
+        merror(LIST_ERROR, ARGV0);
+        OSHash_Free(store);
+        return NULL;
+    }
+    return store;
+}
+
+void Accumulate_DestroyStore(OSHash *store)
+{
+    unsigned int ti;
+    OSHashNode *curr;
+    OSHashNode *next;
+    OS_ACM_Store *stored_data;
+
+    if (!store) {
+        return;
+    }
+
+    /* Free payload before OSHash_Free (which frees keys/nodes only). */
+    for (ti = 0; ti <= store->rows; ti++) {
+        curr = store->table[ti];
+        while (curr != NULL) {
+            next = curr->next;
+            stored_data = (OS_ACM_Store *)curr->data;
+            FreeACMStore(stored_data);
+            curr->data = NULL;
+            curr = next;
+        }
+    }
+
+    OSHash_Free(store);
+}
+
+/* Start the Accumulator module (global fallback for serial paths). */
 int Accumulate_Init()
 {
     struct timeval tp;
 
-    /* Create store data */
-    acm_store = OSHash_Create();
+    acm_store = Accumulate_CreateStore();
     if (!acm_store) {
-        merror(LIST_ERROR, ARGV0);
-        return (0);
-    }
-    if (!OSHash_setSize(acm_store, 2048)) {
-        merror(LIST_ERROR, ARGV0);
         return (0);
     }
 
-    /* Default Expiry */
     gettimeofday(&tp, NULL);
     acm_purge_ts = tp.tv_sec;
 
@@ -76,61 +136,82 @@ Eventinfo *Accumulate(Eventinfo *lf)
 {
     int result;
     int do_update = 0;
+    int locked = 0;
 
     char _key[OS_ACM_MAXKEY];
     OS_ACM_Store *stored_data = 0;
+    OSHash *store;
+    int *lookups;
+    time_t *purge_ts;
 
-    time_t  current_ts;
+    time_t current_ts;
     struct timeval tp;
 
-    if ( lf == NULL ) {
+    if (lf == NULL) {
         debug1("accumulator: DEBUG: Received NULL EventInfo");
         return lf;
     }
-    if ( lf->id == NULL ) {
+    if (lf->id == NULL) {
         debug2("accumulator: DEBUG: No id available");
         return lf;
     }
-    if ( lf->decoder_info == NULL ) {
+    if (lf->decoder_info == NULL) {
         debug1("accumulator: DEBUG: No decoder_info available");
         return lf;
     }
-    if ( lf->decoder_info->name == NULL ) {
-        debug1("accumulator: DEBUG: No decoder name available");
+    if (lf->decoder_info->name == NULL) {
+        debug1("%s: DEBUG: No decoder name available", ARGV0);
         return lf;
     }
 
-    /* Purge the cache as needed */
-    Accumulate_CleanUp();
+    if (tls_acm_store) {
+        store = tls_acm_store;
+        lookups = &tls_acm_lookups;
+        purge_ts = &tls_acm_purge_ts;
+    } else {
+        store = acm_store;
+        lookups = &acm_lookups;
+        purge_ts = &acm_purge_ts;
+        os_mutex_lock(&accumulate_mutex);
+        locked = 1;
+    }
+
+    if (!store) {
+        if (locked) {
+            os_mutex_unlock(&accumulate_mutex);
+        }
+        return lf;
+    }
+
+    Accumulate_CleanUp_Store(store, lookups, purge_ts);
 
     gettimeofday(&tp, NULL);
     current_ts = tp.tv_sec;
 
-    /* Accumulator Key */
     result = snprintf(_key, OS_FLSIZE, "%s %s %s",
                       lf->hostname,
                       lf->decoder_info->name,
                       lf->id
                      );
-    if ( result < 0 || (unsigned) result >= sizeof(_key) ) {
-        debug1("accumulator: DEBUG: error setting accumulator key, id:%s,name:%s", lf->id, lf->decoder_info->name);
+    if (result < 0 || (unsigned)result >= sizeof(_key)) {
+        debug1("accumulator: DEBUG: error setting accumulator key, id:%s,name:%s",
+               lf->id, lf->decoder_info->name);
+        if (locked) {
+            os_mutex_unlock(&accumulate_mutex);
+        }
         return lf;
     }
 
-    /* Check if acm is already present */
-    if ((stored_data = (OS_ACM_Store *)OSHash_Get(acm_store, _key)) != NULL) {
+    if ((stored_data = (OS_ACM_Store *)OSHash_Get(store, _key)) != NULL) {
         debug2("accumulator: DEBUG: Lookup for '%s' found a stored value!", _key);
 
-        if ( stored_data->timestamp > 0 && stored_data->timestamp < current_ts - OS_ACM_EXPIRE_ELM ) {
-            if ( OSHash_Delete(acm_store, _key) != NULL ) {
+        if (stored_data->timestamp > 0 && stored_data->timestamp < current_ts - OS_ACM_EXPIRE_ELM) {
+            if (OSHash_Delete(store, _key) != NULL) {
                 debug1("accumulator: DEBUG: Deleted expired hash entry for '%s'", _key);
-                /* Clear this memory */
                 FreeACMStore(stored_data);
-                /* Reallocate what we need */
                 stored_data = InitACMStore();
             }
         } else {
-            /* Update the event */
             do_update = 1;
             if (acm_str_replace(&lf->dstuser, stored_data->dstuser) == 0) {
                 debug2("accumulator: DEBUG: (%s) updated lf->dstuser to %s", _key, lf->dstuser);
@@ -164,56 +245,79 @@ Eventinfo *Accumulate(Eventinfo *lf)
         stored_data = InitACMStore();
     }
 
-    /* Store the object in the cache */
     stored_data->timestamp = current_ts;
     if (acm_str_replace(&stored_data->dstuser, lf->dstuser) == 0) {
-        debug2("accumulator: DEBUG: (%s) updated stored_data->dstuser to %s", _key, stored_data->dstuser);
+        debug2("accumulator: DEBUG: (%s) updated stored_data->dstuser to %s",
+               _key, stored_data->dstuser);
     }
 
     if (acm_str_replace(&stored_data->srcuser, lf->srcuser) == 0) {
-        debug2("accumulator: DEBUG: (%s) updated stored_data->srcuser to %s", _key, stored_data->srcuser);
+        debug2("accumulator: DEBUG: (%s) updated stored_data->srcuser to %s",
+               _key, stored_data->srcuser);
     }
 
     if (acm_str_replace(&stored_data->dstip, lf->dstip) == 0) {
-        debug2("accumulator: DEBUG: (%s) updated stored_data->dstip to %s", _key, stored_data->dstip);
+        debug2("accumulator: DEBUG: (%s) updated stored_data->dstip to %s",
+               _key, stored_data->dstip);
     }
 
     if (acm_str_replace(&stored_data->srcip, lf->srcip) == 0) {
-        debug2("accumulator: DEBUG: (%s) updated stored_data->srcip to %s", _key, stored_data->srcip);
+        debug2("accumulator: DEBUG: (%s) updated stored_data->srcip to %s",
+               _key, stored_data->srcip);
     }
 
     if (acm_str_replace(&stored_data->dstport, lf->dstport) == 0) {
-        debug2("accumulator: DEBUG: (%s) updated stored_data->dstport to %s", _key, stored_data->dstport);
+        debug2("accumulator: DEBUG: (%s) updated stored_data->dstport to %s",
+               _key, stored_data->dstport);
     }
 
     if (acm_str_replace(&stored_data->srcport, lf->srcport) == 0) {
-        debug2("accumulator: DEBUG: (%s) updated stored_data->srcport to %s", _key, stored_data->srcport);
+        debug2("accumulator: DEBUG: (%s) updated stored_data->srcport to %s",
+               _key, stored_data->srcport);
     }
 
     if (acm_str_replace(&stored_data->data, lf->data) == 0) {
-        debug2("accumulator: DEBUG: (%s) updated stored_data->data to %s", _key, stored_data->data);
+        debug2("accumulator: DEBUG: (%s) updated stored_data->data to %s",
+               _key, stored_data->data);
     }
 
-    /* Update or Add to the hash */
-    if ( do_update == 1 ) {
-        /* Update the hash entry */
-        if ( (result = OSHash_Update(acm_store, _key, stored_data)) != 1) {
-            verbose("accumulator: ERROR: Update of stored data for %s failed (%d).", _key, result);
+    if (do_update == 1) {
+        if ((result = OSHash_Update(store, _key, stored_data)) != 1) {
+            verbose("accumulator: ERROR: Update of stored data for %s failed (%d).",
+                    _key, result);
         } else {
             debug1("accumulator: DEBUG: Updated stored data for %s", _key);
         }
     } else {
-        if ((result = OSHash_Add(acm_store, _key, stored_data)) != 2 ) {
-            verbose("accumulator: ERROR: Addition of stored data for %s failed (%d).", _key, result);
+        if ((result = OSHash_Add(store, _key, stored_data)) != 2) {
+            verbose("accumulator: ERROR: Addition of stored data for %s failed (%d).",
+                    _key, result);
         } else {
             debug1("accumulator: DEBUG: Added stored data for %s", _key);
         }
     }
 
+    if (locked) {
+        os_mutex_unlock(&accumulate_mutex);
+    }
     return lf;
 }
 
-void Accumulate_CleanUp()
+void Accumulate_CleanUp(void)
+{
+    if (tls_acm_store) {
+        Accumulate_CleanUp_Store(tls_acm_store, &tls_acm_lookups, &tls_acm_purge_ts);
+        return;
+    }
+
+    os_mutex_lock(&accumulate_mutex);
+    if (acm_store) {
+        Accumulate_CleanUp_Store(acm_store, &acm_lookups, &acm_purge_ts);
+    }
+    os_mutex_unlock(&accumulate_mutex);
+}
+
+static void Accumulate_CleanUp_Store(OSHash *store, int *lookups, time_t *purge_ts)
 {
     struct timeval tp;
     time_t current_ts = 0;
@@ -224,40 +328,33 @@ void Accumulate_CleanUp()
     char *key;
     unsigned int ti;
 
-    /* Keep track of how many times we're called */
-    acm_lookups++;
+    (*lookups)++;
 
     gettimeofday(&tp, NULL);
     current_ts = tp.tv_sec;
 
-    /* Do we really need to purge? */
-    if ( acm_lookups < OS_ACM_PURGE_COUNT && acm_purge_ts < current_ts + OS_ACM_PURGE_INTERVAL ) {
+    if (*lookups < OS_ACM_PURGE_COUNT && *purge_ts < current_ts + OS_ACM_PURGE_INTERVAL) {
         return;
     }
     debug1("accumulator: DEBUG: Accumulator_CleanUp() running .. ");
 
-    /* Yes, we do */
-    acm_lookups = 0;
-    acm_purge_ts = current_ts;
+    *lookups = 0;
+    *purge_ts = current_ts;
 
-    /* Loop through the hash */
-    for ( ti = 0; ti < acm_store->rows; ti++ ) {
-        curr = acm_store->table[ti];
-        while ( curr != NULL ) {
-            /* Get the Key and Data */
-            key  = (char *) curr->key;
-            stored_data = (OS_ACM_Store *) curr->data;
-            /* Increment to the next element */
+    for (ti = 0; ti < store->rows; ti++) {
+        curr = store->table[ti];
+        while (curr != NULL) {
+            key = (char *)curr->key;
+            stored_data = (OS_ACM_Store *)curr->data;
             curr = curr->next;
 
             debug2("accumulator: DEBUG: CleanUp() evaluating cached key: %s ", key);
-            /* Check for a valid element */
-            if ( stored_data != NULL ) {
-                /* Check for expiration */
-                debug2("accumulator: DEBUG: CleanUp() elm:%ld, curr:%ld", (long int)stored_data->timestamp, (long int)current_ts);
-                if ( stored_data->timestamp < current_ts - OS_ACM_EXPIRE_ELM ) {
+            if (stored_data != NULL) {
+                debug2("accumulator: DEBUG: CleanUp() elm:%ld, curr:%ld",
+                       (long int)stored_data->timestamp, (long int)current_ts);
+                if (stored_data->timestamp < current_ts - OS_ACM_EXPIRE_ELM) {
                     debug2("accumulator: DEBUG: CleanUp() Expiring '%s'", key);
-                    if ( OSHash_Delete(acm_store, key) != NULL ) {
+                    if (OSHash_Delete(store, key) != NULL) {
                         FreeACMStore(stored_data);
                         expired++;
                     } else {
@@ -271,7 +368,7 @@ void Accumulate_CleanUp()
 }
 
 /* Initialize a storage object */
-OS_ACM_Store *InitACMStore()
+static OS_ACM_Store *InitACMStore(void)
 {
     OS_ACM_Store *obj;
     os_calloc(1, sizeof(OS_ACM_Store), obj);
@@ -289,9 +386,9 @@ OS_ACM_Store *InitACMStore()
 }
 
 /* Free an accumulation store struct */
-void FreeACMStore(OS_ACM_Store *obj)
+static void FreeACMStore(OS_ACM_Store *obj)
 {
-    if ( obj != NULL ) {
+    if (obj != NULL) {
         debug2("accumulator: DEBUG: Freeing an accumulator struct.");
         free(obj->dstuser);
         free(obj->srcuser);
@@ -304,28 +401,24 @@ void FreeACMStore(OS_ACM_Store *obj)
     }
 }
 
-int acm_str_replace(char **dst, const char *src)
+static int acm_str_replace(char **dst, const char *src)
 {
     int result = 0;
 
-    /* Don't overwrite with a null str */
-    if ( src == NULL ) {
+    if (src == NULL) {
         return -1;
     }
 
-    /* Don't overwrite something we already know */
     if (*dst != NULL && **dst != '\0') {
         return -1;
     }
 
-    /* Make sure we have data to write */
     size_t slen = strlen(src);
-    if ( slen <= 0  || slen > OS_ACM_MAXELM - 1 ) {
+    if (slen <= 0 || slen > OS_ACM_MAXELM - 1) {
         return -1;
     }
 
-    /* Free dst, and malloc the memory we need! */
-    if ( *dst != NULL ) {
+    if (*dst != NULL) {
         free(*dst);
     }
     os_malloc(slen + 1, *dst);
@@ -336,4 +429,3 @@ int acm_str_replace(char **dst, const char *src)
     }
     return result;
 }
-

--- a/src/analysisd/accumulator.h
+++ b/src/analysisd/accumulator.h
@@ -11,11 +11,17 @@
 #define __ACCUMULATOR_H
 
 #include "eventinfo.h"
+#include "hash_op.h"
 
 /* Accumulator Functions */
 int Accumulate_Init(void);
 Eventinfo *Accumulate(Eventinfo *lf);
 void Accumulate_CleanUp(void);
 
-#endif /* __ACCUMULATOR_H */
+/* Per-shard / TLS accumulate store (pipeline process workers). */
+OSHash *Accumulate_CreateStore(void);
+void Accumulate_DestroyStore(OSHash *store);
+void analysisd_set_acm_store(OSHash *store);
+OSHash *analysisd_get_acm_store(void);
 
+#endif /* __ACCUMULATOR_H */

--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -24,8 +24,10 @@ void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
     const char *ip;
     const char *user;
     char *filename = NULL;
+    long alert_id;
 
     ip = user = "-";
+    alert_id = lf->alert_id ? lf->alert_id : __crt_ftell;
 
     /* Clean the IP */
     if (lf->srcip && (ar->ar_cmd->expect & SRCIP)) {
@@ -86,7 +88,7 @@ void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
                  user,
                  ip,
                  (long int)lf->time,
-                 __crt_ftell,
+                 alert_id,
                  lf->generated_rule->sigid,
                  lf->location,
                  filename ? filename : "-");
@@ -117,7 +119,7 @@ void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
                      user,
                      ip,
                      (long int)lf->time,
-                     __crt_ftell,
+                     alert_id,
                      lf->generated_rule->sigid,
                      lf->location,
                      filename);
@@ -133,7 +135,7 @@ void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
                      user,
                      ip,
                      (long int)lf->time,
-                     __crt_ftell,
+                     alert_id,
                      lf->generated_rule->sigid,
                      lf->location,
                      filename);

--- a/src/analysisd/alerts/getloglocation.c
+++ b/src/analysisd/alerts/getloglocation.c
@@ -9,6 +9,7 @@
 
 /* Get the log directory/file based on the day/month/year */
 
+#include "shared.h"
 #include "getloglocation.h"
 #include "config.h"
 
@@ -26,6 +27,24 @@ static char __alogfile[OS_FLSIZE + 1];
 static char __flogfile[OS_FLSIZE + 1];
 static char __jlogfile[OS_FLSIZE + 1];
 static char __ejlogfile[OS_FLSIZE + 1];
+
+#ifndef WIN32
+static pthread_mutex_t log_io_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
+
+void analysisd_log_io_lock(void)
+{
+#ifndef WIN32
+    os_mutex_lock(&log_io_mutex);
+#endif
+}
+
+void analysisd_log_io_unlock(void)
+{
+#ifndef WIN32
+    os_mutex_unlock(&log_io_mutex);
+#endif
+}
 
 void OS_InitLog()
 {
@@ -56,8 +75,8 @@ int OS_GetLogLocation(const Eventinfo *lf)
      * Check if the year directory is there
      * If not, create it. Same for the month directory.
      */
-    
-     
+    analysisd_log_io_lock();
+
     /* For the events */
     if (_eflog) {
         if (ftell(_eflog) == 0) {
@@ -303,6 +322,7 @@ int OS_GetLogLocation(const Eventinfo *lf)
     /* Setting the new day */
     __crt_day = lf->day;
 
+    analysisd_log_io_unlock();
     return (0);
 }
 

--- a/src/analysisd/alerts/getloglocation.h
+++ b/src/analysisd/alerts/getloglocation.h
@@ -21,6 +21,10 @@ void OS_InitFwLog(void);
  */
 int OS_GetLogLocation(const Eventinfo *lf);
 
+/* Serialize all alert/archive/firewall/json FILE* access (rollover + writers). */
+void analysisd_log_io_lock(void);
+void analysisd_log_io_unlock(void);
+
 /* Global declarations */
 extern FILE *_eflog;
 extern FILE *_ejflog;

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -150,13 +150,19 @@ void OS_LogOutput(Eventinfo *lf)
         lf->full_log);
 
     /* Print the last events if present */
-    if (lf->generated_rule->last_events) {
-        char **lasts = lf->generated_rule->last_events;
-        while (*lasts) {
-            printf("%.1256s\n", *lasts);
-            lasts++;
+    {
+        char **lasts = lf->alert_last_events ? lf->alert_last_events :
+                       (lf->generated_rule ? lf->generated_rule->last_events : NULL);
+
+        if (lasts) {
+            while (*lasts) {
+                printf("%.1256s\n", *lasts);
+                lasts++;
+            }
+            if (!lf->alert_last_events && lf->generated_rule) {
+                OS_FreeRuleLastEvents(lf->generated_rule);
+            }
         }
-        OS_FreeRuleLastEvents(lf->generated_rule);
     }
 
     printf("\n");
@@ -179,69 +185,76 @@ void OS_Log(Eventinfo *lf)
 #endif
 
     /* Writing to the alert log file */
-    fprintf(_aflog,
-            "** Alert %ld.%ld:%s - %s\n"
-            "%d %s %02d %s %s%s%s\nRule: %d (level %d) -> '%s'"
-            "%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n%.1256s\n",
-            (long int)lf->time,
-            __crt_ftell,
-            lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
-            lf->generated_rule->group,
-            lf->year,
-            lf->mon,
-            lf->day,
-            lf->hour,
-            lf->hostname != lf->location ? lf->hostname : "",
-            lf->hostname != lf->location ? "->" : "",
-            lf->location,
-            lf->generated_rule->sigid,
-            lf->generated_rule->level,
-            lf->generated_rule->comment,
+    {
+        long alert_id = lf->alert_id ? lf->alert_id : __crt_ftell;
+        char **lasts = lf->alert_last_events ? lf->alert_last_events :
+                       (lf->generated_rule ? lf->generated_rule->last_events : NULL);
 
-            lf->srcip == NULL ? "" : "\nSrc IP: ",
-            lf->srcip == NULL ? "" : lf->srcip,
+        fprintf(_aflog,
+                "** Alert %ld.%ld:%s - %s\n"
+                "%d %s %02d %s %s%s%s\nRule: %d (level %d) -> '%s'"
+                "%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n%.1256s\n",
+                (long int)lf->time,
+                alert_id,
+                lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
+                lf->generated_rule->group,
+                lf->year,
+                lf->mon,
+                lf->day,
+                lf->hour,
+                lf->hostname != lf->location ? lf->hostname : "",
+                lf->hostname != lf->location ? "->" : "",
+                lf->location,
+                lf->generated_rule->sigid,
+                lf->generated_rule->level,
+                lf->generated_rule->comment,
+
+                lf->srcip == NULL ? "" : "\nSrc IP: ",
+                lf->srcip == NULL ? "" : lf->srcip,
 
 #ifdef LIBGEOIP_ENABLED
-            lf->srcgeoip == NULL ? "" : "\nSrc Location: ",
-            lf->srcgeoip == NULL ? "" : lf->srcgeoip,
+                lf->srcgeoip == NULL ? "" : "\nSrc Location: ",
+                lf->srcgeoip == NULL ? "" : lf->srcgeoip,
 #else
-            "",
-            "",
+                "",
+                "",
 #endif
 
 
-            lf->srcport == NULL ? "" : "\nSrc Port: ",
-            lf->srcport == NULL ? "" : lf->srcport,
+                lf->srcport == NULL ? "" : "\nSrc Port: ",
+                lf->srcport == NULL ? "" : lf->srcport,
 
-            lf->dstip == NULL ? "" : "\nDst IP: ",
-            lf->dstip == NULL ? "" : lf->dstip,
+                lf->dstip == NULL ? "" : "\nDst IP: ",
+                lf->dstip == NULL ? "" : lf->dstip,
 
 #ifdef LIBGEOIP_ENABLED
-            lf->dstgeoip == NULL ? "" : "\nDst Location: ",
-            lf->dstgeoip == NULL ? "" : lf->dstgeoip,
+                lf->dstgeoip == NULL ? "" : "\nDst Location: ",
+                lf->dstgeoip == NULL ? "" : lf->dstgeoip,
 #else
-            "",
-            "",
+                "",
+                "",
 #endif
 
 
 
-            lf->dstport == NULL ? "" : "\nDst Port: ",
-            lf->dstport == NULL ? "" : lf->dstport,
+                lf->dstport == NULL ? "" : "\nDst Port: ",
+                lf->dstport == NULL ? "" : lf->dstport,
 
-            lf->dstuser == NULL ? "" : "\nUser: ",
-            lf->dstuser == NULL ? "" : lf->dstuser,
+                lf->dstuser == NULL ? "" : "\nUser: ",
+                lf->dstuser == NULL ? "" : lf->dstuser,
 
-            lf->full_log);
+                lf->full_log);
 
-    /* Print the last events if present */
-    if (lf->generated_rule->last_events) {
-        char **lasts = lf->generated_rule->last_events;
-        while (*lasts) {
-            fprintf(_aflog, "%.1256s\n", *lasts);
-            lasts++;
+        /* Print the last events if present */
+        if (lasts) {
+            while (*lasts) {
+                fprintf(_aflog, "%.1256s\n", *lasts);
+                lasts++;
+            }
+            if (!lf->alert_last_events && lf->generated_rule) {
+                OS_FreeRuleLastEvents(lf->generated_rule);
+            }
         }
-        OS_FreeRuleLastEvents(lf->generated_rule);
     }
 
     fprintf(_aflog, "\n");
@@ -375,14 +388,10 @@ void OS_InitFwLog()
     }
 }
 
-int FW_Log(Eventinfo *lf)
+void FW_NormalizeAction(Eventinfo *lf)
 {
-    /* If we don't have the srcip or the
-     * action, there is no point in going
-     * forward over here
-     */
-    if (!lf->action || !lf->srcip || !lf->dstip || !lf->protocol) {
-        return (0);
+    if (!lf || !lf->action) {
+        return;
     }
 
     /* Set the actions */
@@ -424,8 +433,7 @@ int FW_Log(Eventinfo *lf)
             if (OSMatch_Execute(lf->action, strlen(lf->action), &FWDROPpm)) {
                 os_free(lf->action);
                 os_strdup("DROP", lf->action);
-            }
-            if (OSMatch_Execute(lf->action, strlen(lf->action), &FWALLOWpm)) {
+            } else if (OSMatch_Execute(lf->action, strlen(lf->action), &FWALLOWpm)) {
                 os_free(lf->action);
                 os_strdup("ALLOW", lf->action);
             } else {
@@ -434,6 +442,19 @@ int FW_Log(Eventinfo *lf)
             }
             break;
     }
+}
+
+int FW_Log(Eventinfo *lf)
+{
+    /* If we don't have the srcip or the
+     * action, there is no point in going
+     * forward over here
+     */
+    if (!lf->action || !lf->srcip || !lf->dstip || !lf->protocol) {
+        return (0);
+    }
+
+    FW_NormalizeAction(lf);
 
     /* Log to file */
     fprintf(_fflog,

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -65,6 +65,7 @@ void OS_Store(const Eventinfo *lf)
         return;
     }
 
+    analysisd_log_io_lock();
     fprintf(_eflog,
             "%d %s %02d %s %s%s%s %s\n",
             lf->year,
@@ -77,6 +78,7 @@ void OS_Store(const Eventinfo *lf)
             lf->full_log);
 
     fflush(_eflog);
+    analysisd_log_io_unlock();
     return;
 }
 
@@ -98,7 +100,7 @@ void OS_LogOutput(Eventinfo *lf)
         "%d %s %02d %s %s%s%s\nRule: %d (level %d) -> '%s'"
         "%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n%.1256s\n",
         (long int)lf->time,
-        __crt_ftell,
+        lf->alert_id ? lf->alert_id : __crt_ftell,
         lf->generated_rule->alert_opts & DO_MAILALERT ? " mail " : "",
         lf->generated_rule->group,
         lf->year,
@@ -160,13 +162,14 @@ void OS_LogOutput(Eventinfo *lf)
                 lasts++;
             }
             if (!lf->alert_last_events && lf->generated_rule) {
+                os_mutex_lock(&lf->generated_rule->mutex);
                 OS_FreeRuleLastEvents(lf->generated_rule);
+                os_mutex_unlock(&lf->generated_rule->mutex);
             }
         }
     }
 
     printf("\n");
-
     fflush(stdout);
     return;
 }
@@ -189,7 +192,9 @@ void OS_Log(Eventinfo *lf)
         long alert_id = lf->alert_id ? lf->alert_id : __crt_ftell;
         char **lasts = lf->alert_last_events ? lf->alert_last_events :
                        (lf->generated_rule ? lf->generated_rule->last_events : NULL);
+        int clear_shared_last_events = 0;
 
+        analysisd_log_io_lock();
         fprintf(_aflog,
                 "** Alert %ld.%ld:%s - %s\n"
                 "%d %s %02d %s %s%s%s\nRule: %d (level %d) -> '%s'"
@@ -252,13 +257,21 @@ void OS_Log(Eventinfo *lf)
                 lasts++;
             }
             if (!lf->alert_last_events && lf->generated_rule) {
-                OS_FreeRuleLastEvents(lf->generated_rule);
+                clear_shared_last_events = 1;
             }
         }
-    }
 
-    fprintf(_aflog, "\n");
-    fflush(_aflog);
+        fprintf(_aflog, "\n");
+        fflush(_aflog);
+        analysisd_log_io_unlock();
+
+        /* Free shared rule buffers only after releasing log_io (lock order). */
+        if (clear_shared_last_events) {
+            os_mutex_lock(&lf->generated_rule->mutex);
+            OS_FreeRuleLastEvents(lf->generated_rule);
+            os_mutex_unlock(&lf->generated_rule->mutex);
+        }
+    }
 
     return;
 }
@@ -268,6 +281,7 @@ void OS_CustomLog(const Eventinfo *lf, const char *format)
     char *log;
     char *tmp_log;
     char tmp_buffer[1024];
+    long alert_id = lf->alert_id ? lf->alert_id : __crt_ftell;
 
     /* Replace all the tokens */
     os_strdup(format, log);
@@ -278,7 +292,7 @@ void OS_CustomLog(const Eventinfo *lf, const char *format)
         os_free(log);
         log = NULL;
     }
-    snprintf(tmp_buffer, 1024, "%ld", __crt_ftell);
+    snprintf(tmp_buffer, 1024, "%ld", alert_id);
     log = searchAndReplace(tmp_log, CustomAlertTokenName[CUSTOM_ALERT_TOKEN_FTELL], tmp_buffer);
     if (tmp_log) {
         os_free(tmp_log);
@@ -362,9 +376,11 @@ void OS_CustomLog(const Eventinfo *lf, const char *format)
         tmp_log = NULL;
     }
 
+    analysisd_log_io_lock();
     fprintf(_aflog, "%s", log);
     fprintf(_aflog, "\n");
     fflush(_aflog);
+    analysisd_log_io_unlock();
 
     if (log) {
         os_free(log);
@@ -457,6 +473,7 @@ int FW_Log(Eventinfo *lf)
     FW_NormalizeAction(lf);
 
     /* Log to file */
+    analysisd_log_io_lock();
     fprintf(_fflog,
             "%d %s %02d %s %s%s%s %s %s %s:%s->%s:%s\n",
             lf->year,
@@ -474,6 +491,7 @@ int FW_Log(Eventinfo *lf)
             lf->dstport ? lf->dstport : "0");
 
     fflush(_fflog);
+    analysisd_log_io_unlock();
 
     return (1);
 }

--- a/src/analysisd/alerts/log.h
+++ b/src/analysisd/alerts/log.h
@@ -21,6 +21,7 @@ void OS_LogOutput(Eventinfo *lf);
 void OS_Log(Eventinfo *lf);
 void OS_CustomLog(const Eventinfo *lf, const char *format);
 void OS_Store(const Eventinfo *lf);
+void FW_NormalizeAction(Eventinfo *lf);
 int FW_Log(Eventinfo *lf);
 
 #endif

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -33,6 +33,12 @@
 #include "dodiff.h"
 #include "output/jsonout.h"
 
+#ifndef WIN32
+#include "pipeline.h"
+#include "state.h"
+#include "sig_op.h"
+#endif
+
 #ifdef PRELUDE_OUTPUT_ENABLED
 #include "output/prelude.h"
 #endif
@@ -56,36 +62,90 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node);
 static void LoopRule(RuleNode *curr_node, FILE *flog);
 
 /* For decoders */
-void DecodeEvent(Eventinfo *lf);
+void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match);
 int DecodeSyscheck(Eventinfo *lf);
 int DecodeRootcheck(Eventinfo *lf);
 int DecodeHostinfo(Eventinfo *lf);
 
+Eventinfo *analysisd_event_alloc(void);
+void analysisd_set_time_context(Eventinfo *lf);
+int analysisd_handle_hour_rollover(Eventinfo *lf);
+Eventinfo *analysisd_decode_event(Eventinfo *lf, char mq_prefix, regex_matching *decoder_match);
+int analysisd_analyze_event(Eventinfo *lf);
+void analysisd_finish_event(Eventinfo *lf);
+
 /* For stats */
-static void DumpLogstats(void);
+void DumpLogstats(void);
 
 /** Global definitions **/
 int today;
 int thishour;
 int prev_year;
 char prev_month[4];
+#ifndef WIN32
+__thread int __crt_hour;
+__thread int __crt_wday;
+__thread time_t c_time;
+#else
 int __crt_hour;
 int __crt_wday;
 time_t c_time;
+#endif
 char __shost[512];
 OSDecoderInfo *NULL_Decoder;
 
 /* execd queue */
-static int execdq = 0;
+int analysisd_execdq = 0;
 
 /* Active response queue */
-static int arq = 0;
+int analysisd_arq = 0;
 
-static int hourly_alerts;
-static int hourly_events;
-static int hourly_syscheck;
-static int hourly_firewall;
+int hourly_alerts;
+int hourly_events;
+int hourly_syscheck;
+int hourly_firewall;
 
+RuleInfo *analysisd_stats_rule = NULL;
+
+void analysisd_inc_hourly_events(void)
+{
+#ifndef WIN32
+    __sync_add_and_fetch(&hourly_events, 1);
+#else
+    hourly_events++;
+#endif
+}
+
+#ifndef WIN32
+void analysisd_inc_hourly_syscheck(void)
+{
+    __sync_add_and_fetch(&hourly_syscheck, 1);
+}
+
+void analysisd_inc_hourly_firewall(void)
+{
+    __sync_add_and_fetch(&hourly_firewall, 1);
+}
+#else
+void analysisd_inc_hourly_syscheck(void)
+{
+    hourly_syscheck++;
+}
+
+void analysisd_inc_hourly_firewall(void)
+{
+    hourly_firewall++;
+}
+#endif
+
+
+#ifndef WIN32
+static void analysisd_HandleSIG(int sig)
+{
+    merror(SIGNAL_RECV, ARGV0, sig, strsignal(sig));
+    analysisd_pipeline_request_shutdown();
+}
+#endif
 
 /* Print help statement */
 __attribute__((noreturn))
@@ -460,7 +520,11 @@ int main_analysisd(int argc, char **argv)
     debug1(PRIVSEP_MSG, ARGV0, user);
 
     /* Signal manipulation */
+#ifndef WIN32
+    StartSIG2(ARGV0, analysisd_HandleSIG);
+#else
     StartSIG(ARGV0);
+#endif
 
     /* Set the user */
     if (Privsep_SetUser(uid) < 0) {
@@ -536,7 +600,6 @@ __attribute__((noreturn))
 void OS_ReadMSG_analysisd(int m_queue)
 #endif
 {
-    int i;
     char msg[OS_MAXSTR + 1];
     Eventinfo *lf;
 
@@ -578,7 +641,7 @@ void OS_ReadMSG_analysisd(int m_queue)
 
 #ifndef LOCAL
         if (Config.ar & REMOTE_AR) {
-            if ((arq = StartMQ(ARQUEUE, WRITE)) < 0) {
+            if ((analysisd_arq = StartMQ(ARQUEUE, WRITE)) < 0) {
                 merror(ARQ_ERROR, ARGV0);
 
                 /* If LOCAL_AR is set, keep it there */
@@ -605,7 +668,7 @@ void OS_ReadMSG_analysisd(int m_queue)
 #endif
 
         if (Config.ar & LOCAL_AR) {
-            if ((execdq = StartMQ(EXECQUEUE, WRITE)) < 0) {
+            if ((analysisd_execdq = StartMQ(EXECQUEUE, WRITE)) < 0) {
                 merror(ARQ_ERROR, ARGV0);
 
                 /* If REMOTE_AR is set, keep it there */
@@ -640,6 +703,7 @@ void OS_ReadMSG_analysisd(int m_queue)
         }
         stats_rule->group = "stats,";
         stats_rule->comment = "Excessive number of events (above normal).";
+        analysisd_stats_rule = stats_rule;
     }
 
     /* Do some cleanup */
@@ -682,377 +746,56 @@ void OS_ReadMSG_analysisd(int m_queue)
         debug1("%s: INFO: Custom output found.!", ARGV0);
     }
 
-    /* Daemon loop */
+#ifndef WIN32
+    /* Always-on multi-threaded pipeline (Linux). Does not return until shutdown. */
+    analysisd_pipeline_run(m_queue);
+    DeletePID(ARGV0);
+    exit(0);
+#else
+    /* WIN32: legacy single-threaded recv loop. */
     while (1) {
-        lf = (Eventinfo *)calloc(1, sizeof(Eventinfo));
-        os_calloc(Config.decoder_order_size, sizeof(char*), lf->fields);
+        int recv_len;
 
-        /* This shouldn't happen */
-        if (lf == NULL) {
-            ErrorExit(MEM_ERROR, ARGV0, errno, strerror(errno));
-        }
+        lf = analysisd_event_alloc();
 
         DEBUG_MSG("%s: DEBUG: Waiting for msgs - %d ", ARGV0, (int)time(0));
 
-        /* Receive message from queue */
-        if ((i = OS_RecvUnix(m_queue, OS_MAXSTR, msg))) {
-            RuleNode *rulenode_pt;
-
-            /* Get the time we received the event */
+        if ((recv_len = OS_RecvUnix(m_queue, OS_MAXSTR, msg))) {
             c_time = time(NULL);
-
-            /* Default values for the log info */
             Zero_Eventinfo(lf);
 
-            /* Check for a valid message */
-            if (i < 4) {
+            if (recv_len < 4) {
                 merror(IMSG_ERROR, ARGV0, msg);
                 Free_Eventinfo(lf);
                 continue;
             }
 
-            /* Message before extracting header */
             DEBUG_MSG("%s: DEBUG: Received msg: %s ", ARGV0, msg);
 
-            /* Clean the msg appropriately */
-            if (OS_CleanMSG(msg, lf) < 0) {
+            if (OS_CleanMSG_ex(msg, lf, c_time, 1) < 0) {
                 merror(IMSG_ERROR, ARGV0, msg);
                 Free_Eventinfo(lf);
                 continue;
             }
 
-            /* Msg cleaned */
             DEBUG_MSG("%s: DEBUG: Msg cleanup: %s ", ARGV0, lf->log);
 
-            /* Current rule must be null in here */
             currently_rule = NULL;
+            analysisd_inc_hourly_events();
 
-            /** Check the date/hour changes **/
-
-            /* Update the hour */
-            if (thishour != __crt_hour) {
-                /* Search all the rules and print the number
-                 * of alerts that each one fired
-                 */
-                DumpLogstats();
-                thishour = __crt_hour;
-
-                /* Check if the date has changed */
-                if (today != lf->day) {
-                    if (Config.stats) {
-                        /* Update the hourly stats (done daily) */
-                        Update_Hour();
-                    }
-
-                    if (OS_GetLogLocation(lf) < 0) {
-                        ErrorExit("%s: Error allocating log files", ARGV0);
-                    }
-
-                    today = lf->day;
-                    strncpy(prev_month, lf->mon, 3);
-                    prev_year = lf->year;
-                }
+            lf = analysisd_decode_event(lf, msg[0], NULL);
+            if (!lf) {
+                continue;
             }
 
-
-            /* Increment number of events received */
-            hourly_events++;
-
-            /***  Run decoders ***/
-
-            /* Integrity check from syscheck */
-            if (msg[0] == SYSCHECK_MQ) {
-                hourly_syscheck++;
-
-                if (!DecodeSyscheck(lf)) {
-                    /* We don't process syscheck events further */
-                    goto CLMEM;
-                }
-
-                /* Get log size */
-                lf->size = strlen(lf->log);
-            }
-
-            /* Rootcheck decoding */
-            else if (msg[0] == ROOTCHECK_MQ) {
-                if (!DecodeRootcheck(lf)) {
-                    /* We don't process rootcheck events further */
-                    goto CLMEM;
-                }
-                lf->size = strlen(lf->log);
-            }
-
-            /* Host information special decoder */
-            else if (msg[0] == HOSTINFO_MQ) {
-                if (!DecodeHostinfo(lf)) {
-                    /* We don't process hostinfo events further */
-                    goto CLMEM;
-                }
-                lf->size = strlen(lf->log);
-            }
-
-            /* Run the general Decoders */
-            else {
-                /* Get log size */
-                lf->size = strlen(lf->log);
-
-                DecodeEvent(lf);
-            }
-
-            /* Run accumulator */
-            if ( lf->decoder_info->accumulate == 1 ) {
-                lf = Accumulate(lf);
-            }
-
-            /* Firewall event */
-            if (lf->decoder_info->type == FIREWALL) {
-                /* If we could not get any information from
-                 * the log, just ignore it
-                 */
-                hourly_firewall++;
-                if (Config.logfw) {
-                    if (!FW_Log(lf)) {
-                        goto CLMEM;
-                    }
-                }
-            }
-
-            /* We only check if the last message is
-             * duplicated on syslog
-             */
-            else if (lf->decoder_info->type == SYSLOG) {
-                /* Check if the message is duplicated */
-                if (LastMsg_Stats(lf->full_log) == 1) {
-                    goto CLMEM;
-                } else {
-                    LastMsg_Change(lf->full_log);
-                }
-            }
-
-            /* Stats checking */
-            if (Config.stats) {
-                if (Check_Hour() == 1) {
-                    RuleInfo *saved_rule = lf->generated_rule;
-                    char *saved_log;
-
-                    /* Save previous log */
-                    saved_log = lf->full_log;
-
-                    lf->generated_rule = stats_rule;
-                    lf->full_log = __stats_comment;
-
-                    /* Alert for statistical analysis */
-                    if (stats_rule->alert_opts & DO_LOGALERT) {
-                        __crt_ftell = ftell(_aflog);
-                        if (Config.custom_alert_output) {
-                            OS_CustomLog(lf, Config.custom_alert_output_format);
-                        } else {
-                            OS_Log(lf);
-                        }
-                        /* Log to json file */
-                        if (Config.jsonout_output) {
-                            jsonout_output_event(lf);
-                        }
-
-                    }
-
-                    /* Set lf to the old values */
-                    lf->generated_rule = saved_rule;
-                    lf->full_log = saved_log;
-                }
-            }
-
-            /* Check the rules */
-            DEBUG_MSG("%s: DEBUG: Checking the rules - %d ",
-                      ARGV0, lf->decoder_info->type);
-
-            /* Loop over all the rules */
-            rulenode_pt = OS_GetFirstRule();
-            if (!rulenode_pt) {
-                ErrorExit("%s: Rules in an inconsistent state. Exiting.",
-                          ARGV0);
-            }
-
-            do {
-                if (lf->decoder_info->type == OSSEC_ALERT) {
-                    if (!lf->generated_rule) {
-                        goto CLMEM;
-                    }
-
-                    /* Process the alert */
-                    currently_rule = lf->generated_rule;
-                }
-
-                /* Categories must match */
-                else if (rulenode_pt->ruleinfo->category !=
-                         lf->decoder_info->type) {
-                    continue;
-                }
-
-                /* Check each rule */
-                else if ((currently_rule = OS_CheckIfRuleMatch(lf, rulenode_pt))
-                         == NULL) {
-                    continue;
-                }
-
-                /* Ignore level 0 */
-                if (currently_rule->level == 0) {
-                    break;
-                }
-
-                /* Check ignore time */
-                if (currently_rule->ignore_time) {
-                    if (currently_rule->time_ignored == 0) {
-                        currently_rule->time_ignored = lf->time;
-                    }
-                    /* If the current time - the time the rule was ignored
-                     * is less than the time it should be ignored,
-                     * leave (do not alert again)
-                     */
-                    else if ((lf->time - currently_rule->time_ignored)
-                             < currently_rule->ignore_time) {
-                        break;
-                    } else {
-                        currently_rule->time_ignored = lf->time;
-                    }
-                }
-
-                /* Pointer to the rule that generated it */
-                lf->generated_rule = currently_rule;
-
-                /* Check if we should ignore it */
-                if (currently_rule->ckignore && IGnore(lf)) {
-                    /* Ignore rule */
-                    lf->generated_rule = NULL;
-                    break;
-                }
-
-                /* Check if we need to add to ignore list */
-                if (currently_rule->ignore) {
-                    AddtoIGnore(lf);
-                }
-
-                /* Log the alert if configured to */
-                if (currently_rule->alert_opts & DO_LOGALERT) {
-                    __crt_ftell = ftell(_aflog);
-
-                    if (Config.custom_alert_output) {
-                        OS_CustomLog(lf, Config.custom_alert_output_format);
-                    } else {
-                        OS_Log(lf);
-                    }
-                    /* Log to json file */
-                    if (Config.jsonout_output) {
-                        jsonout_output_event(lf);
-                    }
-                }
-
-#ifdef PRELUDE_OUTPUT_ENABLED
-                /* Log to prelude */
-                if (Config.prelude) {
-                    if (Config.prelude_log_level <= currently_rule->level) {
-                        OS_PreludeLog(lf);
-                    }
-                }
-#endif
-
-#ifdef ZEROMQ_OUTPUT_ENABLED
-                /* Log to zeromq */
-                if (Config.zeromq_output) {
-                    zeromq_output_event(lf);
-                }
-#endif
-
-
-                /* Execute an active response */
-                if (currently_rule->ar) {
-                    int do_ar;
-                    active_response **rule_ar;
-
-                    rule_ar = currently_rule->ar;
-
-                    while (*rule_ar) {
-                        do_ar = 1;
-                        if ((*rule_ar)->ar_cmd->expect & USERNAME) {
-                            if (!lf->dstuser ||
-                                    !OS_PRegex(lf->dstuser, "^[a-zA-Z._0-9@?-]*$")) {
-                                if (lf->dstuser) {
-                                    merror(CRAFTED_USER, ARGV0, lf->dstuser);
-                                }
-                                do_ar = 0;
-                            }
-                        }
-                        if ((*rule_ar)->ar_cmd->expect & SRCIP) {
-                            if (!lf->srcip ||
-                                    !OS_PRegex(lf->srcip, "^[a-zA-Z.:_0-9-]*$")) {
-                                if (lf->srcip) {
-                                    merror(CRAFTED_IP, ARGV0, lf->srcip);
-                                }
-                                do_ar = 0;
-                            }
-                        }
-                        if ((*rule_ar)->ar_cmd->expect & FILENAME) {
-                            if (!lf->filename) {
-                                do_ar = 0;
-                            }
-                        }
-
-                        if (do_ar && execdq > 0) {
-                            OS_Exec(execdq, arq, lf, *rule_ar);
-                        }
-                        rule_ar++;
-                    }
-                }
-
-                /* Copy the structure to the state memory of if_matched_sid */
-                if (currently_rule->sid_prev_matched) {
-                    if (!OSList_AddData(currently_rule->sid_prev_matched, lf)) {
-                        merror("%s: Unable to add data to sig list.", ARGV0);
-                    } else {
-                        lf->sid_node_to_delete =
-                            currently_rule->sid_prev_matched->last_node;
-                    }
-                }
-                /* Group list */
-                else if (currently_rule->group_prev_matched) {
-                    unsigned int j = 0;
-
-                    while (j < currently_rule->group_prev_matched_sz) {
-                        if (!OSList_AddData(
-                                    currently_rule->group_prev_matched[j],
-                                    lf)) {
-                            merror("%s: Unable to add data to grp list.", ARGV0);
-                        }
-                        j++;
-                    }
-                }
-
-                OS_AddEvent(lf);
-
-                break;
-
-            } while ((rulenode_pt = rulenode_pt->next) != NULL);
-
-            /* If configured to log all, do it */
-            if (Config.logall)
-                OS_Store(lf);
-            if (Config.logall_json)
-                jsonout_output_archive(lf);
-
-CLMEM:
-            /** Cleaning the memory **/
-
-            /* Only clear the memory if the eventinfo was not
-             * added to the stateful memory
-             * -- message is free inside clean event --
-             */
-            if (lf->generated_rule == NULL) {
-                Free_Eventinfo(lf);
+            if (!analysisd_analyze_event(lf)) {
+                analysisd_finish_event(lf);
             }
         } else {
             free(lf);
         }
     }
+#endif
 }
 
 /* Checks if the current_rule matches the event information */
@@ -1636,7 +1379,9 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
     }
 
     hourly_alerts++;
+    os_mutex_lock(&rule->mutex);
     rule->firedtimes++;
+    os_mutex_unlock(&rule->mutex);
 
     return (rule); /* Matched */
 }
@@ -1645,12 +1390,14 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
 static void LoopRule(RuleNode *curr_node, FILE *flog)
 {
     if (curr_node->ruleinfo->firedtimes) {
+        os_mutex_lock(&curr_node->ruleinfo->mutex);
         fprintf(flog, "%d-%d-%d-%d\n",
                 thishour,
                 curr_node->ruleinfo->sigid,
                 curr_node->ruleinfo->level,
                 curr_node->ruleinfo->firedtimes);
         curr_node->ruleinfo->firedtimes = 0;
+        os_mutex_unlock(&curr_node->ruleinfo->mutex);
     }
 
     if (curr_node->child) {
@@ -1665,7 +1412,7 @@ static void LoopRule(RuleNode *curr_node, FILE *flog)
 }
 
 /* Dump the hourly stats about each rule */
-static void DumpLogstats()
+void DumpLogstats()
 {
     RuleNode *rulenode_pt;
     char logfile[OS_FLSIZE + 1];

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -116,6 +116,15 @@ void analysisd_inc_hourly_events(void)
 #endif
 }
 
+void analysisd_inc_hourly_alerts(void)
+{
+#ifndef WIN32
+    __sync_add_and_fetch(&hourly_alerts, 1);
+#else
+    hourly_alerts++;
+#endif
+}
+
 #ifndef WIN32
 void analysisd_inc_hourly_syscheck(void)
 {
@@ -1378,7 +1387,7 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
         return (NULL);
     }
 
-    hourly_alerts++;
+    analysisd_inc_hourly_alerts();
     os_mutex_lock(&rule->mutex);
     rule->firedtimes++;
     os_mutex_unlock(&rule->mutex);

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -801,7 +801,7 @@ void OS_ReadMSG_analysisd(int m_queue)
                 analysisd_finish_event(lf);
             }
         } else {
-            free(lf);
+            Free_Eventinfo(lf);
         }
     }
 #endif

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -20,10 +20,15 @@ extern int thishour;
 extern int prev_year;
 extern char prev_month[4];
 
+#ifndef WIN32
+extern __thread int __crt_hour;
+extern __thread int __crt_wday;
+extern __thread time_t c_time; /* Current time of event (TLS per match/decode worker). */
+#else
 extern int __crt_hour;
 extern int __crt_wday;
-
 extern time_t c_time; /* Current time of event. Used everywhere */
+#endif
 
 /* Local host name */
 extern char __shost[512];
@@ -32,6 +37,10 @@ extern OSDecoderInfo *NULL_Decoder;
 
 #define OSSEC_SERVER    "ossec-server"
 #define MAX_DECODER_ORDER_SIZE  1024
+
+void analysisd_inc_hourly_events(void);
+void analysisd_inc_hourly_syscheck(void);
+void analysisd_inc_hourly_firewall(void);
 
 
 #endif /* _LOGAUDIT__H */

--- a/src/analysisd/analysisd.h
+++ b/src/analysisd/analysisd.h
@@ -39,6 +39,7 @@ extern OSDecoderInfo *NULL_Decoder;
 #define MAX_DECODER_ORDER_SIZE  1024
 
 void analysisd_inc_hourly_events(void);
+void analysisd_inc_hourly_alerts(void);
 void analysisd_inc_hourly_syscheck(void);
 void analysisd_inc_hourly_firewall(void);
 

--- a/src/analysisd/analysisd_stages.c
+++ b/src/analysisd/analysisd_stages.c
@@ -1,0 +1,479 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef WIN32
+#include "queue_op.h"
+#endif
+
+#include "shared.h"
+#include "alerts/alerts.h"
+#include "alerts/getloglocation.h"
+#include "active-response.h"
+#include "config.h"
+#include "rules.h"
+#include "stats.h"
+#include "eventinfo.h"
+#include "accumulator.h"
+#include "analysisd.h"
+#include "fts.h"
+#include "cleanevent.h"
+#include "output/jsonout.h"
+#include "pipeline.h"
+#include "state.h"
+#include "alerts/log.h"
+
+#ifdef PRELUDE_OUTPUT_ENABLED
+#include "output/prelude.h"
+#endif
+
+#ifdef ZEROMQ_OUTPUT_ENABLED
+#include "output/zeromq.h"
+#endif
+
+extern int analysisd_execdq;
+extern int analysisd_arq;
+extern RuleInfo *analysisd_stats_rule;
+extern int hourly_events;
+extern int hourly_syscheck;
+extern int hourly_firewall;
+
+#ifndef WIN32
+extern os_queue *writer_queue_log;
+extern os_queue *writer_queue_statistical;
+extern os_queue *writer_queue_archive;
+extern os_queue *writer_queue_firewall;
+static int archive_drop_warned = 0;
+static pthread_mutex_t hour_rollover_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/* Snapshot leftover rule->last_events onto the async alert copy (fallback if
+ * Search/doDiff already moved context onto the live event). Then clear the
+ * live RuleInfo buffer under rule->mutex. */
+static void analysisd_snapshot_rule_last_events(Eventinfo *dst, RuleInfo *rule)
+{
+    if (!dst || !rule) {
+        return;
+    }
+
+    /* Already claimed onto the live event and deep-copied onto dst. */
+    if (dst->alert_last_events) {
+        return;
+    }
+
+    if (!rule->last_events) {
+        return;
+    }
+
+    os_mutex_lock(&rule->mutex);
+    if (!rule->last_events || !rule->last_events_copied) {
+        os_mutex_unlock(&rule->mutex);
+        return;
+    }
+
+    OS_MoveRuleLastEvents(rule, dst);
+    os_mutex_unlock(&rule->mutex);
+}
+#endif
+
+extern void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match);
+extern int DecodeSyscheck(Eventinfo *lf);
+extern int DecodeRootcheck(Eventinfo *lf);
+extern int DecodeHostinfo(Eventinfo *lf);
+extern RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node);
+extern void DumpLogstats(void);
+
+Eventinfo *analysisd_event_alloc(void)
+{
+    Eventinfo *lf = (Eventinfo *)calloc(1, sizeof(Eventinfo));
+
+    if (!lf) {
+        ErrorExit(MEM_ERROR, ARGV0, errno, strerror(errno));
+    }
+
+    os_calloc(Config.decoder_order_size, sizeof(char *), lf->fields);
+    return lf;
+}
+
+void analysisd_set_time_context(Eventinfo *lf)
+{
+    struct tm tm_buf;
+    struct tm *p;
+
+    c_time = lf->time;
+    p = localtime_r(&c_time, &tm_buf);
+    __crt_hour = p->tm_hour;
+    __crt_wday = p->tm_wday;
+}
+
+int analysisd_handle_hour_rollover(Eventinfo *lf)
+{
+#ifndef WIN32
+    os_mutex_lock(&hour_rollover_mutex);
+#endif
+    if (thishour != __crt_hour) {
+        DumpLogstats();
+        thishour = __crt_hour;
+
+        if (today != lf->day) {
+            if (Config.stats) {
+                Update_Hour();
+            }
+
+            if (OS_GetLogLocation(lf) < 0) {
+#ifndef WIN32
+                os_mutex_unlock(&hour_rollover_mutex);
+#endif
+                ErrorExit("%s: Error allocating log files", ARGV0);
+            }
+
+            today = lf->day;
+            strncpy(prev_month, lf->mon, 3);
+            prev_year = lf->year;
+        }
+    }
+#ifndef WIN32
+    os_mutex_unlock(&hour_rollover_mutex);
+#endif
+
+    return 0;
+}
+
+Eventinfo *analysisd_decode_event(Eventinfo *lf, char mq_prefix, regex_matching *decoder_match)
+{
+    if (mq_prefix == SYSCHECK_MQ) {
+        analysisd_inc_hourly_syscheck();
+
+        if (!DecodeSyscheck(lf)) {
+            Free_Eventinfo(lf);
+            return NULL;
+        }
+
+        lf->size = strlen(lf->log);
+    } else if (mq_prefix == ROOTCHECK_MQ) {
+        if (!DecodeRootcheck(lf)) {
+            Free_Eventinfo(lf);
+            return NULL;
+        }
+        lf->size = strlen(lf->log);
+    } else if (mq_prefix == HOSTINFO_MQ) {
+        if (!DecodeHostinfo(lf)) {
+            Free_Eventinfo(lf);
+            return NULL;
+        }
+        lf->size = strlen(lf->log);
+    } else {
+        lf->size = strlen(lf->log);
+        DecodeEvent(lf, decoder_match);
+    }
+
+    if (lf->decoder_info && lf->decoder_info->type == FIREWALL) {
+        analysisd_inc_hourly_firewall();
+        if (Config.logfw) {
+            /* Incomplete firewall events are dropped (same as FW_Log). */
+            if (!lf->action || !lf->srcip || !lf->dstip || !lf->protocol) {
+                Free_Eventinfo(lf);
+                return NULL;
+            }
+
+            /* Normalize on the live event so rule matching sees DROP/ALLOW. */
+            FW_NormalizeAction(lf);
+#ifndef WIN32
+            if (writer_queue_firewall) {
+                Eventinfo *fw_copy = analysisd_copy_event_for_log(lf);
+
+                if (fw_copy && os_queue_push_ex_block(writer_queue_firewall, fw_copy) != 0) {
+                    Free_Eventinfo(fw_copy);
+                    FW_Log(lf);
+                }
+            } else
+#endif
+            {
+                FW_Log(lf);
+            }
+        }
+    }
+
+    return lf;
+}
+
+int analysisd_analyze_event(Eventinfo *lf)
+{
+    RuleNode *rulenode_pt;
+    int owned_by_writer = 0;
+
+    if (!lf || !lf->decoder_info) {
+        return 0;
+    }
+
+    /* Flood window is TLS per process/match shard (no global lastmsg_mutex). */
+    if (lf->decoder_info->type == SYSLOG) {
+        if (LastMsg_Stats(lf->full_log) == 1) {
+            return 0;
+        }
+        LastMsg_Change(lf->full_log);
+    }
+
+    if (lf->decoder_info->accumulate == 1) {
+        lf = Accumulate(lf);
+        if (!lf || !lf->decoder_info) {
+            return 0;
+        }
+    }
+
+    analysisd_set_time_context(lf);
+    currently_rule = NULL;
+    analysisd_handle_hour_rollover(lf);
+
+    /* Check_Hour excessive-events alerts use a dedicated statistical writer so
+     * they do not contend with the normal alerts queue (Nested parity). */
+    if (Config.stats && Check_Hour() == 1 && analysisd_stats_rule) {
+        RuleInfo *saved_rule = lf->generated_rule;
+        char *saved_log = lf->full_log;
+
+        lf->generated_rule = analysisd_stats_rule;
+        lf->full_log = __stats_comment;
+
+        if (analysisd_stats_rule->alert_opts & DO_LOGALERT) {
+#ifndef WIN32
+            if (writer_queue_statistical) {
+                Eventinfo *alert_copy;
+
+                lf->alert_id = analysisd_claim_alert_id();
+                alert_copy = analysisd_copy_event_for_log(lf);
+                if (alert_copy) {
+                    analysisd_snapshot_rule_last_events(alert_copy, analysisd_stats_rule);
+                    if (analysisd_enqueue_statistical(alert_copy) != 0) {
+                        Free_Eventinfo(alert_copy);
+                        analysisd_inc_alerts_dropped();
+                    }
+                }
+            } else
+#endif
+            {
+                __crt_ftell = _aflog ? ftell(_aflog) : 0;
+                if (Config.custom_alert_output) {
+                    OS_CustomLog(lf, Config.custom_alert_output_format);
+                } else {
+                    OS_Log(lf);
+                }
+                if (Config.jsonout_output) {
+                    jsonout_output_event(lf);
+                }
+            }
+        }
+
+        lf->generated_rule = saved_rule;
+        lf->full_log = saved_log;
+    }
+
+    DEBUG_MSG("%s: DEBUG: Checking the rules - %d ", ARGV0, lf->decoder_info->type);
+
+    rulenode_pt = OS_GetFirstRule();
+    if (!rulenode_pt) {
+        ErrorExit("%s: Rules in an inconsistent state. Exiting.", ARGV0);
+    }
+
+    do {
+        if (lf->decoder_info->type == OSSEC_ALERT) {
+            if (!lf->generated_rule) {
+                return 0;
+            }
+            currently_rule = lf->generated_rule;
+        } else if (rulenode_pt->ruleinfo->category != lf->decoder_info->type) {
+            continue;
+        } else if ((currently_rule = OS_CheckIfRuleMatch(lf, rulenode_pt)) == NULL) {
+            continue;
+        }
+
+        if (currently_rule->level == 0) {
+            break;
+        }
+
+        if (currently_rule->ignore_time) {
+            int skip_ignore = 0;
+
+            os_mutex_lock(&currently_rule->mutex);
+            if (currently_rule->time_ignored == 0) {
+                currently_rule->time_ignored = lf->time;
+            } else if ((lf->time - currently_rule->time_ignored) < currently_rule->ignore_time) {
+                skip_ignore = 1;
+            } else {
+                currently_rule->time_ignored = lf->time;
+            }
+            os_mutex_unlock(&currently_rule->mutex);
+            if (skip_ignore) {
+                break;
+            }
+        }
+
+        lf->generated_rule = currently_rule;
+
+        if (currently_rule->ckignore && IGnore(lf)) {
+            lf->generated_rule = NULL;
+            break;
+        }
+
+        if (currently_rule->ignore) {
+            AddtoIGnore(lf);
+        }
+
+        if (currently_rule->alert_opts & DO_LOGALERT) {
+#ifndef WIN32
+            if (writer_queue_log) {
+                Eventinfo *alert_copy;
+
+                lf->alert_id = analysisd_claim_alert_id();
+                alert_copy = analysisd_copy_event_for_log(lf);
+                if (alert_copy) {
+                    analysisd_snapshot_rule_last_events(alert_copy, currently_rule);
+                    if (analysisd_enqueue_alert(alert_copy) != 0) {
+                        Free_Eventinfo(alert_copy);
+                        analysisd_inc_alerts_dropped();
+                    }
+                }
+            } else
+#endif
+            {
+                __crt_ftell = _aflog ? ftell(_aflog) : 0;
+                if (Config.custom_alert_output) {
+                    OS_CustomLog(lf, Config.custom_alert_output_format);
+                } else {
+                    OS_Log(lf);
+                }
+                if (Config.jsonout_output) {
+                    jsonout_output_event(lf);
+                }
+#ifndef WIN32
+                analysisd_inc_alerts_written();
+#endif
+            }
+        }
+
+#ifdef PRELUDE_OUTPUT_ENABLED
+        if (Config.prelude && Config.prelude_log_level <= currently_rule->level) {
+            OS_PreludeLog(lf);
+        }
+#endif
+
+#ifdef ZEROMQ_OUTPUT_ENABLED
+        if (Config.zeromq_output) {
+            zeromq_output_event(lf);
+        }
+#endif
+
+        if (currently_rule->ar) {
+            active_response **rule_ar = currently_rule->ar;
+
+            while (*rule_ar) {
+                int do_ar = 1;
+
+                if ((*rule_ar)->ar_cmd->expect & USERNAME) {
+                    if (!lf->dstuser || !OS_PRegex(lf->dstuser, "^[a-zA-Z._0-9@?-]*$")) {
+                        if (lf->dstuser) {
+                            merror(CRAFTED_USER, ARGV0, lf->dstuser);
+                        }
+                        do_ar = 0;
+                    }
+                }
+                if ((*rule_ar)->ar_cmd->expect & SRCIP) {
+                    if (!lf->srcip || !OS_PRegex(lf->srcip, "^[a-zA-Z.:_0-9-]*$")) {
+                        if (lf->srcip) {
+                            merror(CRAFTED_IP, ARGV0, lf->srcip);
+                        }
+                        do_ar = 0;
+                    }
+                }
+                if ((*rule_ar)->ar_cmd->expect & FILENAME) {
+                    if (!lf->filename) {
+                        do_ar = 0;
+                    }
+                }
+
+                if (do_ar && analysisd_execdq > 0) {
+                    OS_Exec(analysisd_execdq, analysisd_arq, lf, *rule_ar);
+                }
+                rule_ar++;
+            }
+        }
+
+        if (currently_rule->sid_prev_matched) {
+            os_mutex_lock(&currently_rule->mutex);
+            if (!OSList_AddData(currently_rule->sid_prev_matched, lf)) {
+                merror("%s: Unable to add data to sig list.", ARGV0);
+            } else {
+                lf->sid_node_to_delete = currently_rule->sid_prev_matched->last_node;
+            }
+            os_mutex_unlock(&currently_rule->mutex);
+        } else if (currently_rule->group_prev_matched) {
+            unsigned int j = 0;
+
+            os_mutex_lock(&currently_rule->mutex);
+            while (j < currently_rule->group_prev_matched_sz) {
+                if (!OSList_AddData(currently_rule->group_prev_matched[j], lf)) {
+                    merror("%s: Unable to add data to grp list.", ARGV0);
+                }
+                j++;
+            }
+            os_mutex_unlock(&currently_rule->mutex);
+        }
+
+        OS_AddEvent(lf);
+        break;
+    } while ((rulenode_pt = rulenode_pt->next) != NULL);
+
+    if (Config.logall) {
+#ifndef WIN32
+        if (writer_queue_archive) {
+            /* No rule matched: EventList will not retain lf — transfer ownership
+             * to the archive writer instead of deep-copying. Matched events keep
+             * a deep copy because OS_AddEvent still owns the live Eventinfo. */
+            if (lf->generated_rule == NULL) {
+                if (os_queue_push_ex(writer_queue_archive, lf) == 0) {
+                    owned_by_writer = 1;
+                } else {
+                    analysisd_inc_archives_dropped();
+                    if (!archive_drop_warned) {
+                        merror("%s: WARN: Dropping archive events: archive queue full "
+                               "(logall best-effort under backlog).", ARGV0);
+                        archive_drop_warned = 1;
+                    }
+                }
+            } else {
+                Eventinfo *arch_copy = analysisd_copy_event_for_log(lf);
+
+                if (arch_copy && os_queue_push_ex(writer_queue_archive, arch_copy) != 0) {
+                    Free_Eventinfo(arch_copy);
+                    analysisd_inc_archives_dropped();
+                    if (!archive_drop_warned) {
+                        merror("%s: WARN: Dropping archive events: archive queue full "
+                               "(logall best-effort under backlog).", ARGV0);
+                        archive_drop_warned = 1;
+                    }
+                }
+            }
+        } else
+#endif
+        {
+            OS_Store(lf);
+            if (Config.logall_json) {
+                jsonout_output_archive(lf);
+            }
+        }
+    } else if (Config.logall_json) {
+        jsonout_output_archive(lf);
+    }
+
+    return owned_by_writer;
+}
+
+void analysisd_finish_event(Eventinfo *lf)
+{
+    if (lf && lf->generated_rule == NULL) {
+        Free_Eventinfo(lf);
+    }
+}

--- a/src/analysisd/analysisd_stages.c
+++ b/src/analysisd/analysisd_stages.c
@@ -48,8 +48,23 @@ extern os_queue *writer_queue_log;
 extern os_queue *writer_queue_statistical;
 extern os_queue *writer_queue_archive;
 extern os_queue *writer_queue_firewall;
-static int archive_drop_warned = 0;
+static time_t archive_drop_last_warn = 0;
 static pthread_mutex_t hour_rollover_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+#define ANALYSISD_ARCHIVE_DROP_WARN_INTERVAL_SEC 30
+
+static void analysisd_warn_archive_dropped(void)
+{
+    time_t now = time(NULL);
+
+    if (archive_drop_last_warn != 0 &&
+        (now - archive_drop_last_warn) < ANALYSISD_ARCHIVE_DROP_WARN_INTERVAL_SEC) {
+        return;
+    }
+    archive_drop_last_warn = now;
+    merror("%s: WARN: Dropping archive events: archive queue full "
+           "(logall best-effort under backlog).", ARGV0);
+}
 
 /* Snapshot leftover rule->last_events onto the async alert copy (fallback if
  * Search/doDiff already moved context onto the live event). Then clear the
@@ -107,6 +122,9 @@ void analysisd_set_time_context(Eventinfo *lf)
     c_time = lf->time;
     p = localtime_r(&c_time, &tm_buf);
     if (!p) {
+        /* Invalid sentinels so callers do not reuse a prior event's time. */
+        __crt_hour = -1;
+        __crt_wday = -1;
         return;
     }
     __crt_hour = p->tm_hour;
@@ -234,44 +252,61 @@ int analysisd_analyze_event(Eventinfo *lf)
 
     /* Check_Hour excessive-events alerts use a dedicated statistical writer so
      * they do not contend with the normal alerts queue (Nested parity). */
-    if (Config.stats && Check_Hour() == 1 && analysisd_stats_rule) {
-        RuleInfo *saved_rule = lf->generated_rule;
-        char *saved_log = lf->full_log;
+    {
+        char stats_comment[192];
 
-        lf->generated_rule = analysisd_stats_rule;
-        lf->full_log = __stats_comment;
+        if (Config.stats && Check_Hour(stats_comment, sizeof(stats_comment)) == 1 &&
+            analysisd_stats_rule) {
+            RuleInfo *saved_rule = lf->generated_rule;
+            char *saved_log = lf->full_log;
 
-        if (analysisd_stats_rule->alert_opts & DO_LOGALERT) {
+            lf->generated_rule = analysisd_stats_rule;
+            lf->full_log = stats_comment;
+
+            if (analysisd_stats_rule->alert_opts & DO_LOGALERT) {
 #ifndef WIN32
-            if (writer_queue_statistical) {
-                Eventinfo *alert_copy;
+                if (writer_queue_statistical) {
+                    Eventinfo *alert_copy;
 
-                lf->alert_id = analysisd_claim_alert_id();
-                alert_copy = analysisd_copy_event_for_log(lf);
-                if (alert_copy) {
-                    analysisd_snapshot_rule_last_events(alert_copy, analysisd_stats_rule);
-                    if (analysisd_enqueue_statistical(alert_copy) != 0) {
-                        Free_Eventinfo(alert_copy);
+                    lf->alert_id = analysisd_claim_alert_id();
+                    alert_copy = analysisd_copy_event_for_log(lf);
+                    if (alert_copy) {
+                        analysisd_snapshot_rule_last_events(alert_copy, analysisd_stats_rule);
+                        if (analysisd_enqueue_statistical(alert_copy) != 0) {
+                            Free_Eventinfo(alert_copy);
+                            analysisd_inc_alerts_dropped();
+                        }
+                    } else {
                         analysisd_inc_alerts_dropped();
                     }
-                }
-            } else
+                } else
 #endif
-            {
-                __crt_ftell = _aflog ? ftell(_aflog) : 0;
-                if (Config.custom_alert_output) {
-                    OS_CustomLog(lf, Config.custom_alert_output_format);
-                } else {
-                    OS_Log(lf);
-                }
-                if (Config.jsonout_output) {
-                    jsonout_output_event(lf);
+                {
+#ifndef WIN32
+                    if (!lf->alert_id) {
+                        lf->alert_id = analysisd_claim_alert_id();
+                    }
+                    __crt_ftell = lf->alert_id;
+#else
+                    analysisd_log_io_lock();
+                    __crt_ftell = _aflog ? ftell(_aflog) : 0;
+                    lf->alert_id = __crt_ftell;
+                    analysisd_log_io_unlock();
+#endif
+                    if (Config.custom_alert_output) {
+                        OS_CustomLog(lf, Config.custom_alert_output_format);
+                    } else {
+                        OS_Log(lf);
+                    }
+                    if (Config.jsonout_output) {
+                        jsonout_output_event(lf);
+                    }
                 }
             }
-        }
 
-        lf->generated_rule = saved_rule;
-        lf->full_log = saved_log;
+            lf->generated_rule = saved_rule;
+            lf->full_log = saved_log;
+        }
     }
 
     DEBUG_MSG("%s: DEBUG: Checking the rules - %d ", ARGV0, lf->decoder_info->type);
@@ -338,11 +373,25 @@ int analysisd_analyze_event(Eventinfo *lf)
                         Free_Eventinfo(alert_copy);
                         analysisd_inc_alerts_dropped();
                     }
+                } else {
+                    analysisd_inc_alerts_dropped();
+                    merror("%s: WARN: Dropping alert: failed to copy event for async write.",
+                           ARGV0);
                 }
             } else
 #endif
             {
+#ifndef WIN32
+                if (!lf->alert_id) {
+                    lf->alert_id = analysisd_claim_alert_id();
+                }
+                __crt_ftell = lf->alert_id;
+#else
+                analysisd_log_io_lock();
                 __crt_ftell = _aflog ? ftell(_aflog) : 0;
+                lf->alert_id = __crt_ftell;
+                analysisd_log_io_unlock();
+#endif
                 if (Config.custom_alert_output) {
                     OS_CustomLog(lf, Config.custom_alert_output_format);
                 } else {
@@ -371,6 +420,13 @@ int analysisd_analyze_event(Eventinfo *lf)
 
         if (currently_rule->ar) {
             active_response **rule_ar = currently_rule->ar;
+
+#ifndef WIN32
+            /* AR-only rules never claimed an ID on the log path. */
+            if (!lf->alert_id) {
+                lf->alert_id = analysisd_claim_alert_id();
+            }
+#endif
 
             while (*rule_ar) {
                 int do_ar = 1;
@@ -440,11 +496,7 @@ int analysisd_analyze_event(Eventinfo *lf)
                     owned_by_writer = 1;
                 } else {
                     analysisd_inc_archives_dropped();
-                    if (!archive_drop_warned) {
-                        merror("%s: WARN: Dropping archive events: archive queue full "
-                               "(logall best-effort under backlog).", ARGV0);
-                        archive_drop_warned = 1;
-                    }
+                    analysisd_warn_archive_dropped();
                 }
             } else {
                 Eventinfo *arch_copy = analysisd_copy_event_for_log(lf);
@@ -452,11 +504,10 @@ int analysisd_analyze_event(Eventinfo *lf)
                 if (arch_copy && os_queue_push_ex(writer_queue_archive, arch_copy) != 0) {
                     Free_Eventinfo(arch_copy);
                     analysisd_inc_archives_dropped();
-                    if (!archive_drop_warned) {
-                        merror("%s: WARN: Dropping archive events: archive queue full "
-                               "(logall best-effort under backlog).", ARGV0);
-                        archive_drop_warned = 1;
-                    }
+                    analysisd_warn_archive_dropped();
+                } else if (!arch_copy) {
+                    analysisd_inc_archives_dropped();
+                    analysisd_warn_archive_dropped();
                 }
             }
         } else

--- a/src/analysisd/analysisd_stages.c
+++ b/src/analysisd/analysisd_stages.c
@@ -106,6 +106,9 @@ void analysisd_set_time_context(Eventinfo *lf)
 
     c_time = lf->time;
     p = localtime_r(&c_time, &tm_buf);
+    if (!p) {
+        return;
+    }
     __crt_hour = p->tm_hour;
     __crt_wday = p->tm_wday;
 }

--- a/src/analysisd/cleanevent.c
+++ b/src/analysisd/cleanevent.c
@@ -24,8 +24,14 @@ static const char *(month[]) = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
 /* Format a received message in the Eventinfo structure */
 int OS_CleanMSG(char *msg, Eventinfo *lf)
 {
+    return OS_CleanMSG_ex(msg, lf, c_time, 1);
+}
+
+int OS_CleanMSG_ex(char *msg, Eventinfo *lf, time_t recv_time, int update_time_globals)
+{
     size_t loglen;
     char *pieces;
+    struct tm tm_buf;
     struct tm *p;
 
     /* The message is formatted in the following way:
@@ -551,8 +557,8 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
     }
 
     /* Set up the event data */
-    lf->time = c_time;
-    p = localtime(&c_time);
+    lf->time = recv_time;
+    p = localtime_r(&recv_time, &tm_buf);
 
     /* Assign hour, day, year and month values */
     lf->day = p->tm_mday;
@@ -563,9 +569,11 @@ int OS_CleanMSG(char *msg, Eventinfo *lf)
              p->tm_min,
              p->tm_sec);
 
-    /* Set the global hour/weekday */
-    __crt_hour = p->tm_hour;
-    __crt_wday = p->tm_wday;
+    if (update_time_globals) {
+        c_time = recv_time;
+        __crt_hour = p->tm_hour;
+        __crt_wday = p->tm_wday;
+    }
 
 #ifdef TESTRULE
     if (!alert_only) {

--- a/src/analysisd/cleanevent.h
+++ b/src/analysisd/cleanevent.h
@@ -13,6 +13,7 @@
 #include "eventinfo.h"
 
 int OS_CleanMSG(char *msg, Eventinfo *lf);
+int OS_CleanMSG_ex(char *msg, Eventinfo *lf, time_t recv_time, int update_time_globals);
 
 
 #endif /* _CLEANEVENT_H_ */

--- a/src/analysisd/correlation_shard.c
+++ b/src/analysisd/correlation_shard.c
@@ -1,0 +1,46 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * Location-hash shards isolate Search_LastEvents / EventList history per
+ * agent location (or hostname). Cross-agent frequency/context must use
+ * if_matched_sid / if_matched_group (global sid lists under rule->mutex).
+ * Stock brute-force rules that use if_matched_sid remain correct; pure
+ * context+frequency rules only correlate within a single location shard.
+ *
+ * Migration checklist (rule_matching_threads > 1):
+ * 1. Inventory frequency/context rules that expect events from multiple agents.
+ * 2. Prefer if_matched_sid / if_matched_group for those patterns.
+ * 3. Keep pure Search_LastEvents rules when correlation is intentionally local.
+ * 4. Cover cross-agent sid lists with regressions (issue_correlation_agent_shard).
+ */
+
+#ifndef WIN32
+
+#include "shared.h"
+#include "correlation_shard.h"
+#include "eventinfo.h"
+
+unsigned int analysisd_shard_id(const Eventinfo *lf, unsigned int nshards)
+{
+    const char *key;
+    unsigned int h = 5381;
+    unsigned char c;
+
+    if (nshards <= 1) {
+        return 0;
+    }
+
+    key = lf && lf->location ? lf->location : (lf && lf->hostname ? lf->hostname : "");
+    while ((c = (unsigned char)*key++) != '\0') {
+        h = ((h << 5) + h) + c;
+    }
+
+    return h % nshards;
+}
+
+#endif /* !WIN32 */

--- a/src/analysisd/correlation_shard.h
+++ b/src/analysisd/correlation_shard.h
@@ -1,0 +1,30 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef ANALYSISD_CORRELATION_SHARD_H
+#define ANALYSISD_CORRELATION_SHARD_H
+
+#include "eventinfo.h"
+
+#ifndef WIN32
+
+/* Hash location (or hostname) into [0, nshards). Exceeds nested's single
+ * contended EventList by giving each process worker a private list. */
+unsigned int analysisd_shard_id(const Eventinfo *lf, unsigned int nshards);
+
+EventList *OS_EventList_Create(int maxsize);
+void OS_EventList_Destroy(EventList *list);
+void analysisd_set_event_list(EventList *list);
+EventList *analysisd_get_event_list(void);
+
+/* Accumulate store TLS setters live in accumulator.h; pipeline includes both. */
+
+#endif /* !WIN32 */
+
+#endif /* ANALYSISD_CORRELATION_SHARD_H */

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -17,7 +17,29 @@
 
 
 /* Use the osdecoders to decode the received event */
-void DecodeEvent(Eventinfo *lf)
+static char **decoder_regex_substrings(OSRegex *regex)
+{
+    regex_matching *match = os_regex_get_thread_match();
+
+    if (match) {
+        return match->sub_strings;
+    }
+
+    return regex->sub_strings;
+}
+
+static char **decoder_pcre2_substrings(OSPcre2 *pcre2)
+{
+    regex_matching *match = os_regex_get_thread_match();
+
+    if (match) {
+        return match->sub_strings;
+    }
+
+    return pcre2->sub_strings;
+}
+
+void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
 {
     OSDecoderNode *node;
     OSDecoderNode *child_node;
@@ -27,6 +49,9 @@ void DecodeEvent(Eventinfo *lf)
     const char *pmatch = NULL;
     const char *cmatch = NULL;
     const char *regex_prev = NULL;
+    char **capture_strings;
+
+    os_regex_set_thread_match(decoder_match);
 
     node = OS_GetFirstOSDecoder(lf->program_name);
 
@@ -198,18 +223,19 @@ void DecodeEvent(Eventinfo *lf)
 
                 lf->decoder_info = nnode;
 
-                for (i = 0; nnode->regex->sub_strings[i]; i++) {
+                capture_strings = decoder_regex_substrings(nnode->regex);
+                for (i = 0; capture_strings && capture_strings[i]; i++) {
                     if (i >= Config.decoder_order_size) {
                         ErrorExit("%s: ERROR: Regex has too many groups.", ARGV0);
                     }
 
                     if (nnode->order[i])
-                        nnode->order[i](lf, nnode->regex->sub_strings[i], i);
+                        nnode->order[i](lf, capture_strings[i], i);
                     else
                         /* We do not free any memory used above */
-                        os_free(nnode->regex->sub_strings[i]);
+                        os_free(capture_strings[i]);
 
-                    nnode->regex->sub_strings[i] = NULL;
+                    capture_strings[i] = NULL;
                 }
 
                 /* If we have a next regex, try getting it */
@@ -260,18 +286,19 @@ void DecodeEvent(Eventinfo *lf)
 
                 lf->decoder_info = nnode;
 
-                for (i = 0; nnode->pcre2->sub_strings[i]; i++) {
+                capture_strings = decoder_pcre2_substrings(nnode->pcre2);
+                for (i = 0; capture_strings && capture_strings[i]; i++) {
                     if (i >= Config.decoder_order_size) {
                         ErrorExit("%s: ERROR: Regex has too many groups.", ARGV0);
                     }
 
                     if (nnode->order[i])
-                        nnode->order[i](lf, nnode->pcre2->sub_strings[i], i);
+                        nnode->order[i](lf, capture_strings[i], i);
                     else
                         /* We do not free any memory used above */
-                        os_free(nnode->pcre2->sub_strings[i]);
+                        os_free(capture_strings[i]);
 
-                    nnode->pcre2->sub_strings[i] = NULL;
+                    capture_strings[i] = NULL;
                 }
 
                 /* If we have a next regex, try getting it */
@@ -299,9 +326,10 @@ void DecodeEvent(Eventinfo *lf)
         print_out("       No decoder matched.");
     }
 #endif
-    return;
+    goto out;
 
 out:
+    os_regex_set_thread_match(NULL);
 #ifdef TESTRULE
     if (!alert_only && lf->decoder_info) {
         print_out("       decoder: '%s'", lf->decoder_info->name);

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -56,7 +56,7 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
     node = OS_GetFirstOSDecoder(lf->program_name);
 
     if (!node) {
-        return;
+        goto out;
     }
 
 #ifdef TESTRULE
@@ -160,7 +160,7 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
                     } while (child_node && child_node->osdecoder->get_next);
 
                     if (!child_node) {
-                        return;
+                        goto out;
                     }
 
                     child_node = child_node->next;
@@ -174,7 +174,7 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
 
         /* Nothing matched */
         if (!nnode) {
-            return;
+            goto out;
         }
 
         /* If we have an external decoder, execute it */

--- a/src/analysisd/decoders/hostinfo.c
+++ b/src/analysisd/decoders/hostinfo.c
@@ -11,6 +11,7 @@
 #include "decoder.h"
 
 #include "config.h"
+#include "shared.h"
 #include "os_regex/os_regex.h"
 #include "eventinfo.h"
 #include "alerts/alerts.h"
@@ -28,6 +29,9 @@ static int id_new = 0;
 static int id_mod = 0;
 static char _hi_buf[OS_MAXSTR + 1];
 static FILE *_hi_fp = NULL;
+#ifndef WIN32
+static pthread_mutex_t hostinfo_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
 
 /* Hostinfo decoder */
 static OSDecoderInfo *hostinfo_dec = NULL;
@@ -114,7 +118,7 @@ static FILE *HI_File(void)
  * Not using the default rendering tools for simplicity
  * and to be less resource intensive
  */
-int DecodeHostinfo(Eventinfo *lf)
+static int DecodeHostinfo_unlocked(Eventinfo *lf)
 {
     int changed = 0;
     size_t bf_size;
@@ -220,5 +224,19 @@ int DecodeHostinfo(Eventinfo *lf)
     }
 
     return (1);
+}
+
+int DecodeHostinfo(Eventinfo *lf)
+{
+    int result;
+
+#ifndef WIN32
+    os_mutex_lock(&hostinfo_mutex);
+#endif
+    result = DecodeHostinfo_unlocked(lf);
+#ifndef WIN32
+    os_mutex_unlock(&hostinfo_mutex);
+#endif
+    return result;
 }
 

--- a/src/analysisd/decoders/rootcheck.c
+++ b/src/analysisd/decoders/rootcheck.c
@@ -10,6 +10,7 @@
 /* Rootcheck decoder */
 
 #include "config.h"
+#include "shared.h"
 #include "os_regex/os_regex.h"
 #include "eventinfo.h"
 #include "alerts/alerts.h"
@@ -21,10 +22,32 @@
 static char *rk_agent_ips[MAX_AGENTS];
 static FILE *rk_agent_fps[MAX_AGENTS];
 static int rk_err;
+#ifndef WIN32
+/* Table mutex: agent slot alloc / lookup. Per-agent mutex: FILE* I/O. */
+static pthread_mutex_t rk_table_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t rk_agent_mutex[MAX_AGENTS];
+static int rk_agent_mutex_ready = 0;
+#endif
 
-/* Rootcheck decoder */
-static OSDecoderInfo *rootcheck_dec = NULL;
+/* Rootcheck decoder template (shared id/name/type). Per-thread copy holds fts. */
+static OSDecoderInfo *rootcheck_dec_tmpl = NULL;
+#ifndef WIN32
+static __thread OSDecoderInfo rk_dec_tls;
+static __thread int rk_dec_tls_ready = 0;
+#endif
 
+static OSDecoderInfo *rootcheck_decoder_for_event(void)
+{
+#ifndef WIN32
+    if (!rk_dec_tls_ready && rootcheck_dec_tmpl) {
+        rk_dec_tls = *rootcheck_dec_tmpl;
+        rk_dec_tls_ready = 1;
+    }
+    return &rk_dec_tls;
+#else
+    return rootcheck_dec_tmpl;
+#endif
+}
 
 /* Initialize the necessary information to process the rootcheck information */
 void RootcheckInit()
@@ -36,14 +59,20 @@ void RootcheckInit()
     for (; i < MAX_AGENTS; i++) {
         rk_agent_ips[i] = NULL;
         rk_agent_fps[i] = NULL;
+#ifndef WIN32
+        os_mutex_init(&rk_agent_mutex[i], NULL);
+#endif
     }
+#ifndef WIN32
+    rk_agent_mutex_ready = 1;
+#endif
 
-    /* Zero decoder */
-    os_calloc(1, sizeof(OSDecoderInfo), rootcheck_dec);
-    rootcheck_dec->id = getDecoderfromlist(ROOTCHECK_MOD);
-    rootcheck_dec->type = OSSEC_RL;
-    rootcheck_dec->name = ROOTCHECK_MOD;
-    rootcheck_dec->fts = 0;
+    /* Template decoder — workers use a TLS copy so fts is not shared. */
+    os_calloc(1, sizeof(OSDecoderInfo), rootcheck_dec_tmpl);
+    rootcheck_dec_tmpl->id = getDecoderfromlist(ROOTCHECK_MOD);
+    rootcheck_dec_tmpl->type = OSSEC_RL;
+    rootcheck_dec_tmpl->name = ROOTCHECK_MOD;
+    rootcheck_dec_tmpl->fts = 0;
 
     debug1("%s: RootcheckInit completed.", ARGV0);
 
@@ -116,29 +145,16 @@ static FILE *RK_File(const char *agent, int *agent_id)
  * Not using the default rendering tools for simplicity
  * and to be less resource intensive
  */
-int DecodeRootcheck(Eventinfo *lf)
+static int DecodeRootcheck_with_fp(Eventinfo *lf, FILE *fp)
 {
-    int agent_id;
-
     char *tmpstr;
     char rk_buf[OS_SIZE_2048 + 1];
-
-    FILE *fp;
-
     fpos_t fp_pos;
+    OSDecoderInfo *rk_dec = rootcheck_decoder_for_event();
 
     /* Zero rk_buf */
     rk_buf[0] = '\0';
     rk_buf[OS_SIZE_2048] = '\0';
-
-    fp = RK_File(lf->location, &agent_id);
-
-    if (!fp) {
-        merror("%s: Error handling rootcheck database.", ARGV0);
-        rk_err++;
-
-        return (0);
-    }
 
     /* Get initial position */
     if (fgetpos(fp, &fp_pos) == -1) {
@@ -169,8 +185,8 @@ int DecodeRootcheck(Eventinfo *lf)
         if (rk_buf[0] != '!') {
             /* Cannot use strncmp to avoid errors with crafted files */
             if (strcmp(lf->log, rk_buf) == 0) {
-                rootcheck_dec->fts = 0;
-                lf->decoder_info = rootcheck_dec;
+                rk_dec->fts = 0;
+                lf->decoder_info = rk_dec;
                 return (1);
             }
         }
@@ -187,8 +203,8 @@ int DecodeRootcheck(Eventinfo *lf)
                     return (0);
                 }
                 fprintf(fp, "!%ld", (long int)lf->time);
-                rootcheck_dec->fts = 0;
-                lf->decoder_info = rootcheck_dec;
+                rk_dec->fts = 0;
+                lf->decoder_info = rk_dec;
                 return (1);
             }
         }
@@ -205,9 +221,42 @@ int DecodeRootcheck(Eventinfo *lf)
     fprintf(fp, "!%ld!%ld %s\n", (long int)lf->time, (long int)lf->time, lf->log);
     fflush(fp);
 
-    rootcheck_dec->fts = 0;
-    rootcheck_dec->fts |= FTS_DONE;
-    lf->decoder_info = rootcheck_dec;
+    rk_dec->fts = 0;
+    rk_dec->fts |= FTS_DONE;
+    lf->decoder_info = rk_dec;
     return (1);
+}
+
+int DecodeRootcheck(Eventinfo *lf)
+{
+    int result;
+    int agent_id = -1;
+    FILE *fp;
+
+#ifndef WIN32
+    os_mutex_lock(&rk_table_mutex);
+#endif
+    fp = RK_File(lf->location, &agent_id);
+    if (!fp) {
+#ifndef WIN32
+        os_mutex_unlock(&rk_table_mutex);
+#endif
+        merror("%s: Error handling rootcheck database.", ARGV0);
+        rk_err++;
+        return (0);
+    }
+
+#ifndef WIN32
+    /* Lock the agent FILE before releasing the table (finer than global lock). */
+    os_mutex_lock(&rk_agent_mutex[agent_id]);
+    os_mutex_unlock(&rk_table_mutex);
+#endif
+
+    result = DecodeRootcheck_with_fp(lf, fp);
+
+#ifndef WIN32
+    os_mutex_unlock(&rk_agent_mutex[agent_id]);
+#endif
+    return result;
 }
 

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -36,11 +36,6 @@ typedef struct __sdb {
     char sha1[OS_FLSIZE + 1];
     char sha256[OS_FLSIZE + 1];
 
-    char agent_cp[MAX_AGENTS + 1][1];
-    char *agent_ips[MAX_AGENTS + 1];
-    FILE *agent_fps[MAX_AGENTS + 1];
-    OSHash *agent_index[MAX_AGENTS + 1];
-
     int db_err;
 
     /* Ids for decoder */
@@ -56,10 +51,24 @@ typedef struct __sdb {
     /* File search variables */
     fpos_t init_pos;
 
-} _sdb; /* syscheck db information */
+} _sdb; /* per-thread working buffers / decoder ids */
 
-/* Local variables */
-static _sdb sdb;
+/* Per-thread comment/decode buffers (safe under parallel decode workers). */
+static __thread _sdb sdb;
+
+/*
+ * Shared agent integrity DB table — process-global so concurrent syscheck
+ * workers serialize FILE* / hash-index mutations for the same agent.
+ */
+static char sk_agent_cp[MAX_AGENTS + 1][1];
+static char *sk_agent_ips[MAX_AGENTS + 1];
+static FILE *sk_agent_fps[MAX_AGENTS + 1];
+static OSHash *sk_agent_index[MAX_AGENTS + 1];
+#ifndef WIN32
+static pthread_mutex_t sk_table_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t sk_agent_mutex[MAX_AGENTS + 1];
+static int sk_shared_ready = 0;
+#endif
 
 /* Extract a token from a string */
 char *extract_token(const char *s, char *delim, int position) {
@@ -100,14 +109,7 @@ void SyscheckInit()
 
     sdb.db_err = 0;
 
-    for (; i <= MAX_AGENTS; i++) {
-        sdb.agent_ips[i] = NULL;
-        sdb.agent_fps[i] = NULL;
-        sdb.agent_index[i] = NULL;
-        sdb.agent_cp[i][0] = '0';
-    }
-
-    /* Clear db memory */
+    /* Clear per-thread working buffers */
     memset(sdb.buf, '\0', OS_MAXSTR + 1);
     memset(sdb.comment, '\0', OS_MAXSTR + 1);
 
@@ -119,7 +121,7 @@ void SyscheckInit()
     memset(sdb.sha1, '\0', OS_FLSIZE + 1);
     memset(sdb.sha256, '\0', OS_FLSIZE + 1);
 
-    /* Create decoder */
+    /* Create decoder (TLS — each worker owns its own) */
     os_calloc(1, sizeof(OSDecoderInfo), sdb.syscheck_dec);
     sdb.syscheck_dec->id = getDecoderfromlist(SYSCHECK_MOD);
     sdb.syscheck_dec->name = SYSCHECK_MOD;
@@ -132,12 +134,35 @@ void SyscheckInit()
     sdb.idn = getDecoderfromlist(SYSCHECK_NEW);
     sdb.idd = getDecoderfromlist(SYSCHECK_DEL);
 
+#ifndef WIN32
+    /* Shared agent table + locks: once per process (workers each call Init). */
+    os_mutex_lock(&sk_table_mutex);
+    if (!sk_shared_ready) {
+        for (i = 0; i <= MAX_AGENTS; i++) {
+            sk_agent_ips[i] = NULL;
+            sk_agent_fps[i] = NULL;
+            sk_agent_index[i] = NULL;
+            sk_agent_cp[i][0] = '0';
+            os_mutex_init(&sk_agent_mutex[i], NULL);
+        }
+        sk_shared_ready = 1;
+    }
+    os_mutex_unlock(&sk_table_mutex);
+#else
+    for (i = 0; i <= MAX_AGENTS; i++) {
+        sk_agent_ips[i] = NULL;
+        sk_agent_fps[i] = NULL;
+        sk_agent_index[i] = NULL;
+        sk_agent_cp[i][0] = '0';
+    }
+#endif
+
     debug1("%s: SyscheckInit completed.", ARGV0);
     return;
 }
 
 /* Check if the db is completed for that specific agent */
-#define DB_IsCompleted(x) (sdb.agent_cp[x][0] == '1')?1:0
+#define DB_IsCompleted(x) (sk_agent_cp[x][0] == '1')?1:0
 
 static void __setcompleted(const char *agent)
 {
@@ -173,38 +198,67 @@ static void DB_SetCompleted(const Eventinfo *lf)
 {
     int i = 0;
 
+#ifndef WIN32
+    os_mutex_lock(&sk_table_mutex);
+#endif
+
     /* Find file pointer */
-    while (sdb.agent_ips[i] != NULL &&  i < MAX_AGENTS) {
-        if (strcmp(sdb.agent_ips[i], lf->location) == 0) {
+    while (sk_agent_ips[i] != NULL &&  i < MAX_AGENTS) {
+        if (strcmp(sk_agent_ips[i], lf->location) == 0) {
             /* Return if already set as completed */
             if (DB_IsCompleted(i)) {
+#ifndef WIN32
+                os_mutex_unlock(&sk_table_mutex);
+#endif
                 return;
             }
 
+#ifndef WIN32
+            os_mutex_lock(&sk_agent_mutex[i]);
+            os_mutex_unlock(&sk_table_mutex);
+#endif
             __setcompleted(lf->location);
 
             /* Set as completed in memory */
-            sdb.agent_cp[i][0] = '1';
+            sk_agent_cp[i][0] = '1';
+#ifndef WIN32
+            os_mutex_unlock(&sk_agent_mutex[i]);
+#endif
             return;
         }
 
         i++;
     }
+
+#ifndef WIN32
+    os_mutex_unlock(&sk_table_mutex);
+#endif
 }
 
 
-/* Return the file pointer to be used to verify the integrity */
+/* Return the file pointer to be used to verify the integrity.
+ * On success (non-WIN32), the matching sk_agent_mutex[agent_id] is held;
+ * caller must unlock it when finished with FILE I/O.
+ */
 static FILE *DB_File(const char *agent, int *agent_id)
 {
     int i = 0;
 
+#ifndef WIN32
+    os_mutex_lock(&sk_table_mutex);
+#endif
+
     /* Find file pointer */
-    while (sdb.agent_ips[i] != NULL  &&  i < MAX_AGENTS) {
-        if (strcmp(sdb.agent_ips[i], agent) == 0) {
+    while (sk_agent_ips[i] != NULL  &&  i < MAX_AGENTS) {
+        if (strcmp(sk_agent_ips[i], agent) == 0) {
+#ifndef WIN32
+            os_mutex_lock(&sk_agent_mutex[i]);
+            os_mutex_unlock(&sk_table_mutex);
+#endif
             /* Point to the beginning of the file */
-            fseek(sdb.agent_fps[i], 0, SEEK_SET);
+            fseek(sk_agent_fps[i], 0, SEEK_SET);
             *agent_id = i;
-            return (sdb.agent_fps[i]);
+            return (sk_agent_fps[i]);
         }
 
         i++;
@@ -212,45 +266,56 @@ static FILE *DB_File(const char *agent, int *agent_id)
 
     /* If here, our agent wasn't found */
     if (i == MAX_AGENTS) {
+#ifndef WIN32
+        os_mutex_unlock(&sk_table_mutex);
+#endif
         merror("%s: Unable to open integrity file. Increase MAX_AGENTS.", ARGV0);
         return (NULL);
     }
 
-    os_strdup(agent, sdb.agent_ips[i]);
+    os_strdup(agent, sk_agent_ips[i]);
 
     /* Get agent file */
     snprintf(sdb.buf, OS_FLSIZE , "%s/%s", SYSCHECK_DIR, agent);
 
     /* r+ to read and write. Do not truncate */
-    sdb.agent_fps[i] = fopen(sdb.buf, "r+");
-    if (!sdb.agent_fps[i]) {
+    sk_agent_fps[i] = fopen(sdb.buf, "r+");
+    if (!sk_agent_fps[i]) {
         /* Try opening with a w flag, file probably does not exist */
-        sdb.agent_fps[i] = fopen(sdb.buf, "w");
-        if (sdb.agent_fps[i]) {
-            fclose(sdb.agent_fps[i]);
-            sdb.agent_fps[i] = fopen(sdb.buf, "r+");
+        sk_agent_fps[i] = fopen(sdb.buf, "w");
+        if (sk_agent_fps[i]) {
+            fclose(sk_agent_fps[i]);
+            sk_agent_fps[i] = fopen(sdb.buf, "r+");
         }
     }
 
     /* Check again */
-    if (!sdb.agent_fps[i]) {
+    if (!sk_agent_fps[i]) {
         merror("%s: Unable to open '%s'", ARGV0, sdb.buf);
 
-        free(sdb.agent_ips[i]);
-        sdb.agent_ips[i] = NULL;
+        free(sk_agent_ips[i]);
+        sk_agent_ips[i] = NULL;
+#ifndef WIN32
+        os_mutex_unlock(&sk_table_mutex);
+#endif
         return (NULL);
     }
 
     /* Return the opened pointer (the beginning of it) */
-    fseek(sdb.agent_fps[i], 0, SEEK_SET);
+    fseek(sk_agent_fps[i], 0, SEEK_SET);
     *agent_id = i;
 
     /* Check if the agent was completed */
     if (__iscompleted(agent)) {
-        sdb.agent_cp[i][0] = '1';
+        sk_agent_cp[i][0] = '1';
     }
 
-    return (sdb.agent_fps[i]);
+#ifndef WIN32
+    os_mutex_lock(&sk_agent_mutex[i]);
+    os_mutex_unlock(&sk_table_mutex);
+#endif
+
+    return (sk_agent_fps[i]);
 }
 
 /* Parse a syscheck db line and return the filename within line_buf. */
@@ -292,17 +357,17 @@ static void DB_BuildIndex(int agent_id, FILE *fp)
     fpos_t line_pos;
     char line_copy[OS_MAXSTR + 1];
 
-    if (sdb.agent_index[agent_id] != NULL) {
+    if (sk_agent_index[agent_id] != NULL) {
         return;
     }
 
-    sdb.agent_index[agent_id] = OSHash_Create();
-    if (!sdb.agent_index[agent_id]) {
+    sk_agent_index[agent_id] = OSHash_Create();
+    if (!sk_agent_index[agent_id]) {
         merror("%s: Unable to create syscheck index for agent.", ARGV0);
         return;
     }
 
-    if (!OSHash_setSize(sdb.agent_index[agent_id], 4096)) {
+    if (!OSHash_setSize(sk_agent_index[agent_id], 4096)) {
         merror("%s: Unable to size syscheck index for agent.", ARGV0);
     }
 
@@ -321,13 +386,13 @@ static void DB_BuildIndex(int agent_id, FILE *fp)
             continue;
         }
 
-        ent = (sk_db_entry *)OSHash_Get(sdb.agent_index[agent_id], fname);
+        ent = (sk_db_entry *)OSHash_Get(sk_agent_index[agent_id], fname);
         if (!ent) {
             ent = (sk_db_entry *)calloc(1, sizeof(sk_db_entry));
             if (!ent) {
                 continue;
             }
-            if (OSHash_Add(sdb.agent_index[agent_id], fname, ent) != 2) {
+            if (OSHash_Add(sk_agent_index[agent_id], fname, ent) != 2) {
                 free(ent);
                 continue;
             }
@@ -347,11 +412,11 @@ static sk_db_entry *DB_GetOrCreateIndexEntry(int agent_id, const char *f_name)
 {
     sk_db_entry *ent;
 
-    if (!sdb.agent_index[agent_id]) {
+    if (!sk_agent_index[agent_id]) {
         return (NULL);
     }
 
-    ent = (sk_db_entry *)OSHash_Get(sdb.agent_index[agent_id], f_name);
+    ent = (sk_db_entry *)OSHash_Get(sk_agent_index[agent_id], f_name);
     if (ent) {
         return (ent);
     }
@@ -361,7 +426,7 @@ static sk_db_entry *DB_GetOrCreateIndexEntry(int agent_id, const char *f_name)
         return (NULL);
     }
 
-    if (OSHash_Add(sdb.agent_index[agent_id], f_name, ent) != 2) {
+    if (OSHash_Add(sk_agent_index[agent_id], f_name, ent) != 2) {
         free(ent);
         return (NULL);
     }
@@ -744,15 +809,13 @@ static int DB_SearchLinear(const char *f_name, const char *c_sum, Eventinfo *lf,
 static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
 {
     int agent_id;
-
+    int result = 0;
     FILE *fp;
 
     /* Expose filename variable for active response */
     os_strdup(f_name, lf->filename);
 
-
-
-    /* Get db pointer */
+    /* Get db pointer (holds sk_agent_mutex[agent_id] on success) */
     fp = DB_File(lf->location, &agent_id);
     if (!fp) {
         merror("%s: Error handling integrity database.", ARGV0);
@@ -767,26 +830,28 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
         sk_db_entry *db_entry = NULL;
         int linear_rc;
 
-        if (sdb.agent_index[agent_id]) {
-            db_entry = (sk_db_entry *)OSHash_Get(sdb.agent_index[agent_id], f_name);
+        if (sk_agent_index[agent_id]) {
+            db_entry = (sk_db_entry *)OSHash_Get(sk_agent_index[agent_id], f_name);
         }
 
         if (db_entry) {
             strncpy(sdb.buf, db_entry->prefix_sum, OS_MAXSTR);
             sdb.buf[OS_MAXSTR] = '\0';
             sdb.init_pos = db_entry->pos;
-            return DB_ProcessFoundEntry(f_name, c_sum, lf, fp, db_entry);
+            result = DB_ProcessFoundEntry(f_name, c_sum, lf, fp, db_entry);
+            goto out;
         }
 
         linear_rc = DB_SearchLinear(f_name, c_sum, lf, fp, agent_id);
         if (linear_rc >= 0) {
-            return (linear_rc);
+            result = linear_rc;
+            goto out;
         }
     }
 
     /* If we reach here, this file is not present in our database */
     fseek(fp, 0, SEEK_END);
-    if (sdb.agent_index[agent_id]) {
+    if (sk_agent_index[agent_id]) {
         sk_db_entry *db_entry = DB_GetOrCreateIndexEntry(agent_id, f_name);
 
         if (db_entry && fgetpos(fp, &db_entry->pos) == 0) {
@@ -899,11 +964,19 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
         lf->decoder_info = sdb.syscheck_dec;
         lf->data = NULL;
 
-        return (1);
+        free(newfilec_sum);
+        result = 1;
+        goto out;
     }
 
     lf->data = NULL;
-    return (0);
+    result = 0;
+
+out:
+#ifndef WIN32
+    os_mutex_unlock(&sk_agent_mutex[agent_id]);
+#endif
+    return (result);
 }
 
 /* Special decoder for syscheck

--- a/src/analysisd/dodiff.c
+++ b/src/analysisd/dodiff.c
@@ -12,6 +12,10 @@
 #include "shared.h"
 #include "eventinfo.h"
 
+#ifndef WIN32
+static pthread_mutex_t do_diff_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
+
 static int _add2last(const char *str, size_t strsize, const char *file)
 {
     FILE *fp;
@@ -73,6 +77,12 @@ int doDiff(RuleInfo *rule, const Eventinfo *lf)
     char *htpt = NULL;
     char flastfile[OS_SIZE_2048 + 1];
     char flastcontent[OS_SIZE_8192 + 1];
+    int result = 0;
+
+#ifndef WIN32
+    os_mutex_lock(&do_diff_mutex);
+    os_mutex_lock(&rule->mutex);
+#endif
 
     /* Clean up global */
     flastcontent[0] = '\0';
@@ -99,7 +109,7 @@ int doDiff(RuleInfo *rule, const Eventinfo *lf)
     /* lf->size can't be too long */
     if (lf->size >= OS_SIZE_8192) {
         merror("%s: ERROR: event size (%ld) too long for diff.", ARGV0, lf->size);
-        return (0);
+        goto out;
     }
 
     /* Check if last diff exists */
@@ -107,16 +117,15 @@ int doDiff(RuleInfo *rule, const Eventinfo *lf)
     if (date_of_change <= 0) {
         if (!_add2last(lf->log, lf->size, flastfile)) {
             merror("%s: ERROR: unable to create last file: %s", ARGV0, flastfile);
-            return (0);
         }
-        return (0);
+        goto out;
     } else {
         FILE *fp;
         size_t n;
         fp = fopen(flastfile, "r");
         if (!fp) {
             merror(FOPEN_ERROR, ARGV0, flastfile, errno, strerror(errno));
-            return (0);
+            goto out;
         }
 
         n = fread(flastcontent, 1, OS_SIZE_8192, fp);
@@ -125,22 +134,31 @@ int doDiff(RuleInfo *rule, const Eventinfo *lf)
         } else {
             merror("%s: ERROR: read error on %s", ARGV0, flastfile);
             fclose(fp);
-            return (0);
+            goto out;
         }
         fclose(fp);
     }
 
     /* Nothing changed */
     if (strcmp(flastcontent, lf->log) == 0) {
-        return (0);
+        goto out;
     }
 
     if (!_add2last(lf->log, lf->size, flastfile)) {
         merror("%s: ERROR: unable to create last file: %s", ARGV0, flastfile);
     }
 
-    rule->last_events[0] = "Previous output:";
-    rule->last_events[1] = flastcontent;
-    return (1);
+    /* Heap-copy last_events then move onto the firing event under the same lock. */
+    OS_SetRuleLastEvent(rule, 0, "Previous output:");
+    OS_SetRuleLastEvent(rule, 1, flastcontent);
+    OS_MoveRuleLastEvents(rule, (Eventinfo *)lf);
+    result = 1;
+
+out:
+#ifndef WIN32
+    os_mutex_unlock(&rule->mutex);
+    os_mutex_unlock(&do_diff_mutex);
+#endif
+    return result;
 }
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -11,6 +11,7 @@
 #include "analysisd.h"
 #include "eventinfo.h"
 #include "os_regex/os_regex.h"
+#include "correlation_shard.h"
 
 /* Global definitions */
 #ifdef TESTRULE
@@ -62,6 +63,31 @@ void OS_SetRuleLastEvent(RuleInfo *rule, int idx, const char *log)
     }
 }
 
+/* Move rule frequency/diff context onto the firing event (caller holds mutex). */
+void OS_MoveRuleLastEvents(RuleInfo *rule, Eventinfo *lf)
+{
+    int i;
+
+    if (!rule || !lf || !rule->last_events || !rule->last_events_copied) {
+        return;
+    }
+
+    if (lf->alert_last_events) {
+        for (i = 0; lf->alert_last_events[i]; i++) {
+            free(lf->alert_last_events[i]);
+        }
+        free(lf->alert_last_events);
+        lf->alert_last_events = NULL;
+    }
+
+    os_calloc(MAX_LAST_EVENTS + 1, sizeof(char *), lf->alert_last_events);
+    for (i = 0; i <= MAX_LAST_EVENTS; i++) {
+        lf->alert_last_events[i] = rule->last_events[i];
+        rule->last_events[i] = NULL;
+    }
+    rule->last_events_copied = 0;
+}
+
 
 /* Search last times a signature fired
  * Will look for only that specific signature.
@@ -70,7 +96,10 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
 {
     Eventinfo *lf;
     Eventinfo *first_lf;
+    Eventinfo *ret = NULL;
     OSListNode *lf_node;
+
+    os_mutex_lock(&rule->mutex);
 
     /* Set frequency to 0 */
     rule->__frequency = 0;
@@ -79,13 +108,13 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
     /* Checking if sid search is valid */
     if (!rule->sid_search) {
         merror("%s: ERROR: No sid search.", ARGV0);
-        return (NULL);
+        goto out;
     }
 
     /* Get last node */
     lf_node = OSList_GetLastNode(rule->sid_search);
     if (!lf_node) {
-        return (NULL);
+        goto out;
     }
     first_lf = (Eventinfo *)lf_node->data;
 
@@ -93,15 +122,15 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
         lf = (Eventinfo *)lf_node->data;
 
         /* If time is outside the timeframe, return */
-        if ((c_time - lf->time) > rule->timeframe) {
-            return (NULL);
+        if ((my_lf->time - lf->time) > rule->timeframe) {
+            goto out;
         }
 
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
         else if (lf->matched >= rule->level) {
-            return (NULL);
+            goto out;
         }
 
         /* Check for same ID */
@@ -197,7 +226,7 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
          * or rules with a lower level.
          */
         else if (lf->matched >= rule->level) {
-            return (NULL);
+            goto out;
         }
 
 
@@ -219,11 +248,17 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
         lf->matched = rule->level;
         first_lf->matched = rule->level;
 
-        return (lf);
+        ret = lf;
+        goto out;
 
     } while ((lf_node = lf_node->prev) != NULL);
 
-    return (NULL);
+out:
+    if (ret) {
+        OS_MoveRuleLastEvents(rule, my_lf);
+    }
+    os_mutex_unlock(&rule->mutex);
+    return ret;
 }
 
 /* Search last times a group fired
@@ -233,7 +268,10 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
 {
     Eventinfo *lf;
     Eventinfo *first_lf;
+    Eventinfo *ret = NULL;
     OSListNode *lf_node;
+
+    os_mutex_lock(&rule->mutex);
 
     /* Set frequency to 0 */
     rule->__frequency = 0;
@@ -242,13 +280,13 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
     /* Check if sid search is valid */
     if (!rule->group_search) {
         merror("%s: No group search!", ARGV0);
-        return (NULL);
+        goto out;
     }
 
     /* Get last node */
     lf_node = OSList_GetLastNode(rule->group_search);
     if (!lf_node) {
-        return (NULL);
+        goto out;
     }
     first_lf = (Eventinfo *)lf_node->data;
 
@@ -256,15 +294,15 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
         lf = (Eventinfo *)lf_node->data;
 
         /* If time is outside the timeframe, return */
-        if ((c_time - lf->time) > rule->timeframe) {
-            return (NULL);
+        if ((my_lf->time - lf->time) > rule->timeframe) {
+            goto out;
         }
 
         /* We avoid multiple triggers for the same rule
          * or rules with a lower level.
          */
         else if (lf->matched >= rule->level) {
-            return (NULL);
+            goto out;
         }
 
         /* Check for same ID */
@@ -362,7 +400,7 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
          * or rules with a lower level.
          */
         else if (lf->matched >= rule->level) {
-            return (NULL);
+            goto out;
         }
 
 
@@ -382,12 +420,18 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
         lf->matched = rule->level;
         first_lf->matched = rule->level;
 
-        return (lf);
+        ret = lf;
+        goto out;
 
 
     } while ((lf_node = lf_node->prev) != NULL);
 
-    return (NULL);
+out:
+    if (ret) {
+        OS_MoveRuleLastEvents(rule, my_lf);
+    }
+    os_mutex_unlock(&rule->mutex);
+    return ret;
 }
 
 
@@ -399,14 +443,19 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
     EventNode *eventnode_pt;
     Eventinfo *lf;
     Eventinfo *first_lf;
+    EventList *elist;
 
+    os_mutex_lock(&rule->mutex);
     rule->__frequency = 0;
     OS_FreeRuleLastEvents(rule);
 
     /* Last events */
-    eventnode_pt = OS_GetLastEvent();
+    elist = analysisd_get_event_list();
+    os_mutex_lock(&elist->mutex);
+    eventnode_pt = OS_GetLastEvent_List(elist);
     if (!eventnode_pt) {
-        /* Nothing found */
+        os_mutex_unlock(&elist->mutex);
+        os_mutex_unlock(&rule->mutex);
         return (NULL);
     }
 
@@ -417,7 +466,9 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
         lf = eventnode_pt->event;
 
         /* If time is outside the timeframe, return */
-        if ((c_time - lf->time) > rule->timeframe) {
+        if ((my_lf->time - lf->time) > rule->timeframe) {
+            os_mutex_unlock(&elist->mutex);
+            os_mutex_unlock(&rule->mutex);
             return (NULL);
         }
 
@@ -425,6 +476,8 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
          * or rules with a lower level.
          */
         else if (lf->matched >= rule->level) {
+            os_mutex_unlock(&elist->mutex);
+            os_mutex_unlock(&rule->mutex);
             return (NULL);
         }
 
@@ -501,6 +554,8 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
          * or rules with a lower level.
          */
         else if (lf->matched >= rule->level) {
+            os_mutex_unlock(&elist->mutex);
+            os_mutex_unlock(&rule->mutex);
             return (NULL);
         }
 
@@ -522,10 +577,15 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
         lf->matched = rule->level;
         first_lf->matched = rule->level;
 
+        OS_MoveRuleLastEvents(rule, my_lf);
+        os_mutex_unlock(&elist->mutex);
+        os_mutex_unlock(&rule->mutex);
         return (lf);
 
     } while ((eventnode_pt = eventnode_pt->next) != NULL);
 
+    os_mutex_unlock(&elist->mutex);
+    os_mutex_unlock(&rule->mutex);
     return (NULL);
 }
 
@@ -583,6 +643,10 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->generated_rule = NULL;
     lf->sid_node_to_delete = NULL;
     lf->decoder_info = NULL_Decoder;
+    lf->alert_last_events = NULL;
+    lf->alert_id = 0;
+    lf->tid = 0;
+    memset(&lf->queue_in_time, 0, sizeof(lf->queue_in_time));
 
     lf->filename = NULL;
     lf->perm_before = 0;
@@ -591,6 +655,8 @@ void Zero_Eventinfo(Eventinfo *lf)
     lf->md5_after = NULL;
     lf->sha1_before = NULL;
     lf->sha1_after = NULL;
+    lf->sha256_before = NULL;
+    lf->sha256_after = NULL;
     lf->size_before = NULL;
     lf->size_after = NULL;
     lf->owner_before = NULL;
@@ -609,9 +675,18 @@ void Free_Eventinfo(Eventinfo *lf)
         return;
     }
 
+    /* full_log is the owned allocation. log usually aliases into it
+     * (CleanMSG dual buffer or syscheck log==full_log). Only free log when
+     * EF_SEPARATE_LOG marks a distinct malloc. */
+    if (lf->log && (lf->flags & EF_SEPARATE_LOG)) {
+        free(lf->log);
+        lf->flags &= ~EF_SEPARATE_LOG;
+    }
     if (lf->full_log) {
         free(lf->full_log);
     }
+    lf->full_log = NULL;
+    lf->log = NULL;
     if (lf->location) {
         free(lf->location);
     }
@@ -695,6 +770,12 @@ void Free_Eventinfo(Eventinfo *lf)
     if (lf->sha1_after) {
         free(lf->sha1_after);
     }
+    if (lf->sha256_before) {
+        free(lf->sha256_before);
+    }
+    if (lf->sha256_after) {
+        free(lf->sha256_after);
+    }
     if (lf->size_before) {
         free(lf->size_before);
     }
@@ -714,16 +795,44 @@ void Free_Eventinfo(Eventinfo *lf)
         free(lf->gowner_after);
     }
 
-    /* Free node to delete */
-    if (lf->sid_node_to_delete) {
-        OSList_DeleteThisNode(lf->generated_rule->sid_prev_matched,
-                              lf->sid_node_to_delete);
-    } else if (lf->generated_rule && lf->generated_rule->group_prev_matched) {
-        unsigned int i = 0;
+    if (lf->alert_last_events) {
+        int i;
+        for (i = 0; lf->alert_last_events[i]; i++) {
+            free(lf->alert_last_events[i]);
+        }
+        free(lf->alert_last_events);
+        lf->alert_last_events = NULL;
+    }
 
-        while (i < lf->generated_rule->group_prev_matched_sz) {
-            OSList_DeleteOldestNode(lf->generated_rule->group_prev_matched[i]);
-            i++;
+    /* Correlation list maintenance belongs to the live event only — async
+     * alert/archive/fw copies must not prune shared group/sid lists. */
+    if (!(lf->flags & EF_ASYNC_COPY)) {
+        /* Free node to delete */
+        if (lf->sid_node_to_delete) {
+            if (lf->generated_rule) {
+#ifndef WIN32
+                os_mutex_lock(&lf->generated_rule->mutex);
+#endif
+                OSList_DeleteThisNode(lf->generated_rule->sid_prev_matched,
+                                      lf->sid_node_to_delete);
+#ifndef WIN32
+                os_mutex_unlock(&lf->generated_rule->mutex);
+#endif
+            }
+            lf->sid_node_to_delete = NULL;
+        } else if (lf->generated_rule && lf->generated_rule->group_prev_matched) {
+            unsigned int i = 0;
+
+#ifndef WIN32
+            os_mutex_lock(&lf->generated_rule->mutex);
+#endif
+            while (i < lf->generated_rule->group_prev_matched_sz) {
+                OSList_DeleteOldestNode(lf->generated_rule->group_prev_matched[i]);
+                i++;
+            }
+#ifndef WIN32
+            os_mutex_unlock(&lf->generated_rule->mutex);
+#endif
         }
     }
 

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -10,8 +10,12 @@
 #ifndef _EVTINFO__H
 #define _EVTINFO__H
 
+#include <pthread.h>
+
 #include "rules.h"
 #include "decoders/decoder.h"
+
+#include <time.h>
 
 /* Event Information structure */
 typedef struct _Eventinfo {
@@ -46,6 +50,14 @@ typedef struct _Eventinfo {
     /* Pointer to the rule that generated it */
     RuleInfo *generated_rule;
 
+    /* Async alert writer: snapshot of rule->last_events (owned by this event). */
+    char **alert_last_events;
+    /* Ticket-based alert id (0 = use ftell under writer lock). */
+    long alert_id;
+
+    /* Match-shard / process-thread index */
+    int tid;
+
     /* Pointer to the decoder that matched */
     OSDecoderInfo *decoder_info;
 
@@ -60,6 +72,10 @@ typedef struct _Eventinfo {
     unsigned int flags;
     #define EF_FREE_PNAME 0x001
     #define EF_FREE_HNAME 0x002
+    /* log was separately allocated (not an alias into full_log). */
+    #define EF_SEPARATE_LOG 0x004
+    /* Async alert/archive/fw copy — skip sid/group list maintenance on free. */
+    #define EF_ASYNC_COPY 0x008
 
     /* Other internal variables */
     int matched;
@@ -69,6 +85,9 @@ typedef struct _Eventinfo {
     int year;
     char hour[10];
     char mon[4];
+
+    /* Enqueue timestamp for queue-wait sampling (CLOCK_MONOTONIC). */
+    struct timespec queue_in_time;
 
     /* SYSCHECK Results variables */
     char *filename;
@@ -94,6 +113,15 @@ typedef struct _EventNode {
     struct _EventNode *next;
     struct _EventNode *prev;
 } EventNode;
+
+/* Frequency / correlation ring (one per match shard). */
+typedef struct _EventList {
+    EventNode *first;
+    EventNode *last;
+    int memoryused;
+    int memorymaxsize;
+    pthread_mutex_t mutex;
+} EventList;
 
 #ifdef TESTRULE
 extern int full_output;
@@ -134,6 +162,9 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *currently_rule);
 /* Frequency rule context log samples (heap-owned copies) */
 void OS_SetRuleLastEvent(RuleInfo *rule, int idx, const char *log);
 void OS_FreeRuleLastEvents(RuleInfo *rule);
+/* Transfer rule->last_events ownership onto lf->alert_last_events.
+ * Caller must already hold rule->mutex. */
+void OS_MoveRuleLastEvents(RuleInfo *rule, Eventinfo *lf);
 
 /* Zero the eventinfo structure */
 void Zero_Eventinfo(Eventinfo *lf);
@@ -143,12 +174,16 @@ void Free_Eventinfo(Eventinfo *lf);
 
 /* Add and event to the list of previous events */
 void OS_AddEvent(Eventinfo *lf);
+void OS_AddEvent_List(Eventinfo *lf, EventList *list);
 
 /* Return the last event from the Event list */
 EventNode *OS_GetLastEvent(void);
+EventNode *OS_GetLastEvent_List(EventList *list);
 
 /* Create the event list. Maxsize must be specified */
 void OS_CreateEventList(int maxsize);
+EventList *OS_EventList_Create(int maxsize);
+void OS_EventList_Destroy(EventList *list);
 
 /* Pointers to the event decoders */
 void *SrcUser_FP(Eventinfo *lf, char *field, int order);

--- a/src/analysisd/eventinfo_list.c
+++ b/src/analysisd/eventinfo_list.c
@@ -10,101 +10,163 @@
 #include "shared.h"
 #include "eventinfo.h"
 #include "rules.h"
+#include "correlation_shard.h"
 
-/* Local variables */
-static EventNode *eventnode;
-static EventNode *lastnode;
+/* Global default list (legacy / single-thread). Match workers may install a
+ * private shard list via analysisd_set_event_list(). */
+static EventList g_event_list;
+static __thread EventList *tls_event_list = NULL;
 
-static int _memoryused = 0;
-static int _memorymaxsize = 0;
 int _max_freq = 0;
 
+EventList *analysisd_get_event_list(void)
+{
+    return tls_event_list ? tls_event_list : &g_event_list;
+}
+
+void analysisd_set_event_list(EventList *list)
+{
+    tls_event_list = list;
+}
+
+static void os_eventlist_init(EventList *list, int maxsize)
+{
+    list->first = NULL;
+    list->last = NULL;
+    list->memoryused = 0;
+    list->memorymaxsize = maxsize;
+    os_mutex_init(&list->mutex, NULL);
+}
 
 /* Create the Event List */
 void OS_CreateEventList(int maxsize)
 {
-    eventnode = NULL;
-    _memorymaxsize = maxsize;
-    _memoryused = 0;
-
+    os_eventlist_init(&g_event_list, maxsize);
+    tls_event_list = NULL;
     debug1("%s: OS_CreateEventList completed.", ARGV0);
-    return;
+}
+
+EventList *OS_EventList_Create(int maxsize)
+{
+    EventList *list;
+
+    os_calloc(1, sizeof(EventList), list);
+    os_eventlist_init(list, maxsize);
+    return list;
+}
+
+void OS_EventList_Destroy(EventList *list)
+{
+    EventNode *node;
+    EventNode *next;
+
+    if (!list) {
+        return;
+    }
+
+    os_mutex_lock(&list->mutex);
+    node = list->first;
+    while (node) {
+        next = node->next;
+        if (node->event) {
+            Free_Eventinfo(node->event);
+        }
+        free(node);
+        node = next;
+    }
+    list->first = NULL;
+    list->last = NULL;
+    list->memoryused = 0;
+    os_mutex_unlock(&list->mutex);
+    os_mutex_destroy(&list->mutex);
+    free(list);
 }
 
 /* Get the last event -- or first node */
-EventNode *OS_GetLastEvent()
+EventNode *OS_GetLastEvent_List(EventList *list)
 {
-    EventNode *eventnode_pt = eventnode;
-
-    return (eventnode_pt);
+    if (!list) {
+        return NULL;
+    }
+    return list->first;
 }
 
-/* Add an event to the list -- always to the beginning */
-void OS_AddEvent(Eventinfo *lf)
+EventNode *OS_GetLastEvent(void)
 {
-    EventNode *tmp_node = eventnode;
+    return OS_GetLastEvent_List(analysisd_get_event_list());
+}
+
+void OS_AddEvent_List(Eventinfo *lf, EventList *list)
+{
+    EventNode *tmp_node;
+
+    if (!list || !lf) {
+        return;
+    }
+
+    os_mutex_lock(&list->mutex);
+    tmp_node = list->first;
 
     if (tmp_node) {
         EventNode *new_node;
         new_node = (EventNode *)calloc(1, sizeof(EventNode));
 
         if (new_node == NULL) {
+            os_mutex_unlock(&list->mutex);
             ErrorExit(MEM_ERROR, ARGV0, errno, strerror(errno));
         }
 
-        /* Always add to the beginning of the list
-         * The new node will become the first node and
-         * new_node->next will be the previous first node
-         */
         new_node->next = tmp_node;
         new_node->prev = NULL;
         tmp_node->prev = new_node;
 
-        eventnode = new_node;
-
-        /* Add the event to the node */
+        list->first = new_node;
         new_node->event = lf;
 
-        _memoryused++;
+        list->memoryused++;
 
-        /* Need to remove the last nodes */
-        if (_memoryused > _memorymaxsize) {
+        if (list->memoryused > list->memorymaxsize) {
             int i = 0;
             EventNode *oldlast;
 
-            /* Remove at least the last 10 events
-             * or the events that will not match anymore
-             * (higher than max frequency)
-             */
-            while ((i < 10) || ((lf->time - lastnode->event->time) > _max_freq)) {
-                oldlast = lastnode;
-                lastnode = lastnode->prev;
-                lastnode->next = NULL;
+            while (list->last &&
+                   ((i < 10) || ((lf->time - list->last->event->time) > _max_freq))) {
+                oldlast = list->last;
+                list->last = list->last->prev;
+                if (list->last) {
+                    list->last->next = NULL;
+                } else {
+                    list->first = NULL;
+                }
 
-                /* Free event info */
                 Free_Eventinfo(oldlast->event);
                 free(oldlast);
 
-                _memoryused--;
+                list->memoryused--;
                 i++;
+                if (!list->last) {
+                    break;
+                }
             }
         }
-    }
-
-    else {
-        /* Add first node */
-        eventnode = (EventNode *)calloc(1, sizeof(EventNode));
-        if (eventnode == NULL) {
+    } else {
+        list->first = (EventNode *)calloc(1, sizeof(EventNode));
+        if (list->first == NULL) {
+            os_mutex_unlock(&list->mutex);
             ErrorExit(MEM_ERROR, ARGV0, errno, strerror(errno));
         }
 
-        eventnode->prev = NULL;
-        eventnode->next = NULL;
-        eventnode->event = lf;
-
-        lastnode = eventnode;
+        list->first->prev = NULL;
+        list->first->next = NULL;
+        list->first->event = lf;
+        list->last = list->first;
+        list->memoryused = 1;
     }
 
-    return;
+    os_mutex_unlock(&list->mutex);
 }
 
+void OS_AddEvent(Eventinfo *lf)
+{
+    OS_AddEvent_List(lf, analysisd_get_event_list());
+}

--- a/src/analysisd/eventinfo_list.c
+++ b/src/analysisd/eventinfo_list.c
@@ -64,8 +64,16 @@ void OS_EventList_Destroy(EventList *list)
         return;
     }
 
+    /* Unlink under the list lock; Free_Eventinfo after unlock so we never
+     * nest rule->mutex under list->mutex (Search_LastEvents takes the
+     * opposite order). */
     os_mutex_lock(&list->mutex);
     node = list->first;
+    list->first = NULL;
+    list->last = NULL;
+    list->memoryused = 0;
+    os_mutex_unlock(&list->mutex);
+
     while (node) {
         next = node->next;
         if (node->event) {
@@ -74,10 +82,6 @@ void OS_EventList_Destroy(EventList *list)
         free(node);
         node = next;
     }
-    list->first = NULL;
-    list->last = NULL;
-    list->memoryused = 0;
-    os_mutex_unlock(&list->mutex);
     os_mutex_destroy(&list->mutex);
     free(list);
 }
@@ -99,6 +103,7 @@ EventNode *OS_GetLastEvent(void)
 void OS_AddEvent_List(Eventinfo *lf, EventList *list)
 {
     EventNode *tmp_node;
+    EventNode *victims = NULL;
 
     if (!list || !lf) {
         return;
@@ -139,8 +144,10 @@ void OS_AddEvent_List(Eventinfo *lf, EventList *list)
                     list->first = NULL;
                 }
 
-                Free_Eventinfo(oldlast->event);
-                free(oldlast);
+                /* Defer Free_Eventinfo: it may lock generated_rule->mutex. */
+                oldlast->prev = NULL;
+                oldlast->next = victims;
+                victims = oldlast;
 
                 list->memoryused--;
                 i++;
@@ -164,6 +171,15 @@ void OS_AddEvent_List(Eventinfo *lf, EventList *list)
     }
 
     os_mutex_unlock(&list->mutex);
+
+    while (victims) {
+        EventNode *node = victims;
+        victims = victims->next;
+        if (node->event) {
+            Free_Eventinfo(node->event);
+        }
+        free(node);
+    }
 }
 
 void OS_AddEvent(Eventinfo *lf)

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -36,9 +36,10 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
 
         char alert_id[23];
         double timestamp_ms;
+        long id_part = lf->alert_id ? lf->alert_id : __crt_ftell;
         timestamp_ms = ((double)lf->time)*1000;
         alert_id[22] = '\0';
-        if((snprintf(alert_id, 22, "%ld.%ld", (long int)lf->time, __crt_ftell)) < 0) {
+        if((snprintf(alert_id, 22, "%ld.%ld", (long int)lf->time, id_part)) < 0) {
             merror("snprintf failed");
         }
 

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -122,8 +122,13 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     if (lf->full_log) {
         cJSON_AddStringToObject(root, "full_log", lf->full_log);
     }
-    if (lf->generated_rule->last_events && lf->generated_rule->last_events[1] && lf->generated_rule->last_events[1][0]) {
-        cJSON_AddStringToObject(root, "previous_output", lf->generated_rule->last_events[1]);
+    {
+        char **lasts = lf->alert_last_events ? lf->alert_last_events :
+                       (lf->generated_rule ? lf->generated_rule->last_events : NULL);
+
+        if (lasts && lasts[1] && lasts[1][0]) {
+            cJSON_AddStringToObject(root, "previous_output", lasts[1]);
+        }
     }
 
     if (lf->filename) {

--- a/src/analysisd/fts.c
+++ b/src/analysisd/fts.c
@@ -11,6 +11,18 @@
 
 #include "fts.h"
 #include "eventinfo.h"
+#include "shared.h"
+
+#ifndef WIN32
+#include <time.h>
+#include "queue_op.h"
+
+/* Declared in pipeline.c; avoid including pipeline.h (circular with fts). */
+extern os_queue *writer_queue_fts;
+#endif
+
+/* Timed wait for FTS writer queue space before sync fallback (seconds). */
+#define FTS_QUEUE_PUSH_WAIT_SEC 1
 
 /* Local variables */
 static unsigned int fts_minsize_for_str = 0;
@@ -20,7 +32,43 @@ static OSHash *fts_store = NULL;
 
 static FILE *fp_list = NULL;
 static FILE *fp_ignore = NULL;
+#ifndef WIN32
+static pthread_mutex_t fts_mutex = PTHREAD_MUTEX_INITIALIZER;
+/* File I/O only — keep separate from fts_mutex (in-memory hash/list). */
+static pthread_mutex_t fts_write_lock = PTHREAD_MUTEX_INITIALIZER;
+#endif
 
+
+void FTS_Fprintf(char *_line)
+{
+    if (!_line || !fp_list) {
+        return;
+    }
+
+#ifndef WIN32
+    os_mutex_lock(&fts_write_lock);
+#endif
+    fseek(fp_list, 0, SEEK_END);
+    fprintf(fp_list, "%s\n", _line);
+#ifndef WIN32
+    os_mutex_unlock(&fts_write_lock);
+#endif
+}
+
+void FTS_Flush(void)
+{
+    if (!fp_list) {
+        return;
+    }
+
+#ifndef WIN32
+    os_mutex_lock(&fts_write_lock);
+#endif
+    fflush(fp_list);
+#ifndef WIN32
+    os_mutex_unlock(&fts_write_lock);
+#endif
+}
 
 /* Start the FTS module */
 int FTS_Init()
@@ -148,9 +196,15 @@ int FTS_Init()
 /* Add a pattern to be ignored */
 void AddtoIGnore(Eventinfo *lf)
 {
+#ifndef WIN32
+    os_mutex_lock(&fts_mutex);
+#endif
     fseek(fp_ignore, 0, SEEK_END);
 
 #ifdef TESTRULE
+#ifndef WIN32
+    os_mutex_unlock(&fts_mutex);
+#endif
     return;
 #endif
 
@@ -172,6 +226,9 @@ void AddtoIGnore(Eventinfo *lf)
             (lf->generated_rule->ignore & FTS_LOCATION) ? lf->location : "");
 
     fflush(fp_ignore);
+#ifndef WIN32
+    os_mutex_unlock(&fts_mutex);
+#endif
 
     return;
 }
@@ -183,6 +240,7 @@ int IGnore(Eventinfo *lf)
 {
     char _line[OS_FLSIZE + 1];
     char _fline[OS_FLSIZE + 1];
+    int matched = 0;
 
     _line[OS_FLSIZE] = '\0';
 
@@ -205,6 +263,9 @@ int IGnore(Eventinfo *lf)
 
     _fline[OS_FLSIZE] = '\0';
 
+#ifndef WIN32
+    os_mutex_lock(&fts_mutex);
+#endif
     /** Check if the ignore is present **/
     /* Point to the beginning of the file */
     fseek(fp_ignore, 0, SEEK_SET);
@@ -214,10 +275,14 @@ int IGnore(Eventinfo *lf)
         }
 
         /* If we match, we can return 1 */
-        return (1);
+        matched = 1;
+        break;
     }
+#ifndef WIN32
+    os_mutex_unlock(&fts_mutex);
+#endif
 
-    return (0);
+    return matched;
 }
 
 /*  Check if the word "msg" is present on the "queue".
@@ -226,8 +291,10 @@ int IGnore(Eventinfo *lf)
 int FTS(Eventinfo *lf)
 {
     int number_of_matches = 0;
+    int result = 0;
     char _line[OS_FLSIZE + 1];
     char *line_for_list = NULL;
+    char *persist_line = NULL;
     OSListNode *fts_node;
 
     _line[OS_FLSIZE] = '\0';
@@ -244,9 +311,13 @@ int FTS(Eventinfo *lf)
              (lf->systemname && (lf->decoder_info->fts & FTS_SYSTEMNAME)) ? lf->systemname : "",
              (lf->decoder_info->fts & FTS_LOCATION) ? lf->location : "");
 
+#ifndef WIN32
+    os_mutex_lock(&fts_mutex);
+#endif
     /** Check if FTS is already present **/
     if (OSHash_Get(fts_store, _line)) {
-        return (0);
+        result = 0;
+        goto out;
     }
 
     /* Check if from the last FTS events, we had at least 3 "similars" before.
@@ -279,19 +350,62 @@ int FTS(Eventinfo *lf)
     }
 
     if (OSHash_Add(fts_store, line_for_list, line_for_list) <= 1) {
-        return (0);
+        result = 0;
+        goto out;
     }
 
 
 #ifdef TESTRULE
-    return (1);
+    result = 1;
+    goto out;
 #endif
 
-    /* Save to fts fp */
-    fseek(fp_list, 0, SEEK_END);
-    fprintf(fp_list, "%s\n", _line);
-    fflush(fp_list);
+    /* Disk persist happens off the match thread (async queue or sync fallback). */
+    os_strdup(_line, persist_line);
+    result = 1;
 
-    return (1);
+out:
+#ifndef WIN32
+    os_mutex_unlock(&fts_mutex);
+#endif
+
+#ifndef TESTRULE
+#ifndef WIN32
+    if (persist_line) {
+        if (writer_queue_fts) {
+            struct timespec ts;
+
+            if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
+                ts.tv_sec += FTS_QUEUE_PUSH_WAIT_SEC;
+                if (os_queue_push_ex_timedwait(writer_queue_fts, persist_line, &ts) == 0) {
+                    persist_line = NULL;
+                }
+            } else if (os_queue_push_ex(writer_queue_fts, persist_line) == 0) {
+                persist_line = NULL;
+            }
+
+            if (persist_line) {
+                /* Queue full/timeout: sync-write so the FTS entry is not lost. */
+                FTS_Fprintf(persist_line);
+                FTS_Flush();
+                free(persist_line);
+                persist_line = NULL;
+            }
+        } else {
+            FTS_Fprintf(persist_line);
+            FTS_Flush();
+            free(persist_line);
+            persist_line = NULL;
+        }
+    }
+#else
+    if (persist_line) {
+        FTS_Fprintf(persist_line);
+        FTS_Flush();
+        free(persist_line);
+    }
+#endif /* !WIN32 */
+#endif /* !TESTRULE */
+
+    return result;
 }
-

--- a/src/analysisd/fts.h
+++ b/src/analysisd/fts.h
@@ -26,5 +26,8 @@ void AddtoIGnore(Eventinfo *lf);
 int IGnore(Eventinfo *lf);
 int FTS(Eventinfo *lf);
 
-#endif /* __FTS_H */
+/* Disk I/O under fts_write_lock (separate from in-memory fts_mutex). */
+void FTS_Fprintf(char *_line);
+void FTS_Flush(void);
 
+#endif /* __FTS_H */

--- a/src/analysisd/lists.h
+++ b/src/analysisd/lists.h
@@ -14,6 +14,9 @@
 
 #include "cdb/cdb.h"
 #include "cdb/uint32.h"
+#ifndef WIN32
+#include <pthread.h>
+#endif
 
 #define LR_STRING_MATCH 0
 #define LR_STRING_NOT_MATCH 1
@@ -28,6 +31,9 @@ typedef struct ListNode {
     char *cdb_filename;
     char *txt_filename;
     struct cdb cdb;
+#ifndef WIN32
+    pthread_mutex_t mutex; /* Protects cdb cursor + open against match workers */
+#endif
     struct ListNode *next;
 } ListNode;
 

--- a/src/analysisd/lists_list.c
+++ b/src/analysisd/lists_list.c
@@ -52,6 +52,10 @@ void OS_ListLoadRules()
 /* External AddList */
 int OS_AddList(ListNode *new_listnode)
 {
+#ifndef WIN32
+    os_mutex_init(&new_listnode->mutex, NULL);
+#endif
+
     if (global_listnode == NULL) {
         /* First list */
         global_listnode = new_listnode;
@@ -258,47 +262,46 @@ static int OS_DBSearchKeyAddressValue(ListRule *lrule, char *key)
 
 int OS_DBSearch(ListRule *lrule, char *key)
 {
+    int result = 0;
+
     //XXX - god damn hack!!! Jeremy Rossi
     if (lrule->loaded == 0) {
         lrule->db = OS_FindList(lrule->filename);
         lrule->loaded = 1;
     }
+    if (lrule->db == NULL) {
+        return 0;
+    }
+
+#ifndef WIN32
+    os_mutex_lock(&lrule->db->mutex);
+#endif
     switch (lrule->lookup_type) {
         case LR_STRING_MATCH:
-            //debug1("LR_STRING_MATCH");
-            if (OS_DBSeachKey(lrule, key) == 1) {
-                return 1;
-            }
-            return 0;
+            result = (OS_DBSeachKey(lrule, key) == 1) ? 1 : 0;
+            break;
         case LR_STRING_NOT_MATCH:
-            //debug1("LR_STRING_NOT_MATCH");
-            if (OS_DBSeachKey(lrule, key) == 1) {
-                return 0;
-            }
-            return 1;
+            result = (OS_DBSeachKey(lrule, key) == 1) ? 0 : 1;
+            break;
         case LR_STRING_MATCH_VALUE:
-            //debug1("LR_STRING_MATCH_VALUE");
-            if (OS_DBSearchKeyValue(lrule, key) == 1) {
-                return 1;
-            }
-            return 0;
+            result = (OS_DBSearchKeyValue(lrule, key) == 1) ? 1 : 0;
+            break;
         case LR_ADDRESS_MATCH:
-            //debug1("LR_ADDRESS_MATCH");
-            return OS_DBSeachKeyAddress(lrule, key);
+            result = OS_DBSeachKeyAddress(lrule, key);
+            break;
         case LR_ADDRESS_NOT_MATCH:
-            //debug1("LR_ADDRESS_NOT_MATCH");
-            if (OS_DBSeachKeyAddress(lrule, key) == 0) {
-                return 1;
-            }
-            return 0;
+            result = (OS_DBSeachKeyAddress(lrule, key) == 0) ? 1 : 0;
+            break;
         case LR_ADDRESS_MATCH_VALUE:
-            //debug1("LR_ADDRESS_MATCH_VALUE");
-            if (OS_DBSearchKeyAddressValue(lrule, key) == 0) {
-                return 1;
-            }
-            return 0;
+            result = (OS_DBSearchKeyAddressValue(lrule, key) == 0) ? 1 : 0;
+            break;
         default:
             debug1("lists_list.c::OS_DBSearch should never hit default");
-            return 0;
+            result = 0;
+            break;
     }
+#ifndef WIN32
+    os_mutex_unlock(&lrule->db->mutex);
+#endif
+    return result;
 }

--- a/src/analysisd/makelists.c
+++ b/src/analysisd/makelists.c
@@ -26,9 +26,15 @@ int today;
 int thishour;
 int prev_year;
 char prev_month[4];
+#ifndef WIN32
+__thread int __crt_hour;
+__thread int __crt_wday;
+__thread time_t c_time;
+#else
 int __crt_hour;
 int __crt_wday;
 time_t c_time;
+#endif
 char __shost[512];
 OSDecoderInfo *NULL_Decoder;
 

--- a/src/analysisd/output/jsonout.c
+++ b/src/analysisd/output/jsonout.c
@@ -15,11 +15,13 @@ void jsonout_output_event(const Eventinfo *lf)
 {
     char *json_alert = Eventinfo_to_jsonstr(lf);
 
+    analysisd_log_io_lock();
     fprintf(_jflog,
             "%s\n",
             json_alert);
 
     fflush(_jflog);
+    analysisd_log_io_unlock();
     free(json_alert);
     return;
 }
@@ -27,11 +29,13 @@ void jsonout_output_archive(const Eventinfo *lf)
 {
     char *json_alert = Archiveinfo_to_jsonstr(lf);
 
+    analysisd_log_io_lock();
     fprintf(_ejflog,
             "%s\n",
             json_alert);
 
     fflush(_ejflog);
+    analysisd_log_io_unlock();
     free(json_alert);
     return;
 }

--- a/src/analysisd/pipeline.c
+++ b/src/analysisd/pipeline.c
@@ -1,0 +1,1338 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * Parity board (nested Wazuh analysisd vs Atomicorp):
+ * - Always-on multi-threaded pipeline on Linux (no pipeline_enabled gate).
+ * - TLS regex_matching + match_data per decode/process worker
+ *   (os_regex_set_thread_match), not process-global regex state.
+ * - Staged drain shutdown (input → decode → shard output → writers) with
+ *   timed joins and fail-closed _exit(1); nested historically exit(1) early.
+ * - No SCA / syscollector / w_* helpers from nested.
+ * - Sharded EventList (one list + one decode-output queue per rule-matching
+ *   thread) exceeds nested's single contended global EventList + mutex model.
+ * - Ticket alert IDs via analysisd_claim_alert_id() for async alert writers.
+ * - Async FTS writer (writer_queue_fts): match path updates memory under
+ *   fts_mutex, enqueues a strdup'd line; FTS_Fprintf/Flush under fts_write_lock.
+ * - Dual input demux (1 recv + N route workers) exceeds nested's single demux.
+ * - Per-agent rootcheck FILE locks; hostinfo under process-wide mutex.
+ */
+
+#ifndef WIN32
+
+/* For pthread_timedjoin_np (Linux). */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "shared.h"
+#include "os_net/os_net.h"
+#include "pipeline.h"
+#include "state.h"
+#include "analysisd.h"
+#include "queue_op.h"
+#include "correlation_shard.h"
+#include "accumulator.h"
+#include "decoders/decoder.h"
+#include "cleanevent.h"
+#include "config.h"
+#include "output/jsonout.h"
+#include "alerts/log.h"
+#include "alerts/getloglocation.h"
+#include "fts.h"
+
+extern int hourly_events;
+extern FILE *_aflog;
+
+os_queue *decode_queue_event_input = NULL;
+os_queue *decode_queue_syscheck_input = NULL;
+os_queue *decode_queue_rootcheck_input = NULL;
+os_queue *decode_queue_hostinfo_input = NULL;
+os_queue **decode_queue_event_output = NULL;
+int decode_queue_event_output_count = 0;
+os_queue *writer_queue_log = NULL;
+os_queue *writer_queue_statistical = NULL;
+os_queue *writer_queue_archive = NULL;
+os_queue *writer_queue_firewall = NULL;
+os_queue *writer_queue_fts = NULL;
+os_queue *raw_input_queue = NULL;
+
+static volatile int analysisd_shutting_down = 0;
+static int pipeline_m_queue = 0;
+static volatile long alert_ticket = 0;
+
+static int cfg_event_threads = 1;
+static int cfg_rule_matching_threads = 1;
+static int cfg_syscheck_threads = 1;
+static int cfg_rootcheck_threads = 1;
+static int cfg_hostinfo_threads = 1;
+static int cfg_input_demux_threads = 2;
+static int cfg_decode_event_queue_size = 16384;
+static int cfg_raw_input_queue_size = 16384;
+static int cfg_decode_syscheck_queue_size = 16384;
+static int cfg_decode_rootcheck_queue_size = 16384;
+static int cfg_decode_hostinfo_queue_size = 16384;
+static int cfg_decode_output_queue_size = 16384;
+static int cfg_alerts_queue_size = 16384;
+static int cfg_statistical_queue_size = 16384;
+static int cfg_archives_queue_size = 16384;
+static int cfg_firewall_queue_size = 16384;
+static int cfg_fts_queue_size = 16384;
+
+/* Mid-pipe push waits (ms); resolved once in analysisd_pipeline_run. */
+static int cfg_raw_input_push_wait_ms = 25;
+static int cfg_demux_push_wait_ms = 50;
+static int cfg_shard_push_wait_ms = 75;
+static int cfg_alerts_push_wait_ms = 100;
+
+#define ANALYSISD_INPUT_DEMUX_THREADS_MAX 8
+#define ANALYSISD_PUSH_WAIT_MS_MAX 5000
+
+static pthread_t input_recv_thread_id;
+static pthread_t *input_demux_threads = NULL;
+static int input_demux_thread_count = 0;
+static pthread_t *decode_event_threads = NULL;
+static pthread_t *decode_syscheck_threads = NULL;
+static pthread_t *decode_rootcheck_threads = NULL;
+static pthread_t *decode_hostinfo_threads = NULL;
+static pthread_t *process_event_threads = NULL;
+static pthread_t writer_log_thread_id;
+static pthread_t writer_statistical_thread_id;
+static pthread_t writer_archive_thread_id;
+static pthread_t writer_firewall_thread_id;
+static pthread_t writer_fts_thread_id;
+static pthread_t state_thread_id;
+static pthread_mutex_t writer_threads_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static int decode_event_thread_count = 0;
+static int decode_syscheck_thread_count = 0;
+static int decode_rootcheck_thread_count = 0;
+static int decode_hostinfo_thread_count = 0;
+static int process_event_thread_count = 0;
+
+static EventList **shard_lists = NULL;
+static OSHash **shard_acm_stores = NULL;
+
+/* Rate-limit drop warnings to once per this many seconds. */
+#define ANALYSISD_DROP_WARN_INTERVAL_SEC 30
+
+static time_t analysisd_last_drop_warn = 0;
+
+static void analysisd_warn_dropped(const char *where)
+{
+    time_t now = time(NULL);
+    unsigned int dropped;
+    unsigned int shard_drop;
+    unsigned int arch_drop;
+
+    if (analysisd_shutting_down) {
+        return;
+    }
+
+    if (analysisd_last_drop_warn != 0 &&
+        (now - analysisd_last_drop_warn) < ANALYSISD_DROP_WARN_INTERVAL_SEC) {
+        return;
+    }
+    analysisd_last_drop_warn = now;
+
+    dropped = analysisd_get_dropped_events();
+    shard_drop = analysisd_get_shard_dropped();
+    arch_drop = analysisd_get_archives_dropped();
+    merror("%s: WARN: pipeline queue pressure (%s): events_dropped=%u "
+           "shard_dropped=%u archives_dropped=%u. Check .state and raise "
+           "queue sizes or reduce EPS; events may be lost before rule match.",
+           ARGV0, where ? where : "unknown", dropped, shard_drop, arch_drop);
+}
+
+static void analysisd_abs_timeout_ms(struct timespec *ts, int ms)
+{
+    if (clock_gettime(CLOCK_REALTIME, ts) != 0) {
+        ts->tv_sec = time(NULL) + (ms / 1000);
+        ts->tv_nsec = (long)(ms % 1000) * 1000000L;
+        return;
+    }
+    ts->tv_nsec += (long)ms * 1000000L;
+    while (ts->tv_nsec >= 1000000000L) {
+        ts->tv_sec++;
+        ts->tv_nsec -= 1000000000L;
+    }
+}
+
+/* Resolve thread count: 0 means auto = min(online CPUs, 32). */
+static int analysisd_resolve_threads(const char *opt_name)
+{
+    int n;
+    long cpus;
+
+    n = getDefine_Int("analysisd", opt_name, 0, 32);
+    if (n > 0) {
+        return n;
+    }
+
+    cpus = sysconf(_SC_NPROCESSORS_ONLN);
+    if (cpus < 1) {
+        cpus = 1;
+    }
+    if (cpus > 32) {
+        cpus = 32;
+    }
+
+    verbose("%s: INFO: analysisd.%s=0; using %ld threads (CPU count).",
+            ARGV0, opt_name, cpus);
+    return (int)cpus;
+}
+
+static int analysisd_resolve_queue_size(const char *opt_name)
+{
+    return getDefine_Int("analysisd", opt_name, 128, 2000000);
+}
+
+/* Push wait before drop: 0 = immediate (Nested-like non-wait where applicable). */
+static int analysisd_resolve_push_wait_ms(const char *opt_name, int default_ms)
+{
+    (void)default_ms; /* Documented fallback; value comes from internal_options.conf. */
+    return getDefine_Int("analysisd", opt_name, 0, ANALYSISD_PUSH_WAIT_MS_MAX);
+}
+
+static int analysisd_queue_push_wait(os_queue *queue, void *data, int wait_ms)
+{
+    struct timespec ts;
+
+    if (!queue) {
+        return -1;
+    }
+    if (wait_ms <= 0) {
+        return os_queue_push_ex(queue, data);
+    }
+    analysisd_abs_timeout_ms(&ts, wait_ms);
+    return os_queue_push_ex_timedwait(queue, data, &ts);
+}
+
+static void analysisd_writer_sync_alert(Eventinfo *lf)
+{
+    if (lf && lf->alert_id) {
+        __crt_ftell = lf->alert_id;
+    } else if (_aflog) {
+        __crt_ftell = ftell(_aflog);
+    } else {
+        __crt_ftell = 0;
+    }
+    if (Config.custom_alert_output) {
+        OS_CustomLog(lf, Config.custom_alert_output_format);
+    } else {
+        OS_Log(lf);
+    }
+    if (Config.jsonout_output) {
+        jsonout_output_event(lf);
+    }
+}
+
+long analysisd_claim_alert_id(void)
+{
+    return __sync_add_and_fetch(&alert_ticket, 1);
+}
+
+void analysisd_init_queues(void)
+{
+    int i;
+
+    /* Parallel demux after single Unix recv. */
+    raw_input_queue = os_queue_init((size_t)cfg_raw_input_queue_size);
+
+    decode_queue_event_input = os_queue_init((size_t)cfg_decode_event_queue_size);
+    decode_queue_syscheck_input = os_queue_init((size_t)cfg_decode_syscheck_queue_size);
+    decode_queue_rootcheck_input = os_queue_init((size_t)cfg_decode_rootcheck_queue_size);
+    decode_queue_hostinfo_input = os_queue_init((size_t)cfg_decode_hostinfo_queue_size);
+
+    decode_queue_event_output_count = process_event_thread_count;
+    os_calloc((size_t)decode_queue_event_output_count, sizeof(os_queue *),
+              decode_queue_event_output);
+    for (i = 0; i < decode_queue_event_output_count; i++) {
+        decode_queue_event_output[i] = os_queue_init((size_t)cfg_decode_output_queue_size);
+    }
+
+    writer_queue_log = os_queue_init((size_t)cfg_alerts_queue_size);
+    writer_queue_statistical = os_queue_init((size_t)cfg_statistical_queue_size);
+    writer_queue_archive = os_queue_init((size_t)cfg_archives_queue_size);
+    writer_queue_firewall = os_queue_init((size_t)cfg_firewall_queue_size);
+    writer_queue_fts = os_queue_init((size_t)cfg_fts_queue_size);
+}
+
+void analysisd_destroy_queues(void)
+{
+    int i;
+
+    os_queue_destroy(raw_input_queue);
+    os_queue_destroy(decode_queue_event_input);
+    os_queue_destroy(decode_queue_syscheck_input);
+    os_queue_destroy(decode_queue_rootcheck_input);
+    os_queue_destroy(decode_queue_hostinfo_input);
+
+    if (decode_queue_event_output) {
+        for (i = 0; i < decode_queue_event_output_count; i++) {
+            os_queue_destroy(decode_queue_event_output[i]);
+            decode_queue_event_output[i] = NULL;
+        }
+        free(decode_queue_event_output);
+        decode_queue_event_output = NULL;
+    }
+    decode_queue_event_output_count = 0;
+
+    os_queue_destroy(writer_queue_log);
+    os_queue_destroy(writer_queue_statistical);
+    os_queue_destroy(writer_queue_archive);
+    os_queue_destroy(writer_queue_firewall);
+    os_queue_destroy(writer_queue_fts);
+
+    raw_input_queue = NULL;
+    decode_queue_event_input = NULL;
+    decode_queue_syscheck_input = NULL;
+    decode_queue_rootcheck_input = NULL;
+    decode_queue_hostinfo_input = NULL;
+    writer_queue_log = NULL;
+    writer_queue_statistical = NULL;
+    writer_queue_archive = NULL;
+    writer_queue_firewall = NULL;
+    writer_queue_fts = NULL;
+}
+
+static os_queue *analysisd_route_queue(char mq_prefix)
+{
+    switch (mq_prefix) {
+        case SYSCHECK_MQ:
+            return decode_queue_syscheck_input;
+        case ROOTCHECK_MQ:
+            return decode_queue_rootcheck_input;
+        case HOSTINFO_MQ:
+            return decode_queue_hostinfo_input;
+        default:
+            return decode_queue_event_input;
+    }
+}
+
+static int analysisd_push_decoded(Eventinfo *lf)
+{
+    unsigned int shard;
+
+    if (!lf || !decode_queue_event_output || process_event_thread_count <= 0) {
+        Free_Eventinfo(lf);
+        return -1;
+    }
+
+    shard = analysisd_shard_id(lf, (unsigned int)process_event_thread_count);
+    analysisd_stamp_queue_in(lf);
+    if (analysisd_queue_push_wait(decode_queue_event_output[shard], lf,
+                                  cfg_shard_push_wait_ms) != 0) {
+        Free_Eventinfo(lf);
+        if (!analysisd_shutting_down) {
+            analysisd_inc_shard_dropped();
+            analysisd_inc_dropped_events();
+            analysisd_warn_dropped("decode->shard");
+        }
+        return -1;
+    }
+
+    return 0;
+}
+
+int analysisd_enqueue_alert(Eventinfo *lf)
+{
+    if (!lf) {
+        return -1;
+    }
+
+    if (!writer_queue_log) {
+        return -1;
+    }
+
+    analysisd_stamp_queue_in(lf);
+    if (analysisd_queue_push_wait(writer_queue_log, lf,
+                                  cfg_alerts_push_wait_ms) == 0) {
+        return 0;
+    }
+
+    if (analysisd_shutting_down) {
+        /* Caller still owns lf. */
+        return -1;
+    }
+
+    /* Brief wait failed: sync write under the same lock as the alert writer. */
+    os_mutex_lock(&writer_threads_mutex);
+    analysisd_writer_sync_alert(lf);
+    os_mutex_unlock(&writer_threads_mutex);
+
+    Free_Eventinfo(lf);
+    analysisd_inc_alerts_written();
+    return 0;
+}
+
+int analysisd_enqueue_statistical(Eventinfo *lf)
+{
+    if (!lf) {
+        return -1;
+    }
+
+    if (!writer_queue_statistical) {
+        return -1;
+    }
+
+    analysisd_stamp_queue_in(lf);
+    if (analysisd_queue_push_wait(writer_queue_statistical, lf,
+                                  cfg_alerts_push_wait_ms) == 0) {
+        return 0;
+    }
+
+    if (analysisd_shutting_down) {
+        return -1;
+    }
+
+    os_mutex_lock(&writer_threads_mutex);
+    analysisd_writer_sync_alert(lf);
+    os_mutex_unlock(&writer_threads_mutex);
+
+    Free_Eventinfo(lf);
+    analysisd_inc_alerts_written();
+    return 0;
+}
+
+Eventinfo *analysisd_copy_event_for_log(const Eventinfo *lf)
+{
+    Eventinfo *cpy;
+    int i;
+
+    if (!lf) {
+        return NULL;
+    }
+
+    os_calloc(1, sizeof(Eventinfo), cpy);
+    os_calloc(Config.decoder_order_size, sizeof(char *), cpy->fields);
+
+    if (lf->full_log) {
+        size_t flen = strlen(lf->full_log);
+        size_t loglen = flen + 1;
+        size_t dual_size = (2 * loglen) + 1;
+        ptrdiff_t log_off = 0;
+
+        if (lf->log) {
+            log_off = lf->log - lf->full_log;
+        }
+
+        if (lf->log && log_off == 0) {
+            /* Syscheck / ossecalert: log aliases the start of full_log. */
+            os_strdup(lf->full_log, cpy->full_log);
+            cpy->log = cpy->full_log;
+        } else if (lf->log && log_off > 0 && (size_t)log_off < dual_size) {
+            /* CleanMSG layout: one (2*loglen+1) allocation; log is in the
+             * second half (possibly advanced past a date/hostname prefix). */
+            os_malloc(dual_size, cpy->full_log);
+            memcpy(cpy->full_log, lf->full_log, dual_size);
+            cpy->log = cpy->full_log + log_off;
+        } else if (lf->log) {
+            /* log is not inside full_log — copy both and mark separate. */
+            os_strdup(lf->full_log, cpy->full_log);
+            os_strdup(lf->log, cpy->log);
+            cpy->flags |= EF_SEPARATE_LOG;
+        } else {
+            os_strdup(lf->full_log, cpy->full_log);
+        }
+    } else if (lf->log) {
+        os_strdup(lf->log, cpy->log);
+        cpy->flags |= EF_SEPARATE_LOG;
+    }
+    if (lf->location) {
+        os_strdup(lf->location, cpy->location);
+    }
+    if (lf->hostname) {
+        if (lf->hostname == lf->location && cpy->location) {
+            cpy->hostname = cpy->location;
+        } else {
+            os_strdup(lf->hostname, cpy->hostname);
+            cpy->flags |= EF_FREE_HNAME;
+        }
+    }
+    if (lf->program_name) {
+        os_strdup(lf->program_name, cpy->program_name);
+        cpy->flags |= EF_FREE_PNAME;
+    }
+    if (lf->action) {
+        os_strdup(lf->action, cpy->action);
+    }
+    if (lf->srcip) {
+        os_strdup(lf->srcip, cpy->srcip);
+    }
+    if (lf->dstip) {
+        os_strdup(lf->dstip, cpy->dstip);
+    }
+    if (lf->srcgeoip) {
+        os_strdup(lf->srcgeoip, cpy->srcgeoip);
+    }
+    if (lf->dstgeoip) {
+        os_strdup(lf->dstgeoip, cpy->dstgeoip);
+    }
+    if (lf->srcport) {
+        os_strdup(lf->srcport, cpy->srcport);
+    }
+    if (lf->dstport) {
+        os_strdup(lf->dstport, cpy->dstport);
+    }
+    if (lf->protocol) {
+        os_strdup(lf->protocol, cpy->protocol);
+    }
+    if (lf->srcuser) {
+        os_strdup(lf->srcuser, cpy->srcuser);
+    }
+    if (lf->dstuser) {
+        os_strdup(lf->dstuser, cpy->dstuser);
+    }
+    if (lf->id) {
+        os_strdup(lf->id, cpy->id);
+    }
+    if (lf->status) {
+        os_strdup(lf->status, cpy->status);
+    }
+    if (lf->command) {
+        os_strdup(lf->command, cpy->command);
+    }
+    if (lf->url) {
+        os_strdup(lf->url, cpy->url);
+    }
+    if (lf->data) {
+        os_strdup(lf->data, cpy->data);
+    }
+    if (lf->systemname) {
+        os_strdup(lf->systemname, cpy->systemname);
+    }
+    if (lf->filename) {
+        os_strdup(lf->filename, cpy->filename);
+    }
+    if (lf->md5_before) {
+        os_strdup(lf->md5_before, cpy->md5_before);
+    }
+    if (lf->md5_after) {
+        os_strdup(lf->md5_after, cpy->md5_after);
+    }
+    if (lf->sha1_before) {
+        os_strdup(lf->sha1_before, cpy->sha1_before);
+    }
+    if (lf->sha1_after) {
+        os_strdup(lf->sha1_after, cpy->sha1_after);
+    }
+    if (lf->sha256_before) {
+        os_strdup(lf->sha256_before, cpy->sha256_before);
+    }
+    if (lf->sha256_after) {
+        os_strdup(lf->sha256_after, cpy->sha256_after);
+    }
+    if (lf->size_before) {
+        os_strdup(lf->size_before, cpy->size_before);
+    }
+    if (lf->size_after) {
+        os_strdup(lf->size_after, cpy->size_after);
+    }
+    if (lf->owner_before) {
+        os_strdup(lf->owner_before, cpy->owner_before);
+    }
+    if (lf->owner_after) {
+        os_strdup(lf->owner_after, cpy->owner_after);
+    }
+    if (lf->gowner_before) {
+        os_strdup(lf->gowner_before, cpy->gowner_before);
+    }
+    if (lf->gowner_after) {
+        os_strdup(lf->gowner_after, cpy->gowner_after);
+    }
+
+    for (i = 0; i < Config.decoder_order_size; i++) {
+        if (lf->fields && lf->fields[i]) {
+            os_strdup(lf->fields[i], cpy->fields[i]);
+        }
+    }
+
+    cpy->perm_before = lf->perm_before;
+    cpy->perm_after = lf->perm_after;
+    cpy->generated_rule = lf->generated_rule;
+    cpy->decoder_info = lf->decoder_info;
+    cpy->time = lf->time;
+    cpy->day = lf->day;
+    cpy->year = lf->year;
+    cpy->alert_id = lf->alert_id;
+    strncpy(cpy->mon, lf->mon, 3);
+    strncpy(cpy->hour, lf->hour, 9);
+    cpy->flags |= EF_ASYNC_COPY;
+
+    if (lf->alert_last_events) {
+        os_calloc(MAX_LAST_EVENTS + 1, sizeof(char *), cpy->alert_last_events);
+        for (i = 0; i < MAX_LAST_EVENTS && lf->alert_last_events[i]; i++) {
+            os_strdup(lf->alert_last_events[i], cpy->alert_last_events[i]);
+        }
+        cpy->alert_last_events[i] = NULL;
+    }
+
+    return cpy;
+}
+
+static void *analysisd_writer_log_thread(void *arg)
+{
+    Eventinfo *lf;
+
+    (void)arg;
+    os_block_worker_signals();
+
+    while (!analysisd_shutting_down) {
+        lf = (Eventinfo *)os_queue_pop_ex(writer_queue_log);
+        if (!lf) {
+            break;
+        }
+
+        analysisd_sample_queue_wait(lf, ANALYSISD_QWAIT_ALERTS);
+
+        os_mutex_lock(&writer_threads_mutex);
+        analysisd_writer_sync_alert(lf);
+        os_mutex_unlock(&writer_threads_mutex);
+
+        Free_Eventinfo(lf);
+        analysisd_inc_alerts_written();
+    }
+
+    return NULL;
+}
+
+static void *analysisd_writer_statistical_thread(void *arg)
+{
+    Eventinfo *lf;
+
+    (void)arg;
+    os_block_worker_signals();
+
+    while (!analysisd_shutting_down) {
+        lf = (Eventinfo *)os_queue_pop_ex(writer_queue_statistical);
+        if (!lf) {
+            break;
+        }
+
+        os_mutex_lock(&writer_threads_mutex);
+        analysisd_writer_sync_alert(lf);
+        os_mutex_unlock(&writer_threads_mutex);
+
+        Free_Eventinfo(lf);
+        analysisd_inc_alerts_written();
+    }
+
+    return NULL;
+}
+
+static void *analysisd_writer_archive_thread(void *arg)
+{
+    Eventinfo *lf;
+
+    (void)arg;
+    os_block_worker_signals();
+
+    while (!analysisd_shutting_down) {
+        lf = (Eventinfo *)os_queue_pop_ex(writer_queue_archive);
+        if (!lf) {
+            break;
+        }
+
+        OS_Store(lf);
+        if (Config.logall_json) {
+            jsonout_output_archive(lf);
+        }
+
+        analysisd_inc_archives_written();
+        Free_Eventinfo(lf);
+    }
+
+    return NULL;
+}
+
+static void *analysisd_writer_firewall_thread(void *arg)
+{
+    Eventinfo *lf;
+
+    (void)arg;
+    os_block_worker_signals();
+
+    while (!analysisd_shutting_down) {
+        lf = (Eventinfo *)os_queue_pop_ex(writer_queue_firewall);
+        if (!lf) {
+            break;
+        }
+
+        FW_Log(lf);
+        analysisd_inc_firewall_written();
+        Free_Eventinfo(lf);
+    }
+
+    return NULL;
+}
+
+static void *analysisd_writer_fts_thread(void *arg)
+{
+    char *line;
+    unsigned int since_flush = 0;
+
+    (void)arg;
+    os_block_worker_signals();
+
+    while (!analysisd_shutting_down) {
+        line = (char *)os_queue_pop_ex(writer_queue_fts);
+        if (!line) {
+            break;
+        }
+
+        FTS_Fprintf(line);
+        free(line);
+        since_flush++;
+
+        /* Batch fflush so match threads are not blocked on disk sync. */
+        if (since_flush >= 64 || os_queue_elements(writer_queue_fts) == 0) {
+            FTS_Flush();
+            since_flush = 0;
+        }
+    }
+
+    FTS_Flush();
+    return NULL;
+}
+
+static void *analysisd_decode_worker_thread(void *arg)
+{
+    os_queue *input_queue = (os_queue *)arg;
+    char *msg;
+    char mq_prefix;
+    Eventinfo *lf;
+    regex_matching decoder_match;
+
+    os_block_worker_signals();
+    memset(&decoder_match, 0, sizeof(decoder_match));
+
+    while (!analysisd_shutting_down) {
+        msg = (char *)os_queue_pop_ex(input_queue);
+        if (!msg) {
+            if (analysisd_shutting_down) {
+                break;
+            }
+            continue;
+        }
+
+        lf = analysisd_event_alloc();
+        Zero_Eventinfo(lf);
+
+        mq_prefix = msg[0];
+
+        if (OS_CleanMSG_ex(msg, lf, time(NULL), 0) < 0) {
+            merror(IMSG_ERROR, ARGV0, msg);
+            Free_Eventinfo(lf);
+            free(msg);
+            continue;
+        }
+
+        free(msg);
+
+        lf = analysisd_decode_event(lf, mq_prefix, &decoder_match);
+        if (!lf) {
+            continue;
+        }
+
+        analysisd_inc_decoded_events();
+        analysisd_push_decoded(lf);
+    }
+
+    regex_matching_clear(&decoder_match);
+    regex_matching_free_match_data(&decoder_match);
+    return NULL;
+}
+
+static void *analysisd_decode_syscheck_thread(void *arg)
+{
+    char *msg;
+    Eventinfo *lf;
+
+    (void)arg;
+    os_block_worker_signals();
+    SyscheckInit();
+
+    while (!analysisd_shutting_down) {
+        msg = (char *)os_queue_pop_ex(decode_queue_syscheck_input);
+        if (!msg) {
+            if (analysisd_shutting_down) {
+                break;
+            }
+            continue;
+        }
+
+        lf = analysisd_event_alloc();
+        Zero_Eventinfo(lf);
+
+        if (OS_CleanMSG_ex(msg, lf, time(NULL), 0) < 0) {
+            merror(IMSG_ERROR, ARGV0, msg);
+            Free_Eventinfo(lf);
+            free(msg);
+            continue;
+        }
+
+        free(msg);
+
+        lf = analysisd_decode_event(lf, SYSCHECK_MQ, NULL);
+        if (!lf) {
+            continue;
+        }
+
+        analysisd_inc_syscheck_decoded_events();
+        analysisd_push_decoded(lf);
+    }
+
+    return NULL;
+}
+
+static void *analysisd_decode_rootcheck_thread(void *arg)
+{
+    char *msg;
+    Eventinfo *lf;
+
+    (void)arg;
+    os_block_worker_signals();
+
+    while (!analysisd_shutting_down) {
+        msg = (char *)os_queue_pop_ex(decode_queue_rootcheck_input);
+        if (!msg) {
+            if (analysisd_shutting_down) {
+                break;
+            }
+            continue;
+        }
+
+        lf = analysisd_event_alloc();
+        Zero_Eventinfo(lf);
+
+        if (OS_CleanMSG_ex(msg, lf, time(NULL), 0) < 0) {
+            Free_Eventinfo(lf);
+            free(msg);
+            continue;
+        }
+
+        free(msg);
+
+        lf = analysisd_decode_event(lf, ROOTCHECK_MQ, NULL);
+        if (!lf) {
+            continue;
+        }
+
+        analysisd_inc_rootcheck_decoded_events();
+        analysisd_push_decoded(lf);
+    }
+
+    return NULL;
+}
+
+static void *analysisd_decode_hostinfo_thread(void *arg)
+{
+    char *msg;
+    Eventinfo *lf;
+
+    (void)arg;
+    os_block_worker_signals();
+
+    while (!analysisd_shutting_down) {
+        msg = (char *)os_queue_pop_ex(decode_queue_hostinfo_input);
+        if (!msg) {
+            if (analysisd_shutting_down) {
+                break;
+            }
+            continue;
+        }
+
+        lf = analysisd_event_alloc();
+        Zero_Eventinfo(lf);
+
+        if (OS_CleanMSG_ex(msg, lf, time(NULL), 0) < 0) {
+            Free_Eventinfo(lf);
+            free(msg);
+            continue;
+        }
+
+        free(msg);
+
+        lf = analysisd_decode_event(lf, HOSTINFO_MQ, NULL);
+        if (!lf) {
+            continue;
+        }
+
+        analysisd_inc_hostinfo_decoded_events();
+        analysisd_push_decoded(lf);
+    }
+
+    return NULL;
+}
+
+static void *analysisd_process_event_thread(void *arg)
+{
+    int tid = (int)(intptr_t)arg;
+    Eventinfo *lf;
+    regex_matching rule_match;
+    int transferred;
+
+    os_block_worker_signals();
+
+    if (tid < 0 || tid >= process_event_thread_count || !shard_lists) {
+        merror("%s: ERROR: invalid process event thread id %d.", ARGV0, tid);
+        return NULL;
+    }
+
+    analysisd_set_event_list(shard_lists[tid]);
+    if (shard_acm_stores) {
+        analysisd_set_acm_store(shard_acm_stores[tid]);
+    }
+    memset(&rule_match, 0, sizeof(rule_match));
+    os_regex_set_thread_match(&rule_match);
+
+    while (!analysisd_shutting_down) {
+        lf = (Eventinfo *)os_queue_pop_ex(decode_queue_event_output[tid]);
+        if (!lf) {
+            if (analysisd_shutting_down) {
+                break;
+            }
+            continue;
+        }
+
+        analysisd_sample_queue_wait(lf, ANALYSISD_QWAIT_SHARD);
+        analysisd_inc_hourly_events();
+        transferred = analysisd_analyze_event(lf);
+        analysisd_inc_processed_events();
+        if (!transferred) {
+            analysisd_finish_event(lf);
+        }
+    }
+
+    analysisd_set_acm_store(NULL);
+    os_regex_set_thread_match(NULL);
+    regex_matching_clear(&rule_match);
+    regex_matching_free_match_data(&rule_match);
+    return NULL;
+}
+
+static void *analysisd_input_recv_thread(void *arg)
+{
+    char msg[OS_MAXSTR + 1];
+    char *copy;
+    int recv_len;
+
+    (void)arg;
+    os_block_worker_signals();
+
+    while (!analysisd_shutting_down) {
+        recv_len = OS_RecvUnix(pipeline_m_queue, OS_MAXSTR, msg);
+        if (recv_len <= 0) {
+            if (analysisd_shutting_down) {
+                break;
+            }
+            continue;
+        }
+
+        if (recv_len < 4) {
+            merror(IMSG_ERROR, ARGV0, msg);
+            continue;
+        }
+
+        copy = strdup(msg);
+        if (!copy) {
+            merror(MEM_ERROR, ARGV0, errno, strerror(errno));
+            continue;
+        }
+
+        analysisd_inc_received_events();
+
+        if (analysisd_queue_push_wait(raw_input_queue, copy,
+                                      cfg_raw_input_push_wait_ms) != 0) {
+            free(copy);
+            analysisd_inc_dropped_events();
+            analysisd_warn_dropped("raw input");
+        }
+    }
+
+    return NULL;
+}
+
+static void *analysisd_input_demux_thread(void *arg)
+{
+    char *copy;
+    os_queue *queue;
+
+    (void)arg;
+    os_block_worker_signals();
+
+    while (!analysisd_shutting_down) {
+        copy = (char *)os_queue_pop_ex(raw_input_queue);
+        if (!copy) {
+            if (analysisd_shutting_down) {
+                break;
+            }
+            continue;
+        }
+
+        queue = analysisd_route_queue(copy[0]);
+        if (analysisd_queue_push_wait(queue, copy, cfg_demux_push_wait_ms) != 0) {
+            free(copy);
+            analysisd_inc_dropped_events();
+            analysisd_warn_dropped("demux->decode");
+        }
+    }
+
+    return NULL;
+}
+
+void analysisd_pipeline_request_shutdown(void)
+{
+    analysisd_shutting_down = 1;
+}
+
+void analysisd_log_pipeline_metrics(unsigned int decoded, unsigned int processed,
+                                    unsigned int dropped)
+{
+    unsigned int event_in = 0;
+    unsigned int event_out = 0;
+    unsigned int alerts_q = 0;
+    unsigned int firewall_q = 0;
+    int i;
+
+    if (decode_queue_event_input) {
+        event_in = os_queue_elements(decode_queue_event_input);
+    }
+    if (decode_queue_event_output) {
+        for (i = 0; i < decode_queue_event_output_count; i++) {
+            event_out += os_queue_elements(decode_queue_event_output[i]);
+        }
+    }
+    if (writer_queue_log) {
+        alerts_q = os_queue_elements(writer_queue_log);
+    }
+    if (writer_queue_firewall) {
+        firewall_q = os_queue_elements(writer_queue_firewall);
+    }
+
+    debug1("%s: pipeline decoded=%u processed=%u dropped=%u "
+           "queues(event_in=%u event_out=%u alerts=%u statistical=%u "
+           "firewall=%u fts=%u)",
+           ARGV0, decoded, processed, dropped, event_in, event_out, alerts_q,
+           writer_queue_statistical ? os_queue_elements(writer_queue_statistical) : 0,
+           firewall_q,
+           writer_queue_fts ? os_queue_elements(writer_queue_fts) : 0);
+
+    if (dropped > 0) {
+        analysisd_warn_dropped("metrics interval");
+    }
+}
+
+static int analysisd_join_thread(pthread_t thread, const char *name)
+{
+    struct timespec ts;
+    int rc;
+
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+        return pthread_join(thread, NULL);
+    }
+
+    ts.tv_sec += ANALYSISD_SHUTDOWN_TIMEOUT;
+    rc = pthread_timedjoin_np(thread, NULL, &ts);
+    if (rc == ETIMEDOUT) {
+        merror("%s: ERROR: timed out joining %s after %d s; aborting to avoid a "
+               "half-alive daemon.",
+               ARGV0, name, ANALYSISD_SHUTDOWN_TIMEOUT);
+        return -1;
+    }
+
+    return rc;
+}
+
+static void analysisd_free_queued_event(void *ptr)
+{
+    Free_Eventinfo((Eventinfo *)ptr);
+}
+
+static void analysisd_drain_queues(void)
+{
+    int i;
+
+    /* Defensive: free anything left after workers exit. */
+    os_queue_free_data(raw_input_queue, free);
+    os_queue_free_data(decode_queue_event_input, free);
+    os_queue_free_data(decode_queue_syscheck_input, free);
+    os_queue_free_data(decode_queue_rootcheck_input, free);
+    os_queue_free_data(decode_queue_hostinfo_input, free);
+
+    if (decode_queue_event_output) {
+        for (i = 0; i < decode_queue_event_output_count; i++) {
+            os_queue_free_data(decode_queue_event_output[i], analysisd_free_queued_event);
+        }
+    }
+
+    os_queue_free_data(writer_queue_log, analysisd_free_queued_event);
+    os_queue_free_data(writer_queue_statistical, analysisd_free_queued_event);
+    os_queue_free_data(writer_queue_archive, analysisd_free_queued_event);
+    os_queue_free_data(writer_queue_firewall, analysisd_free_queued_event);
+    os_queue_free_data(writer_queue_fts, free);
+}
+
+void analysisd_pipeline_shutdown(void)
+{
+    int i;
+    char name[64];
+    int join_failed = 0;
+
+    analysisd_shutting_down = 1;
+    analysisd_state_shutdown();
+
+    /* Stage 1: stop accepting new messages, then drain decode input. */
+    if (pipeline_m_queue >= 0) {
+        close(pipeline_m_queue);
+        pipeline_m_queue = -1;
+    }
+
+    if (analysisd_join_thread(input_recv_thread_id, "input recv thread") != 0) {
+        join_failed = 1;
+    }
+
+    os_queue_shutdown(raw_input_queue);
+    for (i = 0; i < input_demux_thread_count; i++) {
+        snprintf(name, sizeof(name), "input demux thread %d", i);
+        if (analysisd_join_thread(input_demux_threads[i], name) != 0) {
+            join_failed = 1;
+        }
+    }
+
+    os_queue_shutdown(decode_queue_event_input);
+    os_queue_shutdown(decode_queue_syscheck_input);
+    os_queue_shutdown(decode_queue_rootcheck_input);
+    os_queue_shutdown(decode_queue_hostinfo_input);
+
+    for (i = 0; i < decode_event_thread_count; i++) {
+        snprintf(name, sizeof(name), "decode event thread %d", i);
+        if (analysisd_join_thread(decode_event_threads[i], name) != 0) {
+            join_failed = 1;
+        }
+    }
+    for (i = 0; i < decode_syscheck_thread_count; i++) {
+        snprintf(name, sizeof(name), "decode syscheck thread %d", i);
+        if (analysisd_join_thread(decode_syscheck_threads[i], name) != 0) {
+            join_failed = 1;
+        }
+    }
+    for (i = 0; i < decode_rootcheck_thread_count; i++) {
+        snprintf(name, sizeof(name), "decode rootcheck thread %d", i);
+        if (analysisd_join_thread(decode_rootcheck_threads[i], name) != 0) {
+            join_failed = 1;
+        }
+    }
+    for (i = 0; i < decode_hostinfo_thread_count; i++) {
+        snprintf(name, sizeof(name), "decode hostinfo thread %d", i);
+        if (analysisd_join_thread(decode_hostinfo_threads[i], name) != 0) {
+            join_failed = 1;
+        }
+    }
+
+    /* Stage 2: finish rule matching on decoded events (per-shard queues). */
+    if (decode_queue_event_output) {
+        for (i = 0; i < decode_queue_event_output_count; i++) {
+            os_queue_shutdown(decode_queue_event_output[i]);
+        }
+    }
+
+    for (i = 0; i < process_event_thread_count; i++) {
+        snprintf(name, sizeof(name), "process event thread %d", i);
+        if (analysisd_join_thread(process_event_threads[i], name) != 0) {
+            join_failed = 1;
+        }
+    }
+
+    /* Stage 3: flush alert/statistical/archive/firewall/FTS writers. */
+    os_queue_shutdown(writer_queue_log);
+    os_queue_shutdown(writer_queue_statistical);
+    os_queue_shutdown(writer_queue_archive);
+    os_queue_shutdown(writer_queue_firewall);
+    os_queue_shutdown(writer_queue_fts);
+
+    if (analysisd_join_thread(writer_log_thread_id, "alert writer") != 0) {
+        join_failed = 1;
+    }
+    if (analysisd_join_thread(writer_statistical_thread_id,
+                              "statistical writer") != 0) {
+        join_failed = 1;
+    }
+    if (analysisd_join_thread(writer_archive_thread_id, "archive writer") != 0) {
+        join_failed = 1;
+    }
+    if (analysisd_join_thread(writer_firewall_thread_id, "firewall writer") != 0) {
+        join_failed = 1;
+    }
+    if (analysisd_join_thread(writer_fts_thread_id, "FTS writer") != 0) {
+        join_failed = 1;
+    }
+    if (analysisd_join_thread(state_thread_id, "state thread") != 0) {
+        join_failed = 1;
+    }
+
+    analysisd_drain_queues();
+
+    if (shard_lists) {
+        for (i = 0; i < process_event_thread_count; i++) {
+            OS_EventList_Destroy(shard_lists[i]);
+            shard_lists[i] = NULL;
+        }
+        free(shard_lists);
+        shard_lists = NULL;
+    }
+
+    if (shard_acm_stores) {
+        for (i = 0; i < process_event_thread_count; i++) {
+            Accumulate_DestroyStore(shard_acm_stores[i]);
+            shard_acm_stores[i] = NULL;
+        }
+        free(shard_acm_stores);
+        shard_acm_stores = NULL;
+    }
+
+    free(decode_event_threads);
+    free(decode_syscheck_threads);
+    free(decode_rootcheck_threads);
+    free(decode_hostinfo_threads);
+    free(process_event_threads);
+    free(input_demux_threads);
+    input_demux_threads = NULL;
+    input_demux_thread_count = 0;
+
+    analysisd_destroy_queues();
+
+    if (join_failed) {
+        DeletePID(ARGV0);
+        _exit(1);
+    }
+}
+
+void analysisd_pipeline_run(int m_queue)
+{
+    int i;
+
+    pipeline_m_queue = m_queue;
+
+    cfg_event_threads = analysisd_resolve_threads("event_threads");
+    cfg_syscheck_threads = analysisd_resolve_threads("syscheck_threads");
+    cfg_rootcheck_threads = analysisd_resolve_threads("rootcheck_threads");
+    cfg_hostinfo_threads = analysisd_resolve_threads("hostinfo_threads");
+    cfg_rule_matching_threads = analysisd_resolve_threads("rule_matching_threads");
+    cfg_input_demux_threads =
+        getDefine_Int("analysisd", "input_demux_threads", 1,
+                      ANALYSISD_INPUT_DEMUX_THREADS_MAX);
+
+    cfg_decode_event_queue_size = analysisd_resolve_queue_size("decode_event_queue_size");
+    cfg_raw_input_queue_size = analysisd_resolve_queue_size("raw_input_queue_size");
+    cfg_decode_syscheck_queue_size = analysisd_resolve_queue_size("decode_syscheck_queue_size");
+    cfg_decode_rootcheck_queue_size = analysisd_resolve_queue_size("decode_rootcheck_queue_size");
+    cfg_decode_hostinfo_queue_size = analysisd_resolve_queue_size("decode_hostinfo_queue_size");
+    cfg_decode_output_queue_size = analysisd_resolve_queue_size("decode_output_queue_size");
+    cfg_alerts_queue_size = analysisd_resolve_queue_size("alerts_queue_size");
+    cfg_statistical_queue_size = analysisd_resolve_queue_size("statistical_queue_size");
+    cfg_archives_queue_size = analysisd_resolve_queue_size("archives_queue_size");
+    cfg_firewall_queue_size = analysisd_resolve_queue_size("firewall_queue_size");
+    cfg_fts_queue_size = analysisd_resolve_queue_size("fts_queue_size");
+
+    cfg_raw_input_push_wait_ms =
+        analysisd_resolve_push_wait_ms("raw_input_push_wait_ms", 25);
+    cfg_demux_push_wait_ms =
+        analysisd_resolve_push_wait_ms("demux_push_wait_ms", 50);
+    cfg_shard_push_wait_ms =
+        analysisd_resolve_push_wait_ms("shard_push_wait_ms", 75);
+    cfg_alerts_push_wait_ms =
+        analysisd_resolve_push_wait_ms("alerts_push_wait_ms", 100);
+
+    decode_event_thread_count = cfg_event_threads;
+    decode_syscheck_thread_count = cfg_syscheck_threads;
+    decode_rootcheck_thread_count = cfg_rootcheck_threads;
+    decode_hostinfo_thread_count = cfg_hostinfo_threads;
+    process_event_thread_count = cfg_rule_matching_threads;
+    input_demux_thread_count = cfg_input_demux_threads;
+
+    analysisd_state_init();
+    analysisd_init_queues();
+
+    os_calloc((size_t)process_event_thread_count, sizeof(EventList *), shard_lists);
+    os_calloc((size_t)process_event_thread_count, sizeof(OSHash *), shard_acm_stores);
+    for (i = 0; i < process_event_thread_count; i++) {
+        shard_lists[i] = OS_EventList_Create(Config.memorysize);
+        shard_acm_stores[i] = Accumulate_CreateStore();
+        if (!shard_acm_stores[i]) {
+            ErrorExit("%s: ERROR: Unable to create per-shard Accumulate store.", ARGV0);
+        }
+    }
+
+    os_calloc((size_t)decode_event_thread_count, sizeof(pthread_t), decode_event_threads);
+    os_calloc((size_t)decode_syscheck_thread_count, sizeof(pthread_t), decode_syscheck_threads);
+    os_calloc((size_t)decode_rootcheck_thread_count, sizeof(pthread_t), decode_rootcheck_threads);
+    os_calloc((size_t)decode_hostinfo_thread_count, sizeof(pthread_t), decode_hostinfo_threads);
+    os_calloc((size_t)process_event_thread_count, sizeof(pthread_t), process_event_threads);
+    os_calloc((size_t)input_demux_thread_count, sizeof(pthread_t), input_demux_threads);
+
+    CreateThreadJoinable(&writer_log_thread_id, analysisd_writer_log_thread, NULL);
+    CreateThreadJoinable(&writer_statistical_thread_id,
+                         analysisd_writer_statistical_thread, NULL);
+    CreateThreadJoinable(&writer_archive_thread_id, analysisd_writer_archive_thread, NULL);
+    CreateThreadJoinable(&writer_firewall_thread_id, analysisd_writer_firewall_thread, NULL);
+    CreateThreadJoinable(&writer_fts_thread_id, analysisd_writer_fts_thread, NULL);
+    CreateThreadJoinable(&state_thread_id, analysisd_state_thread, NULL);
+
+    for (i = 0; i < decode_syscheck_thread_count; i++) {
+        CreateThreadJoinable(&decode_syscheck_threads[i], analysisd_decode_syscheck_thread, NULL);
+    }
+    for (i = 0; i < decode_rootcheck_thread_count; i++) {
+        CreateThreadJoinable(&decode_rootcheck_threads[i], analysisd_decode_rootcheck_thread, NULL);
+    }
+    for (i = 0; i < decode_hostinfo_thread_count; i++) {
+        CreateThreadJoinable(&decode_hostinfo_threads[i], analysisd_decode_hostinfo_thread, NULL);
+    }
+    for (i = 0; i < decode_event_thread_count; i++) {
+        CreateThreadJoinable(&decode_event_threads[i], analysisd_decode_worker_thread,
+                             decode_queue_event_input);
+    }
+    for (i = 0; i < process_event_thread_count; i++) {
+        CreateThreadJoinable(&process_event_threads[i], analysisd_process_event_thread,
+                             (void *)(intptr_t)i);
+    }
+
+    CreateThreadJoinable(&input_recv_thread_id, analysisd_input_recv_thread, NULL);
+    for (i = 0; i < input_demux_thread_count; i++) {
+        CreateThreadJoinable(&input_demux_threads[i], analysisd_input_demux_thread, NULL);
+    }
+
+    verbose("%s: INFO: Multi-threaded analysisd pipeline started "
+            "(event_threads=%d syscheck=%d rootcheck=%d hostinfo=%d "
+            "rule_matching=%d shards=%d input_demux=%d).",
+            ARGV0, decode_event_thread_count, decode_syscheck_thread_count,
+            decode_rootcheck_thread_count, decode_hostinfo_thread_count,
+            process_event_thread_count, process_event_thread_count,
+            input_demux_thread_count);
+    if (process_event_thread_count > 1) {
+        verbose("%s: INFO: Correlation shards=%d: Search_LastEvents is "
+                "per-location; cross-agent frequency needs if_matched_sid "
+                "or if_matched_group.",
+                ARGV0, process_event_thread_count);
+    }
+
+    while (!analysisd_shutting_down) {
+        sleep(1);
+    }
+
+    verbose("%s: INFO: Shutting down analysisd pipeline.", ARGV0);
+    analysisd_pipeline_shutdown();
+}
+
+#endif /* !WIN32 */

--- a/src/analysisd/pipeline.c
+++ b/src/analysisd/pipeline.c
@@ -220,10 +220,9 @@ static int analysisd_queue_push_wait(os_queue *queue, void *data, int wait_ms)
 
 static void analysisd_writer_sync_alert(Eventinfo *lf)
 {
+    /* Prefer ticketed IDs; never ftell(_aflog) here — that races log rollover. */
     if (lf && lf->alert_id) {
         __crt_ftell = lf->alert_id;
-    } else if (_aflog) {
-        __crt_ftell = ftell(_aflog);
     } else {
         __crt_ftell = 0;
     }

--- a/src/analysisd/pipeline.h
+++ b/src/analysisd/pipeline.h
@@ -1,0 +1,59 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef ANALYSISD_PIPELINE_H
+#define ANALYSISD_PIPELINE_H
+
+#ifndef WIN32
+
+#include "eventinfo.h"
+#include "os_regex/os_regex.h"
+#include "queue_op.h"
+
+#define ANALYSISD_SHUTDOWN_TIMEOUT 30
+
+Eventinfo *analysisd_event_alloc(void);
+void analysisd_set_time_context(Eventinfo *lf);
+int analysisd_handle_hour_rollover(Eventinfo *lf);
+Eventinfo *analysisd_decode_event(Eventinfo *lf, char mq_prefix, regex_matching *decoder_match);
+/* Returns 1 if lf ownership transferred to a writer (caller must not free). */
+int analysisd_analyze_event(Eventinfo *lf);
+void analysisd_finish_event(Eventinfo *lf);
+
+Eventinfo *analysisd_copy_event_for_log(const Eventinfo *lf);
+/* Enqueue alert copy with timed wait; sync-write fallback under writer mutex. */
+int analysisd_enqueue_alert(Eventinfo *lf);
+/* Enqueue Check_Hour / statistical alert; timed wait + sync OS_Log fallback. */
+int analysisd_enqueue_statistical(Eventinfo *lf);
+
+/* Ticket-style alert IDs for async writers (replaces sole reliance on ftell). */
+long analysisd_claim_alert_id(void);
+
+void analysisd_pipeline_run(int m_queue);
+void analysisd_pipeline_shutdown(void);
+void analysisd_pipeline_request_shutdown(void);
+void analysisd_log_pipeline_metrics(unsigned int decoded, unsigned int processed,
+                                    unsigned int dropped);
+
+void analysisd_init_queues(void);
+void analysisd_destroy_queues(void);
+
+/* Exported for analysisd_stages.c / state.c / fts.c */
+extern os_queue *raw_input_queue;
+extern os_queue *writer_queue_log;
+extern os_queue *writer_queue_statistical;
+extern os_queue *writer_queue_archive;
+extern os_queue *writer_queue_firewall;
+extern os_queue *writer_queue_fts;
+extern os_queue **decode_queue_event_output;
+extern int decode_queue_event_output_count;
+
+#endif /* !WIN32 */
+
+#endif /* ANALYSISD_PIPELINE_H */

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -13,7 +13,11 @@
 #include "compiled_rules/compiled_rules.h"
 
 /* Global definition */
+#ifndef WIN32
+__thread RuleInfo *currently_rule;
+#else
 RuleInfo *currently_rule;
+#endif
 
 /* Change path for test rule */
 #ifdef TESTRULE
@@ -1649,6 +1653,7 @@ RuleInfo *zerorulemember(int id, int level,
 
     ruleinfo_pt->sigid = id;
     ruleinfo_pt->firedtimes = 0;
+    os_mutex_init(&ruleinfo_pt->mutex, NULL);
     ruleinfo_pt->maxsize = maxsize;
     ruleinfo_pt->frequency = frequency;
     if (ruleinfo_pt->frequency > _max_freq) {

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -10,6 +10,8 @@
 #ifndef _OS_RULES
 #define _OS_RULES
 
+#include <pthread.h>
+
 #define MAX_LAST_EVENTS 11
 
 #define MAX_TIMEFRAME 604800
@@ -97,6 +99,9 @@ typedef struct _RuleInfo {
     int __frequency;
     char **last_events;
     int last_events_copied;
+
+    /* Protects firedtimes / last_events / prev_matched inserts under parallel matching. */
+    pthread_mutex_t mutex;
 
     /* Not an option in the rule */
     u_int16_t alert_opts;
@@ -195,7 +200,11 @@ typedef struct _RuleNode {
 } RuleNode;
 
 
+#ifndef WIN32
+extern __thread RuleInfo *currently_rule;
+#else
 extern RuleInfo *currently_rule;
+#endif
 
 RuleInfoDetail *zeroinfodetails(int type, const char *data);
 int get_info_attributes(char **attributes, char **values);

--- a/src/analysisd/rules_list.c
+++ b/src/analysisd/rules_list.c
@@ -375,6 +375,11 @@ int OS_MarkID(RuleNode *r_node, RuleInfo *orig_rule)
                                                 Mark_EventNodeDelete)) {
                     ErrorExit("%s: ERROR: Unable to set free data pointer for sid list", ARGV0);
                 }
+
+                if (!OSList_SetMaxSize(r_node->ruleinfo->sid_prev_matched,
+                        getDefine_Int("analysisd", "sid_prev_matched_max", 16, 65536))) {
+                    ErrorExit("%s: ERROR: Unable to set sid_prev_matched max size", ARGV0);
+                }
             }
 
             /* Assign the parent pointer to it */

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -1,0 +1,563 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef WIN32
+
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "shared.h"
+#include "state.h"
+#include "pipeline.h"
+#include "queue_op.h"
+
+extern os_queue *decode_queue_event_input;
+extern os_queue *decode_queue_syscheck_input;
+extern os_queue *decode_queue_rootcheck_input;
+extern os_queue *decode_queue_hostinfo_input;
+extern os_queue **decode_queue_event_output;
+extern int decode_queue_event_output_count;
+extern os_queue *raw_input_queue;
+extern os_queue *writer_queue_log;
+extern os_queue *writer_queue_statistical;
+extern os_queue *writer_queue_archive;
+extern os_queue *writer_queue_firewall;
+extern os_queue *writer_queue_fts;
+
+static volatile int state_shutdown = 0;
+static int state_interval = 5;
+
+static unsigned int s_received_events = 0;
+static unsigned int s_decoded_events = 0;
+static unsigned int s_processed_events = 0;
+static unsigned int s_dropped_events = 0;
+static unsigned int s_shard_dropped = 0;
+static unsigned int s_alerts_dropped = 0;
+static unsigned int s_syscheck_decoded = 0;
+static unsigned int s_rootcheck_decoded = 0;
+static unsigned int s_hostinfo_decoded = 0;
+static unsigned int s_alerts_written = 0;
+static unsigned int s_archives_written = 0;
+static unsigned int s_firewall_written = 0;
+static unsigned int s_archives_dropped = 0;
+
+/* EPDS: events processed during last state_interval window. */
+static unsigned int s_prev_processed = 0;
+static unsigned int s_prev_dropped = 0;
+static unsigned int s_prev_shard_dropped = 0;
+static unsigned int s_prev_alerts_dropped = 0;
+static unsigned int s_prev_archives_dropped = 0;
+static unsigned int s_dropped_delta = 0;
+static unsigned int s_shard_dropped_delta = 0;
+static unsigned int s_alerts_dropped_delta = 0;
+static unsigned int s_archives_dropped_delta = 0;
+static double s_epds = 0.0;
+static double s_alerts_q_wait_ms_est = 0.0;
+
+/* Circular sample buffers for enqueue→dequeue wait (microseconds). */
+#define ANALYSISD_QWAIT_SAMPLES 1024
+static unsigned int s_shard_wait_us[ANALYSISD_QWAIT_SAMPLES];
+static unsigned int s_alerts_wait_us[ANALYSISD_QWAIT_SAMPLES];
+static unsigned int s_shard_wait_idx = 0;
+static unsigned int s_alerts_wait_idx = 0;
+static unsigned int s_shard_wait_count = 0;
+static unsigned int s_alerts_wait_count = 0;
+static unsigned int s_shard_wait_p50_us = 0;
+static unsigned int s_shard_wait_p99_us = 0;
+static unsigned int s_alerts_wait_p50_us = 0;
+static unsigned int s_alerts_wait_p99_us = 0;
+
+void analysisd_state_init(void)
+{
+    state_shutdown = 0;
+    state_interval = getDefine_Int("analysisd", "state_interval", 0, 86400);
+}
+
+void analysisd_state_shutdown(void)
+{
+    state_shutdown = 1;
+}
+
+static void analysisd_inc_counter(unsigned int *counter)
+{
+    __sync_add_and_fetch(counter, 1);
+}
+
+static unsigned int analysisd_get_counter(unsigned int *counter)
+{
+    return __sync_fetch_and_add(counter, 0);
+}
+
+void analysisd_inc_decoded_events(void) { analysisd_inc_counter(&s_decoded_events); }
+void analysisd_inc_processed_events(void) { analysisd_inc_counter(&s_processed_events); }
+void analysisd_inc_received_events(void) { analysisd_inc_counter(&s_received_events); }
+void analysisd_inc_dropped_events(void) { analysisd_inc_counter(&s_dropped_events); }
+void analysisd_inc_shard_dropped(void) { analysisd_inc_counter(&s_shard_dropped); }
+void analysisd_inc_alerts_dropped(void) { analysisd_inc_counter(&s_alerts_dropped); }
+void analysisd_inc_syscheck_decoded_events(void) { analysisd_inc_counter(&s_syscheck_decoded); }
+void analysisd_inc_rootcheck_decoded_events(void) { analysisd_inc_counter(&s_rootcheck_decoded); }
+void analysisd_inc_hostinfo_decoded_events(void) { analysisd_inc_counter(&s_hostinfo_decoded); }
+void analysisd_inc_alerts_written(void) { analysisd_inc_counter(&s_alerts_written); }
+void analysisd_inc_archives_written(void) { analysisd_inc_counter(&s_archives_written); }
+void analysisd_inc_firewall_written(void) { analysisd_inc_counter(&s_firewall_written); }
+void analysisd_inc_archives_dropped(void) { analysisd_inc_counter(&s_archives_dropped); }
+
+unsigned int analysisd_get_dropped_events(void) { return analysisd_get_counter(&s_dropped_events); }
+unsigned int analysisd_get_shard_dropped(void) { return analysisd_get_counter(&s_shard_dropped); }
+unsigned int analysisd_get_alerts_dropped(void) { return analysisd_get_counter(&s_alerts_dropped); }
+unsigned int analysisd_get_received_events(void) { return analysisd_get_counter(&s_received_events); }
+unsigned int analysisd_get_decoded_events(void) { return analysisd_get_counter(&s_decoded_events); }
+unsigned int analysisd_get_processed_events(void) { return analysisd_get_counter(&s_processed_events); }
+unsigned int analysisd_get_syscheck_decoded_events(void) { return analysisd_get_counter(&s_syscheck_decoded); }
+unsigned int analysisd_get_rootcheck_decoded_events(void) { return analysisd_get_counter(&s_rootcheck_decoded); }
+unsigned int analysisd_get_hostinfo_decoded_events(void) { return analysisd_get_counter(&s_hostinfo_decoded); }
+unsigned int analysisd_get_alerts_written(void) { return analysisd_get_counter(&s_alerts_written); }
+unsigned int analysisd_get_archives_written(void) { return analysisd_get_counter(&s_archives_written); }
+unsigned int analysisd_get_firewall_written(void) { return analysisd_get_counter(&s_firewall_written); }
+unsigned int analysisd_get_archives_dropped(void) { return analysisd_get_counter(&s_archives_dropped); }
+
+void analysisd_stamp_queue_in(Eventinfo *lf)
+{
+    if (!lf) {
+        return;
+    }
+    if (clock_gettime(CLOCK_MONOTONIC, &lf->queue_in_time) != 0) {
+        lf->queue_in_time.tv_sec = 0;
+        lf->queue_in_time.tv_nsec = 0;
+    }
+}
+
+void analysisd_sample_queue_wait(Eventinfo *lf, int which)
+{
+    struct timespec now;
+    unsigned long long us;
+    unsigned int *buf;
+    unsigned int *idx;
+    unsigned int *count;
+    unsigned int slot;
+
+    if (!lf || (lf->queue_in_time.tv_sec == 0 && lf->queue_in_time.tv_nsec == 0)) {
+        return;
+    }
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return;
+    }
+
+    us = (unsigned long long)(now.tv_sec - lf->queue_in_time.tv_sec) * 1000000ULL;
+    if (now.tv_nsec >= lf->queue_in_time.tv_nsec) {
+        us += (unsigned long long)(now.tv_nsec - lf->queue_in_time.tv_nsec) / 1000ULL;
+    } else {
+        us -= 1000000ULL;
+        us += (unsigned long long)(now.tv_nsec + 1000000000L - lf->queue_in_time.tv_nsec) / 1000ULL;
+    }
+
+    if (us > 0xffffffffULL) {
+        us = 0xffffffffULL;
+    }
+
+    if (which == ANALYSISD_QWAIT_ALERTS) {
+        buf = s_alerts_wait_us;
+        idx = &s_alerts_wait_idx;
+        count = &s_alerts_wait_count;
+    } else {
+        buf = s_shard_wait_us;
+        idx = &s_shard_wait_idx;
+        count = &s_shard_wait_count;
+    }
+
+    slot = __sync_fetch_and_add(idx, 1) % ANALYSISD_QWAIT_SAMPLES;
+    buf[slot] = (unsigned int)us;
+    __sync_add_and_fetch(count, 1);
+}
+
+static int analysisd_cmp_uint(const void *a, const void *b)
+{
+    unsigned int ua = *(const unsigned int *)a;
+    unsigned int ub = *(const unsigned int *)b;
+
+    if (ua < ub) {
+        return -1;
+    }
+    if (ua > ub) {
+        return 1;
+    }
+    return 0;
+}
+
+static void analysisd_percentile_us(const unsigned int *src, unsigned int filled,
+                                    unsigned int *p50, unsigned int *p99)
+{
+    unsigned int tmp[ANALYSISD_QWAIT_SAMPLES];
+    unsigned int n;
+    unsigned int i50;
+    unsigned int i99;
+
+    *p50 = 0;
+    *p99 = 0;
+    if (filled == 0) {
+        return;
+    }
+
+    n = filled < ANALYSISD_QWAIT_SAMPLES ? filled : ANALYSISD_QWAIT_SAMPLES;
+    memcpy(tmp, src, n * sizeof(unsigned int));
+    qsort(tmp, n, sizeof(unsigned int), analysisd_cmp_uint);
+
+    i50 = (n * 50) / 100;
+    i99 = (n * 99) / 100;
+    if (i50 >= n) {
+        i50 = n - 1;
+    }
+    if (i99 >= n) {
+        i99 = n - 1;
+    }
+    *p50 = tmp[i50];
+    *p99 = tmp[i99];
+}
+
+static float analysisd_queue_usage(const os_queue *queue)
+{
+    unsigned int elements;
+    unsigned int capacity;
+
+    if (!queue || queue->size < 2) {
+        return 0.0f;
+    }
+
+    elements = os_queue_elements(queue);
+    capacity = (unsigned int)(queue->size - 1);
+    if (capacity == 0) {
+        return 0.0f;
+    }
+
+    return (float)elements / (float)capacity;
+}
+
+static unsigned int analysisd_queue_capacity(const os_queue *queue)
+{
+    if (!queue || queue->size < 2) {
+        return 0;
+    }
+
+    return (unsigned int)(queue->size - 1);
+}
+
+static float analysisd_sharded_queue_usage(void)
+{
+    int i;
+    unsigned long elements = 0;
+    unsigned long capacity = 0;
+
+    if (!decode_queue_event_output || decode_queue_event_output_count <= 0) {
+        return 0.0f;
+    }
+
+    for (i = 0; i < decode_queue_event_output_count; i++) {
+        elements += os_queue_elements(decode_queue_event_output[i]);
+        capacity += analysisd_queue_capacity(decode_queue_event_output[i]);
+    }
+
+    if (capacity == 0) {
+        return 0.0f;
+    }
+
+    return (float)elements / (float)capacity;
+}
+
+static unsigned int analysisd_sharded_queue_capacity(void)
+{
+    int i;
+    unsigned int capacity = 0;
+
+    if (!decode_queue_event_output || decode_queue_event_output_count <= 0) {
+        return 0;
+    }
+
+    for (i = 0; i < decode_queue_event_output_count; i++) {
+        capacity += analysisd_queue_capacity(decode_queue_event_output[i]);
+    }
+
+    return capacity;
+}
+
+int analysisd_write_state(void)
+{
+    FILE *fp;
+    char path[PATH_MAX - 8];
+    char path_temp[PATH_MAX + 1];
+    unsigned int dropped;
+    unsigned int processed;
+    unsigned int processed_delta;
+    unsigned int alerts_depth;
+    unsigned int shard_n;
+    unsigned int alerts_n;
+
+    if (!strcmp(__local_name, "unset")) {
+        merror("%s: At analysisd_write_state(): __local_name is unset.", ARGV0);
+        return -1;
+    }
+
+    snprintf(path, sizeof(path), OS_PIDFILE "/%s.state", __local_name);
+    snprintf(path_temp, sizeof(path_temp), "%s.temp", path);
+
+    fp = fopen(path_temp, "w");
+    if (!fp) {
+        merror(FOPEN_ERROR, ARGV0, path_temp, errno, strerror(errno));
+        return -1;
+    }
+
+    dropped = analysisd_get_dropped_events();
+    processed = analysisd_get_processed_events();
+    processed_delta = (processed >= s_prev_processed) ?
+                      (processed - s_prev_processed) : processed;
+    if (state_interval > 0) {
+        s_epds = (double)processed_delta / (double)state_interval;
+    } else {
+        s_epds = 0.0;
+    }
+    s_prev_processed = processed;
+
+    {
+        unsigned int shard_dropped = analysisd_get_shard_dropped();
+        unsigned int alerts_dropped = analysisd_get_alerts_dropped();
+        unsigned int archives_dropped = analysisd_get_archives_dropped();
+
+        s_dropped_delta = (dropped >= s_prev_dropped) ?
+                          (dropped - s_prev_dropped) : dropped;
+        s_shard_dropped_delta = (shard_dropped >= s_prev_shard_dropped) ?
+                                (shard_dropped - s_prev_shard_dropped) :
+                                shard_dropped;
+        s_alerts_dropped_delta = (alerts_dropped >= s_prev_alerts_dropped) ?
+                                 (alerts_dropped - s_prev_alerts_dropped) :
+                                 alerts_dropped;
+        s_archives_dropped_delta = (archives_dropped >= s_prev_archives_dropped) ?
+                                   (archives_dropped - s_prev_archives_dropped) :
+                                   archives_dropped;
+        s_prev_dropped = dropped;
+        s_prev_shard_dropped = shard_dropped;
+        s_prev_alerts_dropped = alerts_dropped;
+        s_prev_archives_dropped = archives_dropped;
+    }
+
+    alerts_depth = 0;
+    if (writer_queue_log) {
+        alerts_depth = os_queue_elements(writer_queue_log);
+    }
+    if (s_epds > 0.0) {
+        s_alerts_q_wait_ms_est = ((double)alerts_depth / s_epds) * 1000.0;
+    } else {
+        s_alerts_q_wait_ms_est = 0.0;
+    }
+
+    shard_n = analysisd_get_counter(&s_shard_wait_count);
+    alerts_n = analysisd_get_counter(&s_alerts_wait_count);
+    analysisd_percentile_us(s_shard_wait_us, shard_n,
+                            &s_shard_wait_p50_us, &s_shard_wait_p99_us);
+    analysisd_percentile_us(s_alerts_wait_us, alerts_n,
+                            &s_alerts_wait_p50_us, &s_alerts_wait_p99_us);
+
+    fprintf(fp,
+            "# State file for %s (pipeline metrics)\n"
+            "\n"
+            "# Events accepted from the Unix MQ (before raw queue)\n"
+            "events_received='%u'\n"
+            "\n"
+            "# Events decoded (general decode workers)\n"
+            "events_decoded='%u'\n"
+            "\n"
+            "# Syscheck events decoded\n"
+            "syscheck_events_decoded='%u'\n"
+            "\n"
+            "# Rootcheck events decoded\n"
+            "rootcheck_events_decoded='%u'\n"
+            "\n"
+            "# Hostinfo events decoded\n"
+            "hostinfo_events_decoded='%u'\n"
+            "\n"
+            "# Events processed (rule matching)\n"
+            "events_processed='%u'\n"
+            "\n"
+            "# Events dropped (decode input queue full)\n"
+            "events_dropped='%u'\n"
+            "\n"
+            "# Events dropped since last state write\n"
+            "events_dropped_delta='%u'\n"
+            "\n"
+            "# Events dropped (decode->shard output timed out)\n"
+            "events_dropped_shard='%u'\n"
+            "\n"
+            "# Shard drops since last state write\n"
+            "events_dropped_shard_delta='%u'\n"
+            "\n"
+            "# Alerts dropped (alert queue timed out without sync fallback write)\n"
+            "alerts_dropped='%u'\n"
+            "\n"
+            "# Alerts dropped since last state write\n"
+            "alerts_dropped_delta='%u'\n"
+            "\n"
+            "# Archives dropped (archive writer queue full; logall is best-effort)\n"
+            "archives_dropped='%u'\n"
+            "\n"
+            "# Archives dropped since last state write\n"
+            "archives_dropped_delta='%u'\n"
+            "\n"
+            "# Alerts written\n"
+            "alerts_written='%u'\n"
+            "\n"
+            "# Archives written\n"
+            "archives_written='%u'\n"
+            "\n"
+            "# Firewall events written\n"
+            "firewall_written='%u'\n"
+            "\n"
+            "# Raw input queue (recv -> demux)\n"
+            "raw_input_queue_usage='%.2f'\n"
+            "raw_input_queue_size='%u'\n"
+            "\n"
+            "# Decode event input queue\n"
+            "event_queue_usage='%.2f'\n"
+            "event_queue_size='%u'\n"
+            "\n"
+            "# Syscheck decode input queue\n"
+            "syscheck_queue_usage='%.2f'\n"
+            "syscheck_queue_size='%u'\n"
+            "\n"
+            "# Rootcheck decode input queue\n"
+            "rootcheck_queue_usage='%.2f'\n"
+            "rootcheck_queue_size='%u'\n"
+            "\n"
+            "# Hostinfo decode input queue\n"
+            "hostinfo_queue_usage='%.2f'\n"
+            "hostinfo_queue_size='%u'\n"
+            "\n"
+            "# Rule matching (decode output) queue\n"
+            "rule_matching_queue_usage='%.2f'\n"
+            "rule_matching_queue_size='%u'\n"
+            "\n"
+            "# Alerts writer queue\n"
+            "alerts_queue_usage='%.2f'\n"
+            "alerts_queue_size='%u'\n"
+            "\n"
+            "# Statistical (Check_Hour) writer queue\n"
+            "statistical_queue_usage='%.2f'\n"
+            "statistical_queue_size='%u'\n"
+            "\n"
+            "# Archives writer queue\n"
+            "archives_queue_usage='%.2f'\n"
+            "archives_queue_size='%u'\n"
+            "\n"
+            "# Firewall writer queue\n"
+            "firewall_queue_usage='%.2f'\n"
+            "firewall_queue_size='%u'\n"
+            "\n"
+            "# FTS writer queue\n"
+            "fts_queue_usage='%.2f'\n"
+            "fts_queue_size='%u'\n"
+            "\n"
+            "# Events processed per second (over state_interval)\n"
+            "events_processed_per_second='%.2f'\n"
+            "\n"
+            "# Estimated alerts queue wait (elements / epds), milliseconds\n"
+            "alerts_queue_wait_ms_est='%.2f'\n"
+            "\n"
+            "# Sampled queue wait percentiles (microseconds)\n"
+            "rule_matching_queue_wait_p50_us='%u'\n"
+            "rule_matching_queue_wait_p99_us='%u'\n"
+            "alerts_queue_wait_p50_us='%u'\n"
+            "alerts_queue_wait_p99_us='%u'\n",
+            __local_name,
+            analysisd_get_received_events(),
+            analysisd_get_decoded_events(),
+            analysisd_get_syscheck_decoded_events(),
+            analysisd_get_rootcheck_decoded_events(),
+            analysisd_get_hostinfo_decoded_events(),
+            analysisd_get_processed_events(),
+            dropped,
+            s_dropped_delta,
+            analysisd_get_shard_dropped(),
+            s_shard_dropped_delta,
+            analysisd_get_alerts_dropped(),
+            s_alerts_dropped_delta,
+            analysisd_get_archives_dropped(),
+            s_archives_dropped_delta,
+            analysisd_get_alerts_written(),
+            analysisd_get_archives_written(),
+            analysisd_get_firewall_written(),
+            analysisd_queue_usage(raw_input_queue),
+            analysisd_queue_capacity(raw_input_queue),
+            analysisd_queue_usage(decode_queue_event_input),
+            analysisd_queue_capacity(decode_queue_event_input),
+            analysisd_queue_usage(decode_queue_syscheck_input),
+            analysisd_queue_capacity(decode_queue_syscheck_input),
+            analysisd_queue_usage(decode_queue_rootcheck_input),
+            analysisd_queue_capacity(decode_queue_rootcheck_input),
+            analysisd_queue_usage(decode_queue_hostinfo_input),
+            analysisd_queue_capacity(decode_queue_hostinfo_input),
+            analysisd_sharded_queue_usage(),
+            analysisd_sharded_queue_capacity(),
+            analysisd_queue_usage(writer_queue_log),
+            analysisd_queue_capacity(writer_queue_log),
+            analysisd_queue_usage(writer_queue_statistical),
+            analysisd_queue_capacity(writer_queue_statistical),
+            analysisd_queue_usage(writer_queue_archive),
+            analysisd_queue_capacity(writer_queue_archive),
+            analysisd_queue_usage(writer_queue_firewall),
+            analysisd_queue_capacity(writer_queue_firewall),
+            analysisd_queue_usage(writer_queue_fts),
+            analysisd_queue_capacity(writer_queue_fts),
+            s_epds,
+            s_alerts_q_wait_ms_est,
+            s_shard_wait_p50_us,
+            s_shard_wait_p99_us,
+            s_alerts_wait_p50_us,
+            s_alerts_wait_p99_us);
+
+    fclose(fp);
+
+    if (rename(path_temp, path) < 0) {
+        merror("%s: ERROR: Unable to update state file '%s': %s",
+               ARGV0, path, strerror(errno));
+        unlink(path_temp);
+        return -1;
+    }
+
+    analysisd_log_pipeline_metrics(analysisd_get_decoded_events(),
+                                   analysisd_get_processed_events(),
+                                   dropped);
+    return 0;
+}
+
+void *analysisd_state_thread(void *arg)
+{
+    int i;
+
+    (void)arg;
+
+    os_block_worker_signals();
+
+    if (!state_interval) {
+        verbose("%s: INFO: analysisd state file disabled (state_interval=0).", ARGV0);
+        while (!state_shutdown) {
+            sleep(1);
+        }
+        return NULL;
+    }
+
+    while (!state_shutdown) {
+        analysisd_write_state();
+
+        for (i = 0; i < state_interval && !state_shutdown; i++) {
+            sleep(1);
+        }
+    }
+
+    return NULL;
+}
+
+#endif /* !WIN32 */

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -287,11 +287,9 @@ static unsigned int analysisd_sharded_queue_capacity(void)
 }
 
 /* Unsigned wraparound preserves the modular delta across UINT_MAX. */
-static unsigned int analysisd_delta_since(unsigned int current, unsigned int *prev)
+static unsigned int analysisd_delta_since(unsigned int current, unsigned int prev)
 {
-    unsigned int delta = current - *prev;
-    *prev = current;
-    return delta;
+    return current - prev;
 }
 
 int analysisd_write_state(void)
@@ -302,6 +300,9 @@ int analysisd_write_state(void)
     unsigned int dropped;
     unsigned int processed;
     unsigned int processed_delta;
+    unsigned int shard_dropped;
+    unsigned int alerts_dropped;
+    unsigned int archives_dropped;
     unsigned int alerts_depth;
     unsigned int shard_n;
     unsigned int alerts_n;
@@ -322,23 +323,22 @@ int analysisd_write_state(void)
 
     dropped = analysisd_get_dropped_events();
     processed = analysisd_get_processed_events();
-    processed_delta = analysisd_delta_since(processed, &s_prev_processed);
+    shard_dropped = analysisd_get_shard_dropped();
+    alerts_dropped = analysisd_get_alerts_dropped();
+    archives_dropped = analysisd_get_archives_dropped();
+
+    /* Compute deltas from committed baselines; update baselines only after
+     * the state file is persisted successfully below. */
+    processed_delta = analysisd_delta_since(processed, s_prev_processed);
+    s_dropped_delta = analysisd_delta_since(dropped, s_prev_dropped);
+    s_shard_dropped_delta = analysisd_delta_since(shard_dropped, s_prev_shard_dropped);
+    s_alerts_dropped_delta = analysisd_delta_since(alerts_dropped, s_prev_alerts_dropped);
+    s_archives_dropped_delta = analysisd_delta_since(archives_dropped,
+                                                     s_prev_archives_dropped);
     if (state_interval > 0) {
         s_epds = (double)processed_delta / (double)state_interval;
     } else {
         s_epds = 0.0;
-    }
-
-    {
-        unsigned int shard_dropped = analysisd_get_shard_dropped();
-        unsigned int alerts_dropped = analysisd_get_alerts_dropped();
-        unsigned int archives_dropped = analysisd_get_archives_dropped();
-
-        s_dropped_delta = analysisd_delta_since(dropped, &s_prev_dropped);
-        s_shard_dropped_delta = analysisd_delta_since(shard_dropped, &s_prev_shard_dropped);
-        s_alerts_dropped_delta = analysisd_delta_since(alerts_dropped, &s_prev_alerts_dropped);
-        s_archives_dropped_delta = analysisd_delta_since(archives_dropped,
-                                                         &s_prev_archives_dropped);
     }
 
     alerts_depth = 0;
@@ -522,6 +522,12 @@ int analysisd_write_state(void)
         unlink(path_temp);
         return -1;
     }
+
+    s_prev_processed = processed;
+    s_prev_dropped = dropped;
+    s_prev_shard_dropped = shard_dropped;
+    s_prev_alerts_dropped = alerts_dropped;
+    s_prev_archives_dropped = archives_dropped;
 
     analysisd_log_pipeline_metrics(analysisd_get_decoded_events(),
                                    analysisd_get_processed_events(),

--- a/src/analysisd/state.c
+++ b/src/analysisd/state.c
@@ -286,6 +286,14 @@ static unsigned int analysisd_sharded_queue_capacity(void)
     return capacity;
 }
 
+/* Unsigned wraparound preserves the modular delta across UINT_MAX. */
+static unsigned int analysisd_delta_since(unsigned int current, unsigned int *prev)
+{
+    unsigned int delta = current - *prev;
+    *prev = current;
+    return delta;
+}
+
 int analysisd_write_state(void)
 {
     FILE *fp;
@@ -314,35 +322,23 @@ int analysisd_write_state(void)
 
     dropped = analysisd_get_dropped_events();
     processed = analysisd_get_processed_events();
-    processed_delta = (processed >= s_prev_processed) ?
-                      (processed - s_prev_processed) : processed;
+    processed_delta = analysisd_delta_since(processed, &s_prev_processed);
     if (state_interval > 0) {
         s_epds = (double)processed_delta / (double)state_interval;
     } else {
         s_epds = 0.0;
     }
-    s_prev_processed = processed;
 
     {
         unsigned int shard_dropped = analysisd_get_shard_dropped();
         unsigned int alerts_dropped = analysisd_get_alerts_dropped();
         unsigned int archives_dropped = analysisd_get_archives_dropped();
 
-        s_dropped_delta = (dropped >= s_prev_dropped) ?
-                          (dropped - s_prev_dropped) : dropped;
-        s_shard_dropped_delta = (shard_dropped >= s_prev_shard_dropped) ?
-                                (shard_dropped - s_prev_shard_dropped) :
-                                shard_dropped;
-        s_alerts_dropped_delta = (alerts_dropped >= s_prev_alerts_dropped) ?
-                                 (alerts_dropped - s_prev_alerts_dropped) :
-                                 alerts_dropped;
-        s_archives_dropped_delta = (archives_dropped >= s_prev_archives_dropped) ?
-                                   (archives_dropped - s_prev_archives_dropped) :
-                                   archives_dropped;
-        s_prev_dropped = dropped;
-        s_prev_shard_dropped = shard_dropped;
-        s_prev_alerts_dropped = alerts_dropped;
-        s_prev_archives_dropped = archives_dropped;
+        s_dropped_delta = analysisd_delta_since(dropped, &s_prev_dropped);
+        s_shard_dropped_delta = analysisd_delta_since(shard_dropped, &s_prev_shard_dropped);
+        s_alerts_dropped_delta = analysisd_delta_since(alerts_dropped, &s_prev_alerts_dropped);
+        s_archives_dropped_delta = analysisd_delta_since(archives_dropped,
+                                                         &s_prev_archives_dropped);
     }
 
     alerts_depth = 0;

--- a/src/analysisd/state.h
+++ b/src/analysisd/state.h
@@ -1,0 +1,59 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef ANALYSISD_STATE_H
+#define ANALYSISD_STATE_H
+
+#ifndef WIN32
+
+#include "eventinfo.h"
+
+/* Queue-wait sample channels for analysisd_sample_queue_wait(). */
+#define ANALYSISD_QWAIT_SHARD  0
+#define ANALYSISD_QWAIT_ALERTS 1
+
+void analysisd_state_init(void);
+void analysisd_state_shutdown(void);
+void *analysisd_state_thread(void *arg);
+int analysisd_write_state(void);
+
+void analysisd_inc_decoded_events(void);
+void analysisd_inc_processed_events(void);
+void analysisd_inc_received_events(void);
+void analysisd_inc_dropped_events(void);
+void analysisd_inc_shard_dropped(void);
+void analysisd_inc_alerts_dropped(void);
+void analysisd_inc_syscheck_decoded_events(void);
+void analysisd_inc_rootcheck_decoded_events(void);
+void analysisd_inc_hostinfo_decoded_events(void);
+void analysisd_inc_alerts_written(void);
+void analysisd_inc_archives_written(void);
+void analysisd_inc_firewall_written(void);
+void analysisd_inc_archives_dropped(void);
+
+unsigned int analysisd_get_dropped_events(void);
+unsigned int analysisd_get_shard_dropped(void);
+unsigned int analysisd_get_alerts_dropped(void);
+unsigned int analysisd_get_received_events(void);
+unsigned int analysisd_get_decoded_events(void);
+unsigned int analysisd_get_processed_events(void);
+unsigned int analysisd_get_syscheck_decoded_events(void);
+unsigned int analysisd_get_rootcheck_decoded_events(void);
+unsigned int analysisd_get_hostinfo_decoded_events(void);
+unsigned int analysisd_get_alerts_written(void);
+unsigned int analysisd_get_archives_written(void);
+unsigned int analysisd_get_firewall_written(void);
+unsigned int analysisd_get_archives_dropped(void);
+
+void analysisd_stamp_queue_in(Eventinfo *lf);
+void analysisd_sample_queue_wait(Eventinfo *lf, int which);
+
+#endif /* !WIN32 */
+
+#endif /* ANALYSISD_STATE_H */

--- a/src/analysisd/stats.c
+++ b/src/analysisd/stats.c
@@ -38,15 +38,29 @@ static int _CHour[25];
 
 static int _cignorehour = 0;
 static int _fired = 0;
+#ifndef WIN32
+static pthread_mutex_t stats_hour_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
 static int _daily_errors = 0;
 static int maxdiff = 0;
 static int mindiff = 0;
 static int percent_diff = 20;
 
-/* Last msgs, to avoid floods */
-static char *_lastmsg;
-static char *_prevlast;
-static char *_pprevlast;
+/* Last msgs flood window. TLS so each process/match shard owns private state
+ * (LastMsg runs only on the analyze path; one process thread owns each shard). */
+static __thread char *_lastmsg;
+static __thread char *_prevlast;
+static __thread char *_pprevlast;
+
+static void lastmsg_ensure_init(void)
+{
+    if (_lastmsg) {
+        return;
+    }
+    os_strdup(" ", _lastmsg);
+    os_strdup(" ", _prevlast);
+    os_strdup(" ", _pprevlast);
+}
 
 
 static void print_totals(void)
@@ -224,68 +238,85 @@ void Update_Hour()
 /* Check Hourly stats */
 int Check_Hour()
 {
-    _CHour[__crt_hour]++;
-    _CWHour[__crt_wday][__crt_hour]++;
+    int result = 0;
+    int hour;
+    int wday;
+
+    hour = __crt_hour;
+    wday = __crt_wday;
+
+#ifndef WIN32
+    os_mutex_lock(&stats_hour_mutex);
+#endif
+    _CHour[hour]++;
+    _CWHour[wday][hour]++;
 
     if (_RHour[24] <= 2) {
-        return (0);
+        goto out;
     }
 
     /* Checking if any message was already fired for this hour */
-    if ((_daily_errors >= 3) || ((_fired == 1) && (_cignorehour == __crt_hour))) {
-        return (0);
+    if ((_daily_errors >= 3) || ((_fired == 1) && (_cignorehour == hour))) {
+        goto out;
     }
 
-    else if (_cignorehour != __crt_hour) {
-        _cignorehour = __crt_hour;
+    else if (_cignorehour != hour) {
+        _cignorehour = hour;
         _fired = 0;
     }
 
     /* Check if passed the threshold */
-    if (_RHour[__crt_hour] != 0) {
-        if (_CHour[__crt_hour] > (_RHour[__crt_hour])) {
-            if (_CHour[__crt_hour] > (gethour(_RHour[__crt_hour]))) {
+    if (_RHour[hour] != 0) {
+        if (_CHour[hour] > (_RHour[hour])) {
+            if (_CHour[hour] > (gethour(_RHour[hour]))) {
                 /* snprintf will null terminate */
                 snprintf(__stats_comment, 191,
                          "The average number of logs"
                          " between %d:00 and %d:00 is %d. We "
-                         "reached %d.", __crt_hour, __crt_hour + 1,
-                         _RHour[__crt_hour], _CHour[__crt_hour]);
+                         "reached %d.", hour, hour + 1,
+                         _RHour[hour], _CHour[hour]);
 
 
                 _fired = 1;
                 _daily_errors++;
-                return (1);
+                result = 1;
+                goto out;
             }
         }
     }
 
     /* We need to have at least 3 days of stats */
-    if (_RWHour[__crt_wday][24] <= 2) {
-        return (0);
+    if (_RWHour[wday][24] <= 2) {
+        goto out;
     }
 
     /* Check for the hour during a specific day of the week */
-    if (_RWHour[__crt_wday][__crt_hour] != 0) {
-        if (_CWHour[__crt_wday][__crt_hour] > _RWHour[__crt_wday][__crt_hour]) {
-            if (_CWHour[__crt_wday][__crt_hour] >
-                    gethour(_RWHour[__crt_wday][__crt_hour])) {
+    if (_RWHour[wday][hour] != 0) {
+        if (_CWHour[wday][hour] > _RWHour[wday][hour]) {
+            if (_CWHour[wday][hour] >
+                    gethour(_RWHour[wday][hour])) {
                 snprintf(__stats_comment, 191,
                          "The average number of logs"
                          " between %d:00 and %d:00 on %s is %d. We"
-                         " reached %d.", __crt_hour, __crt_hour + 1,
-                         weekdays[__crt_wday],
-                         _RWHour[__crt_wday][__crt_hour],
-                         _CWHour[__crt_wday][__crt_hour]);
+                         " reached %d.", hour, hour + 1,
+                         weekdays[wday],
+                         _RWHour[wday][hour],
+                         _CWHour[wday][hour]);
 
 
                 _fired = 1;
                 _daily_errors++;
-                return (1);
+                result = 1;
+                goto out;
             }
         }
     }
-    return (0);
+
+out:
+#ifndef WIN32
+    os_mutex_unlock(&stats_hour_mutex);
+#endif
+    return result;
 }
 
 /* Start hourly stats and other necessary variables */
@@ -323,18 +354,8 @@ int Start_Hour()
                                  "stats_percent_diff",
                                  5, 9999);
 
-    /* Last three messages
-     * They are used to keep track of the last
-     * messages received to avoid floods
-     */
-    _lastmsg = NULL;
-    _prevlast = NULL;
-    _pprevlast = NULL;
-
-    /* They should not be null */
-    os_strdup(" ", _lastmsg);
-    os_strdup(" ", _prevlast);
-    os_strdup(" ", _pprevlast);
+    /* Last three messages — TLS; init this thread (main/startup). */
+    lastmsg_ensure_init();
 
     /* Create the stat queue directories */
     if (IsDir(STATWQUEUE) == -1) {
@@ -432,19 +453,18 @@ int Start_Hour()
  */
 int LastMsg_Stats(const char *log)
 {
+    lastmsg_ensure_init();
+
     if (strcmp(log, _lastmsg) == 0) {
-        return (1);
+        return 1;
     }
-
-    else if (strcmp(log, _prevlast) == 0) {
-        return (1);
+    if (strcmp(log, _prevlast) == 0) {
+        return 1;
     }
-
-    else if (strcmp(log, _pprevlast) == 0) {
-        return (1);
+    if (strcmp(log, _pprevlast) == 0) {
+        return 1;
     }
-
-    return (0);
+    return 0;
 }
 
 /* If the message is not repeated, rearrange the last
@@ -452,14 +472,11 @@ int LastMsg_Stats(const char *log)
  */
 void LastMsg_Change(const char *log)
 {
-    /* Remove the last one */
-    free(_pprevlast);
+    lastmsg_ensure_init();
 
-    /* Move the second to third and the last to second */
+    free(_pprevlast);
     _pprevlast = _prevlast;
     _prevlast = _lastmsg;
-
     os_strdup(log, _lastmsg);
-    return;
 }
 

--- a/src/analysisd/stats.c
+++ b/src/analysisd/stats.c
@@ -236,7 +236,7 @@ void Update_Hour()
 }
 
 /* Check Hourly stats */
-int Check_Hour()
+int Check_Hour(char *comment_out, size_t comment_sz)
 {
     int result = 0;
     int hour;
@@ -244,6 +244,10 @@ int Check_Hour()
 
     hour = __crt_hour;
     wday = __crt_wday;
+
+    if (hour < 0 || hour > 23 || wday < 0 || wday > 6) {
+        return 0;
+    }
 
 #ifndef WIN32
     os_mutex_lock(&stats_hour_mutex);
@@ -313,6 +317,9 @@ int Check_Hour()
     }
 
 out:
+    if (result && comment_out && comment_sz > 0) {
+        snprintf(comment_out, comment_sz, "%s", __stats_comment);
+    }
 #ifndef WIN32
     os_mutex_unlock(&stats_hour_mutex);
 #endif

--- a/src/analysisd/stats.h
+++ b/src/analysisd/stats.h
@@ -16,7 +16,8 @@ int LastMsg_Stats(const char *log);
 extern char __stats_comment[192];
 
 void Update_Hour(void);
-int Check_Hour(void);
+/* On alert (return 1), copies the message into comment_out under the stats lock. */
+int Check_Hour(char *comment_out, size_t comment_sz);
 int Start_Hour(void);
 
 #endif /* _STAT__H */

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -34,7 +34,7 @@ void OS_ReadMSG(char *ut_str);
 /* Analysisd function */
 RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node);
 
-void DecodeEvent(Eventinfo *lf);
+void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match);
 
 /* Print help statement */
 __attribute__((noreturn))
@@ -446,7 +446,7 @@ void OS_ReadMSG(char *ut_str)
             lf->size = strlen(lf->log);
 
             /* Decode event */
-            DecodeEvent(lf);
+            DecodeEvent(lf, NULL);
 
             /* Run accumulator */
             if ( lf->decoder_info->accumulate == 1 ) {

--- a/src/headers/queue_op.h
+++ b/src/headers/queue_op.h
@@ -1,0 +1,50 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef QUEUE_OP_H
+#define QUEUE_OP_H
+
+#ifndef WIN32
+
+#include <pthread.h>
+#include <time.h>
+
+typedef struct os_queue {
+    void **data;
+    size_t begin;
+    size_t end;
+    size_t size;
+    unsigned int elements;
+    int shutdown;
+    pthread_mutex_t mutex;
+    pthread_cond_t available;
+    pthread_cond_t available_not_empty;
+} os_queue;
+
+os_queue *os_queue_init(size_t size);
+void os_queue_destroy(os_queue *queue);
+void os_queue_shutdown(os_queue *queue);
+
+/* Thread-safe API — always use these from outside queue_op.c. */
+int os_queue_push_ex(os_queue *queue, void *data);
+int os_queue_push_ex_block(os_queue *queue, void *data);
+/* Timed wait for space; returns -1 on timeout, shutdown, or push failure. */
+int os_queue_push_ex_timedwait(os_queue *queue, void *data, const struct timespec *abstime);
+
+void *os_queue_pop_ex(os_queue *queue);
+void *os_queue_pop_ex_timedwait(os_queue *queue, const struct timespec *abstime);
+
+unsigned int os_queue_elements(const os_queue *queue);
+
+/* Pop and free every remaining element (caller supplies freefn). */
+void os_queue_free_data(os_queue *queue, void (*freefn)(void *));
+
+#endif /* !WIN32 */
+
+#endif /* QUEUE_OP_H */

--- a/src/headers/queue_op.h
+++ b/src/headers/queue_op.h
@@ -31,10 +31,12 @@ os_queue *os_queue_init(size_t size);
 void os_queue_destroy(os_queue *queue);
 void os_queue_shutdown(os_queue *queue);
 
-/* Thread-safe API — always use these from outside queue_op.c. */
+/* Thread-safe API — always use these from outside queue_op.c.
+ * Push APIs require data != NULL (NULL is reserved for empty pop / free_data end).
+ */
 int os_queue_push_ex(os_queue *queue, void *data);
 int os_queue_push_ex_block(os_queue *queue, void *data);
-/* Timed wait for space; returns -1 on timeout, shutdown, or push failure. */
+/* Timed wait for space; returns -1 on timeout, shutdown, NULL data, or push failure. */
 int os_queue_push_ex_timedwait(os_queue *queue, void *data, const struct timespec *abstime);
 
 void *os_queue_pop_ex(os_queue *queue);

--- a/src/headers/queue_op.h
+++ b/src/headers/queue_op.h
@@ -42,7 +42,7 @@ int os_queue_push_ex_timedwait(os_queue *queue, void *data, const struct timespe
 void *os_queue_pop_ex(os_queue *queue);
 void *os_queue_pop_ex_timedwait(os_queue *queue, const struct timespec *abstime);
 
-unsigned int os_queue_elements(const os_queue *queue);
+unsigned int os_queue_elements(os_queue *queue);
 
 /* Pop and free every remaining element (caller supplies freefn). */
 void os_queue_free_data(os_queue *queue, void (*freefn)(void *));

--- a/src/os_regex/os_match_execute.c
+++ b/src/os_regex/os_match_execute.c
@@ -33,11 +33,20 @@ int OSMatch_Execute_true(const char *subject, size_t len, OSMatch *match)
 int OSMatch_Execute_pcre2_match(const char *str, size_t str_len, OSMatch * reg)
 {
     int rc = 0;
+    pcre2_match_data *match_data = reg->match_data;
+    regex_matching *thread_match = os_regex_get_thread_match();
+
+    if (thread_match) {
+        match_data = regex_matching_get_match_data(thread_match, reg->regex);
+        if (!match_data) {
+            return 0;
+        }
+    }
 
 #ifdef USE_PCRE2_JIT
-    rc = pcre2_jit_match(reg->regex, (PCRE2_SPTR)str, str_len, 0, 0, reg->match_data, NULL);
+    rc = pcre2_jit_match(reg->regex, (PCRE2_SPTR)str, str_len, 0, 0, match_data, NULL);
 #else
-    rc = pcre2_match(reg->regex, (PCRE2_SPTR)str, str_len, 0, 0, reg->match_data, NULL);
+    rc = pcre2_match(reg->regex, (PCRE2_SPTR)str, str_len, 0, 0, match_data, NULL);
 #endif
 
     return (rc >= 0);

--- a/src/os_regex/os_pcre2_execute.c
+++ b/src/os_regex/os_pcre2_execute.c
@@ -28,12 +28,21 @@ const char *OSPcre2_Execute_pcre2_match(const char *str, OSPcre2 *reg)
 {
     int rc = 0, nbs = 0, i = 0;
     PCRE2_SIZE *ov = NULL;
+    pcre2_match_data *match_data = reg->match_data;
+    regex_matching *thread_match = os_regex_get_thread_match();
+
+    if (thread_match) {
+        match_data = regex_matching_get_match_data(thread_match, reg->regex);
+        if (!match_data) {
+            return NULL;
+        }
+    }
 
     /* Execute the reg */
 #ifdef USE_PCRE2_JIT
-    rc = pcre2_jit_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, reg->match_data, NULL);
+    rc = pcre2_jit_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, match_data, NULL);
 #else
-    rc = pcre2_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, reg->match_data, NULL);
+    rc = pcre2_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, match_data, NULL);
 #endif
 
     /* Check execution result */
@@ -42,20 +51,23 @@ const char *OSPcre2_Execute_pcre2_match(const char *str, OSPcre2 *reg)
     }
 
     /* get the offsets informations for the match */
-    ov = pcre2_get_ovector_pointer(reg->match_data);
+    ov = pcre2_get_ovector_pointer(match_data);
 
-    /* get the substrings if required */
-    for (i = 1; i < rc; i++) {
-        PCRE2_SIZE sub_string_start = ov[2 * i];
-        PCRE2_SIZE sub_string_end = ov[2 * i + 1];
-        PCRE2_SIZE sub_string_len = sub_string_end - sub_string_start;
-        if (sub_string_start != -1) {
-            reg->sub_strings[nbs] = (char *)calloc(sub_string_len + 1, sizeof(char));
-            strncpy(reg->sub_strings[nbs], &str[sub_string_start], sub_string_len);
-            nbs++;
+    if (reg->sub_strings || thread_match) {
+        char **target = ospcre2_get_substring_buffer(reg);
+
+        for (i = 1; i < rc && nbs < REGEX_MATCH_MAX_GROUPS; i++) {
+            PCRE2_SIZE sub_string_start = ov[2 * i];
+            PCRE2_SIZE sub_string_end = ov[2 * i + 1];
+            PCRE2_SIZE sub_string_len = sub_string_end - sub_string_start;
+            if (sub_string_start != (PCRE2_SIZE)-1) {
+                target[nbs] = (char *)calloc(sub_string_len + 1, sizeof(char));
+                strncpy(target[nbs], &str[sub_string_start], sub_string_len);
+                nbs++;
+            }
         }
+        target[nbs] = NULL;
     }
-    reg->sub_strings[nbs] = NULL;
 
     return &str[ov[1]];
 }

--- a/src/os_regex/os_regex.h
+++ b/src/os_regex/os_regex.h
@@ -40,6 +40,19 @@
 #define OS_CONVERT_REGEX        1
 #define OS_CONVERT_MATCH        2
 
+#define REGEX_MATCH_MAX_GROUPS  64
+
+typedef struct regex_matching {
+    char *sub_strings[REGEX_MATCH_MAX_GROUPS + 1];
+    pcre2_match_data *match_data;
+} regex_matching;
+
+void regex_matching_clear(regex_matching *match);
+void regex_matching_free_match_data(regex_matching *match);
+pcre2_match_data *regex_matching_get_match_data(regex_matching *match, const pcre2_code *code);
+regex_matching *os_regex_get_thread_match(void);
+void os_regex_set_thread_match(regex_matching *match);
+
 /* OSRegex structure */
 typedef struct _OSRegex {
     int error;
@@ -71,6 +84,9 @@ typedef struct _OSPcre2 {
     char *pattern;
     const char *(*exec_function)(const char *, struct _OSPcre2 *);
 } OSPcre2;
+
+char **os_regex_get_substring_buffer(OSRegex *reg);
+char **ospcre2_get_substring_buffer(OSPcre2 *reg);
 
 /*** Prototypes ***/
 

--- a/src/os_regex/os_regex_execute.c
+++ b/src/os_regex/os_regex_execute.c
@@ -32,12 +32,21 @@ const char *OSRegex_Execute_pcre2_match(const char *str, OSRegex *reg)
 {
     int rc = 0, nbs = 0, i = 0;
     PCRE2_SIZE *ov = NULL;
+    pcre2_match_data *match_data = reg->match_data;
+    regex_matching *thread_match = os_regex_get_thread_match();
+
+    if (thread_match) {
+        match_data = regex_matching_get_match_data(thread_match, reg->regex);
+        if (!match_data) {
+            return NULL;
+        }
+    }
 
     /* Execute the reg */
 #ifdef USE_PCRE2_JIT
-    rc = pcre2_jit_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, reg->match_data, NULL);
+    rc = pcre2_jit_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, match_data, NULL);
 #else
-    rc = pcre2_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, reg->match_data, NULL);
+    rc = pcre2_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, match_data, NULL);
 #endif
 
     /* Check execution result */
@@ -46,21 +55,23 @@ const char *OSRegex_Execute_pcre2_match(const char *str, OSRegex *reg)
     }
 
     /* get the offsets informations for the match */
-    ov = pcre2_get_ovector_pointer(reg->match_data);
+    ov = pcre2_get_ovector_pointer(match_data);
 
-    if (reg->sub_strings) {
+    if (reg->sub_strings || thread_match) {
+        char **target = os_regex_get_substring_buffer(reg);
+
         /* get the substrings if required */
-        for (i = 1; i < rc; i++) {
+        for (i = 1; i < rc && nbs < REGEX_MATCH_MAX_GROUPS; i++) {
             PCRE2_SIZE sub_string_start = ov[2 * i];
             PCRE2_SIZE sub_string_end = ov[2 * i + 1];
             PCRE2_SIZE sub_string_len = sub_string_end - sub_string_start;
-            if (sub_string_start != -1) {
-                reg->sub_strings[nbs] = (char *)calloc(sub_string_len + 1, sizeof(char));
-                strncpy(reg->sub_strings[nbs], &str[sub_string_start], sub_string_len);
+            if (sub_string_start != (PCRE2_SIZE)-1) {
+                target[nbs] = (char *)calloc(sub_string_len + 1, sizeof(char));
+                strncpy(target[nbs], &str[sub_string_start], sub_string_len);
                 nbs++;
             }
         }
-        reg->sub_strings[nbs] = NULL;
+        target[nbs] = NULL;
     }
 
     return &str[ov[1]];

--- a/src/os_regex/os_regex_match.c
+++ b/src/os_regex/os_regex_match.c
@@ -1,121 +1,91 @@
-/* Copyright (C) 2009 Trend Micro Inc.
- * All right reserved.
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
  *
  * This program is a free software; you can redistribute it
  * and/or modify it under the terms of the GNU General Public
  * License (version 2) as published by the FSF - Free Software
- * Foundation
+ * Foundation.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
-
 #include "os_regex.h"
-#include "os_regex_internal.h"
 
-/* Algorithm:
- *       Go as fast as you can :)
- *
- * Supports:
- *      '|' to separate multiple OR patterns
- *      '^' to match the beginning of a string
- */
+#ifndef WIN32
+static __thread regex_matching *os_regex_tls_match = NULL;
+#else
+static regex_matching *os_regex_tls_match = NULL;
+#endif
 
-/* Prototypes */
-static int _InternalMatch(const char *pattern, const char *str, size_t count) __attribute__((nonnull));
-
-
-/* Search for pattern in the string */
-int OS_WordMatch(const char *pattern, const char *str)
+void regex_matching_clear(regex_matching *match)
 {
-    size_t count = 0;
+    int i;
 
-    if (*pattern == '\0') {
-        return (FALSE);
+    if (!match) {
+        return;
     }
 
-    do {
-        if (pattern[count] == '|') {
-            /* If we match '|' , search with
-             * we have so far.
-             */
-            if (_InternalMatch(pattern, str, count)) {
-                return (TRUE);
-            } else {
-                pattern += count + 1;
-                count = 0;
-                continue;
-            }
-        }
-
-        count++;
-
-    } while (pattern[count] != '\0');
-
-    /* Last check until end of string */
-    return (_InternalMatch(pattern, str, count));
+    for (i = 0; i < REGEX_MATCH_MAX_GROUPS && match->sub_strings[i]; i++) {
+        free(match->sub_strings[i]);
+        match->sub_strings[i] = NULL;
+    }
 }
 
-static int _InternalMatch(const char *pattern, const char *str, size_t pattern_size)
+void regex_matching_free_match_data(regex_matching *match)
 {
-    const uchar *pt = (const uchar *)pattern;
-    const uchar *st = (const uchar *)str;
-    const uchar last_char = (const uchar) pattern[pattern_size];
-
-    if (*pattern == '\0') {
-        return (TRUE);
+    if (!match || !match->match_data) {
+        return;
     }
 
-    /* If '^' specified, just do a strncasecmp */
-    else if (*pattern == '^') {
-        pattern++;
-        pattern_size --;
-
-        /* Compare two strings */
-        if (strncasecmp(pattern, str, pattern_size) == 0) {
-            return (TRUE);
-        }
-        return (FALSE);
-    }
-
-    /* Null line */
-    else if (*st == '\0') {
-        return (FALSE);
-    }
-
-    /* Look to match the first pattern */
-    do {
-        /* Match */
-        if (charmap[*st] == charmap[*pt]) {
-            str = (const char *)st++;
-            pt++;
-
-            while (*pt != last_char) {
-                if (*st == '\0') {
-                    return (FALSE);
-                }
-
-                else if (charmap[*pt] != charmap[*st]) {
-                    goto error;
-                }
-
-                st++;
-                pt++;
-            }
-
-            /* Return here if pt == last_char */
-            return (TRUE);
-
-error:
-            st = (const uchar *)str;
-            pt = (const uchar *)pattern;
-        }
-
-        st++;
-    } while (*st != '\0');
-
-    return (FALSE);
+    pcre2_match_data_free(match->match_data);
+    match->match_data = NULL;
 }
 
+pcre2_match_data *regex_matching_get_match_data(regex_matching *match, const pcre2_code *code)
+{
+    (void)code;
+
+    if (!match) {
+        return NULL;
+    }
+
+    /* Fixed ovector size so one thread-owned buffer works for any pattern. */
+    if (!match->match_data) {
+        match->match_data = pcre2_match_data_create(REGEX_MATCH_MAX_GROUPS + 1, NULL);
+    }
+
+    return match->match_data;
+}
+
+void os_regex_set_thread_match(regex_matching *match)
+{
+    os_regex_tls_match = match;
+}
+
+regex_matching *os_regex_get_thread_match(void)
+{
+    return os_regex_tls_match;
+}
+
+char **os_regex_get_substring_buffer(OSRegex *reg)
+{
+    regex_matching *match = os_regex_get_thread_match();
+
+    if (match) {
+        regex_matching_clear(match);
+        return match->sub_strings;
+    }
+
+    return reg->sub_strings;
+}
+
+char **ospcre2_get_substring_buffer(OSPcre2 *reg)
+{
+    regex_matching *match = os_regex_get_thread_match();
+
+    if (match) {
+        regex_matching_clear(match);
+        return match->sub_strings;
+    }
+
+    return reg->sub_strings;
+}

--- a/src/os_regex/os_regex_match.c
+++ b/src/os_regex/os_regex_match.c
@@ -8,13 +8,107 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
+
 #include "os_regex.h"
+#include "os_regex_internal.h"
 
 #ifndef WIN32
 static __thread regex_matching *os_regex_tls_match = NULL;
 #else
 static regex_matching *os_regex_tls_match = NULL;
 #endif
+
+/* Prototypes */
+static int _InternalMatch(const char *pattern, const char *str, size_t count) __attribute__((nonnull));
+
+/*
+ * Search for pattern in the string.
+ * Supports '|' (OR) and '^' (match beginning).
+ */
+int OS_WordMatch(const char *pattern, const char *str)
+{
+    size_t count = 0;
+
+    if (*pattern == '\0') {
+        return (FALSE);
+    }
+
+    do {
+        if (pattern[count] == '|') {
+            if (_InternalMatch(pattern, str, count)) {
+                return (TRUE);
+            } else {
+                pattern += count + 1;
+                count = 0;
+                continue;
+            }
+        }
+
+        count++;
+
+    } while (pattern[count] != '\0');
+
+    return (_InternalMatch(pattern, str, count));
+}
+
+static int _InternalMatch(const char *pattern, const char *str, size_t pattern_size)
+{
+    const uchar *pt = (const uchar *)pattern;
+    const uchar *st = (const uchar *)str;
+    const uchar last_char = (const uchar) pattern[pattern_size];
+
+    if (pattern_size == 0) {
+        return (TRUE);
+    }
+
+    /* If '^' specified, just do a strncasecmp */
+    else if (*pattern == '^') {
+        pattern++;
+        pattern_size--;
+
+        if (strncasecmp(pattern, str, pattern_size) == 0) {
+            return (TRUE);
+        }
+        return (FALSE);
+    }
+
+    /* Null line */
+    else if (*st == '\0') {
+        return (FALSE);
+    }
+
+    /* Look to match the first pattern */
+    do {
+        if (charmap[*st] == charmap[*pt]) {
+            str = (const char *)st++;
+            pt++;
+
+            while (*pt != last_char) {
+                if (*st == '\0') {
+                    return (FALSE);
+                }
+
+                else if (charmap[*pt] != charmap[*st]) {
+                    goto error;
+                }
+
+                st++;
+                pt++;
+            }
+
+            return (TRUE);
+
+error:
+            st = (const uchar *)str;
+            pt = (const uchar *)pattern;
+        }
+
+        st++;
+    } while (*st != '\0');
+
+    return (FALSE);
+}
 
 void regex_matching_clear(regex_matching *match)
 {

--- a/src/os_regex/os_regex_match.c
+++ b/src/os_regex/os_regex_match.c
@@ -42,15 +42,30 @@ void regex_matching_free_match_data(regex_matching *match)
 
 pcre2_match_data *regex_matching_get_match_data(regex_matching *match, const pcre2_code *code)
 {
-    (void)code;
+    uint32_t capture_count;
+    uint32_t needed;
 
-    if (!match) {
+    if (!match || !code) {
         return NULL;
     }
 
-    /* Fixed ovector size so one thread-owned buffer works for any pattern. */
-    if (!match->match_data) {
-        match->match_data = pcre2_match_data_create(REGEX_MATCH_MAX_GROUPS + 1, NULL);
+    /*
+     * Size ovector from the pattern. Reuse the thread-owned buffer when it is
+     * already large enough; recreate when a larger pattern is used.
+     * REGEX_MATCH_MAX_GROUPS remains the limit for copying captures.
+     */
+    capture_count = 0;
+    if (pcre2_pattern_info(code, PCRE2_INFO_CAPTURECOUNT, &capture_count) != 0) {
+        return NULL;
+    }
+    needed = capture_count + 1;
+
+    if (!match->match_data || pcre2_get_ovector_count(match->match_data) < needed) {
+        if (match->match_data) {
+            pcre2_match_data_free(match->match_data);
+            match->match_data = NULL;
+        }
+        match->match_data = pcre2_match_data_create_from_pattern(code, NULL);
     }
 
     return match->match_data;

--- a/src/shared/queue_op.c
+++ b/src/shared/queue_op.c
@@ -1,0 +1,235 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef WIN32
+
+#include "shared.h"
+#include "queue_op.h"
+
+os_queue *os_queue_init(size_t size)
+{
+    os_queue *queue;
+
+    if (size < 2) {
+        return NULL;
+    }
+
+    os_calloc(1, sizeof(os_queue), queue);
+    os_malloc(size * sizeof(void *), queue->data);
+    queue->size = size;
+    queue->elements = 0;
+    queue->shutdown = 0;
+    os_mutex_init(&queue->mutex, NULL);
+    os_cond_init(&queue->available, NULL);
+    os_cond_init(&queue->available_not_empty, NULL);
+    return queue;
+}
+
+void os_queue_destroy(os_queue *queue)
+{
+    if (!queue) {
+        return;
+    }
+
+    free(queue->data);
+    os_mutex_destroy(&queue->mutex);
+    os_cond_destroy(&queue->available);
+    os_cond_destroy(&queue->available_not_empty);
+    free(queue);
+}
+
+void os_queue_shutdown(os_queue *queue)
+{
+    if (!queue) {
+        return;
+    }
+
+    os_mutex_lock(&queue->mutex);
+    queue->shutdown = 1;
+    os_cond_broadcast(&queue->available);
+    os_cond_broadcast(&queue->available_not_empty);
+    os_mutex_unlock(&queue->mutex);
+}
+
+/* Unlocked helpers — callers must hold queue->mutex. */
+static int os_queue_full(const os_queue *queue)
+{
+    return (queue->begin + 1) % queue->size == queue->end;
+}
+
+static int os_queue_empty(const os_queue *queue)
+{
+    return queue->begin == queue->end;
+}
+
+unsigned int os_queue_elements(const os_queue *queue)
+{
+    return queue->elements;
+}
+
+static int os_queue_push(os_queue *queue, void *data)
+{
+    if (os_queue_full(queue)) {
+        return -1;
+    }
+
+    queue->data[queue->begin] = data;
+    queue->begin = (queue->begin + 1) % queue->size;
+    queue->elements++;
+    return 0;
+}
+
+static void *os_queue_pop(os_queue *queue)
+{
+    void *data;
+
+    if (os_queue_empty(queue)) {
+        return NULL;
+    }
+
+    data = queue->data[queue->end];
+    queue->end = (queue->end + 1) % queue->size;
+    queue->elements--;
+    return data;
+}
+
+int os_queue_push_ex(os_queue *queue, void *data)
+{
+    int result;
+
+    os_mutex_lock(&queue->mutex);
+
+    if (queue->shutdown) {
+        os_mutex_unlock(&queue->mutex);
+        return -1;
+    }
+
+    result = os_queue_push(queue, data);
+    if (result == 0) {
+        os_cond_signal(&queue->available);
+    }
+
+    os_mutex_unlock(&queue->mutex);
+    return result;
+}
+
+int os_queue_push_ex_block(os_queue *queue, void *data)
+{
+    int result;
+
+    os_mutex_lock(&queue->mutex);
+
+    while (!queue->shutdown && os_queue_full(queue)) {
+        os_cond_wait(&queue->available_not_empty, &queue->mutex);
+    }
+
+    if (queue->shutdown) {
+        os_mutex_unlock(&queue->mutex);
+        return -1;
+    }
+
+    result = os_queue_push(queue, data);
+    if (result == 0) {
+        /* Wake a consumer waiting for data — not producers waiting for space. */
+        os_cond_signal(&queue->available);
+    }
+    os_mutex_unlock(&queue->mutex);
+
+    return result;
+}
+
+int os_queue_push_ex_timedwait(os_queue *queue, void *data, const struct timespec *abstime)
+{
+    int result;
+
+    if (!queue || !abstime) {
+        return -1;
+    }
+
+    os_mutex_lock(&queue->mutex);
+
+    while (!queue->shutdown && os_queue_full(queue)) {
+        if (pthread_cond_timedwait(&queue->available_not_empty, &queue->mutex,
+                                   abstime) != 0) {
+            os_mutex_unlock(&queue->mutex);
+            return -1;
+        }
+    }
+
+    if (queue->shutdown) {
+        os_mutex_unlock(&queue->mutex);
+        return -1;
+    }
+
+    result = os_queue_push(queue, data);
+    if (result == 0) {
+        os_cond_signal(&queue->available);
+    }
+    os_mutex_unlock(&queue->mutex);
+
+    return result;
+}
+
+void *os_queue_pop_ex(os_queue *queue)
+{
+    void *data;
+
+    os_mutex_lock(&queue->mutex);
+
+    while ((data = os_queue_pop(queue)) == NULL && !queue->shutdown) {
+        os_cond_wait(&queue->available, &queue->mutex);
+    }
+
+    if (data) {
+        os_cond_signal(&queue->available_not_empty);
+    }
+
+    os_mutex_unlock(&queue->mutex);
+    return data;
+}
+
+void *os_queue_pop_ex_timedwait(os_queue *queue, const struct timespec *abstime)
+{
+    void *data;
+
+    os_mutex_lock(&queue->mutex);
+
+    while ((data = os_queue_pop(queue)) == NULL && !queue->shutdown) {
+        if (pthread_cond_timedwait(&queue->available, &queue->mutex, abstime) != 0) {
+            os_mutex_unlock(&queue->mutex);
+            return NULL;
+        }
+    }
+
+    if (data) {
+        os_cond_signal(&queue->available_not_empty);
+    }
+
+    os_mutex_unlock(&queue->mutex);
+    return data;
+}
+
+void os_queue_free_data(os_queue *queue, void (*freefn)(void *))
+{
+    void *data;
+
+    if (!queue) {
+        return;
+    }
+
+    os_mutex_lock(&queue->mutex);
+    while ((data = os_queue_pop(queue)) != NULL) {
+        if (freefn) {
+            freefn(data);
+        }
+    }
+    os_mutex_unlock(&queue->mutex);
+}
+
+#endif /* !WIN32 */

--- a/src/shared/queue_op.c
+++ b/src/shared/queue_op.c
@@ -103,6 +103,10 @@ int os_queue_push_ex(os_queue *queue, void *data)
 {
     int result;
 
+    if (!queue || !data) {
+        return -1;
+    }
+
     os_mutex_lock(&queue->mutex);
 
     if (queue->shutdown) {
@@ -122,6 +126,10 @@ int os_queue_push_ex(os_queue *queue, void *data)
 int os_queue_push_ex_block(os_queue *queue, void *data)
 {
     int result;
+
+    if (!queue || !data) {
+        return -1;
+    }
 
     os_mutex_lock(&queue->mutex);
 
@@ -148,7 +156,7 @@ int os_queue_push_ex_timedwait(os_queue *queue, void *data, const struct timespe
 {
     int result;
 
-    if (!queue || !abstime) {
+    if (!queue || !abstime || !data) {
         return -1;
     }
 

--- a/src/shared/queue_op.c
+++ b/src/shared/queue_op.c
@@ -68,9 +68,19 @@ static int os_queue_empty(const os_queue *queue)
     return queue->begin == queue->end;
 }
 
-unsigned int os_queue_elements(const os_queue *queue)
+unsigned int os_queue_elements(os_queue *queue)
 {
-    return queue->elements;
+    unsigned int elements;
+
+    if (!queue) {
+        return 0;
+    }
+
+    /* Public reader used by metrics/FTS flush — must not race push/pop. */
+    os_mutex_lock(&queue->mutex);
+    elements = queue->elements;
+    os_mutex_unlock(&queue->mutex);
+    return elements;
 }
 
 static int os_queue_push(os_queue *queue, void *data)

--- a/src/shared/tests/Makefile
+++ b/src/shared/tests/Makefile
@@ -1,18 +1,56 @@
-# Makefile for misc tests
+# Makefile for misc shared-library unit tests.
+# Prefer linking against built libs from src/:
+#   cd src && make shared.a
+#   make -C shared/tests check
 
-THREAD_POOL_TEST_OBJS = thread_pool_test.c ../thread_pool.c ../pthreads_op.c \
-	../mem_op.c ../debug_op.c ../string_op.c ../file_op.c
+CC ?= cc
+TOP = ../..
+CFLAGS_COMMON = -g -Wall -I$(TOP)/headers -I$(TOP) -I$(TOP)/analysisd
 
-thread_pool_test: $(THREAD_POOL_TEST_OBJS)
-	$(CC) -pthread -g -o $@ $(THREAD_POOL_TEST_OBJS) -I../../headers/ -I../../ \
-		-DARGV0=\"thread_pool_test\" -DTHREAD_POOL_TEST_HOOK -Wall
+# Headless tests run by `check`. Interactive helpers stay under `legacy_helpers`.
+AUTO_TEST_BINS = thread_pool_test queue_op_test string_test
+LEGACY_HELPER_BINS = prime_test hash_test merge_test ip_test
 
-maketest: thread_pool_test
-		$(CC) -g -o string_test string_test.c ../string_op.c -I../ -I../../ -I../../headers/ -I../headers/ -Wall
-		$(CC) -g -o prime_test prime_test.c ../math_op.c -I../ -I../../ -I../../headers/ -I../headers/ -Wall
-		$(CC) -g -o hash_test hash_test.c ../hash_op.c ../math_op.c -I../ -I../../ -I../../headers/ -I../headers/ -Wall
-		$(CC) -g -o merge_test merge_test.c  ../file_op.c ../debug_op.c -I../ -I../../ -I../../headers/ -I../headers/ -Wall
-		$(CC) -DARGV0=\"ip_test\" -g -o ip_test ip_test.c ../validate_op.c ../debug_op.c ../regex_op.c -I../ -I../../ -I../../headers/ -I../headers/ -Wall
+.PHONY: maketest check clean legacy_helpers
+
+thread_pool_test: thread_pool_test.c
+	$(CC) -pthread $(CFLAGS_COMMON) -DARGV0=\"thread_pool_test\" \
+		-DTHREAD_POOL_TEST_HOOK -o $@ thread_pool_test.c \
+		../thread_pool.c ../pthreads_op.c ../mem_op.c ../debug_op.c \
+		../string_op.c ../file_op.c
+
+queue_op_test: queue_op_test.c $(TOP)/shared.a
+	$(CC) -pthread $(CFLAGS_COMMON) -DARGV0=\"queue_op_test\" -o $@ \
+		queue_op_test.c $(TOP)/shared.a -lpthread
+
+string_test: string_test.c
+	$(CC) $(CFLAGS_COMMON) -DARGV0=\"string_test\" -o $@ string_test.c ../string_op.c
+
+# Interactive / argv-driven helpers (not part of automated check).
+legacy_helpers:
+	$(CC) -g -I$(TOP)/headers -I$(TOP) -DARGV0=\"prime_test\" -o prime_test \
+		prime_test.c ../math_op.c
+	$(CC) -g -I$(TOP)/headers -I$(TOP) -DARGV0=\"hash_test\" -o hash_test \
+		hash_test.c ../hash_op.c ../math_op.c ../debug_op.c ../mem_op.c
+	$(CC) -g -I$(TOP)/headers -I$(TOP) -DARGV0=\"merge_test\" -o merge_test \
+		merge_test.c ../file_op.c ../debug_op.c ../string_op.c ../mem_op.c
+	$(CC) -g -I$(TOP)/headers -I$(TOP) -DARGV0=\"ip_test\" -o ip_test \
+		ip_test.c ../validate_op.c ../debug_op.c ../regex_op.c ../mem_op.c \
+		../string_op.c
+
+maketest: $(AUTO_TEST_BINS)
+
+check: $(AUTO_TEST_BINS)
+	@failed=0; \
+	for bin in $(AUTO_TEST_BINS); do \
+		echo "=== $$bin ==="; \
+		./$$bin || failed=1; \
+	done; \
+	if [ $$failed -ne 0 ]; then \
+		echo "FAIL: shared unit tests"; \
+		exit 1; \
+	fi; \
+	echo "PASS: shared unit tests"
 
 clean:
-		-rm string_test prime_test hash_test merge_test ip_test thread_pool_test *.core
+	-rm -f $(AUTO_TEST_BINS) $(LEGACY_HELPER_BINS) *.core

--- a/src/shared/tests/queue_op_test.c
+++ b/src/shared/tests/queue_op_test.c
@@ -1,0 +1,294 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef WIN32
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "shared.h"
+#include "queue_op.h"
+
+/* Symbols required by shared.a helpers. */
+const char *__local_name = "queue_op_test";
+
+int getDefine_Int(const char *section, const char *key, int min, int max)
+{
+    (void)section;
+    (void)key;
+    (void)max;
+    return min;
+}
+
+static int test_basic_push_pop(void)
+{
+    os_queue *queue;
+    int i;
+
+    queue = os_queue_init(4);
+    if (!queue) {
+        fprintf(stderr, "FAIL: os_queue_init\n");
+        return 1;
+    }
+
+    for (i = 0; i < 3; i++) {
+        char *item = strdup("event");
+        if (os_queue_push_ex(queue, item) != 0) {
+            fprintf(stderr, "FAIL: os_queue_push_ex %d\n", i);
+            free(item);
+            os_queue_destroy(queue);
+            return 1;
+        }
+    }
+
+    if (os_queue_push_ex(queue, (void *)"overflow") == 0) {
+        fprintf(stderr, "FAIL: expected full queue push to fail\n");
+        os_queue_destroy(queue);
+        return 1;
+    }
+
+    for (i = 0; i < 3; i++) {
+        char *item = (char *)os_queue_pop_ex(queue);
+        if (!item || strcmp(item, "event") != 0) {
+            fprintf(stderr, "FAIL: os_queue_pop_ex %d\n", i);
+            os_queue_destroy(queue);
+            return 1;
+        }
+        free(item);
+    }
+
+    os_queue_shutdown(queue);
+    os_queue_destroy(queue);
+    return 0;
+}
+
+static int test_timedwait_timeout_on_full(void)
+{
+    os_queue *queue;
+    struct timespec ts;
+    char *item;
+    int i;
+    int rc;
+
+    queue = os_queue_init(3);
+    if (!queue) {
+        fprintf(stderr, "FAIL: os_queue_init timedwait\n");
+        return 1;
+    }
+
+    for (i = 0; i < 2; i++) {
+        item = strdup("fill");
+        if (os_queue_push_ex(queue, item) != 0) {
+            fprintf(stderr, "FAIL: fill push %d\n", i);
+            free(item);
+            os_queue_destroy(queue);
+            return 1;
+        }
+    }
+
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+        fprintf(stderr, "FAIL: clock_gettime\n");
+        os_queue_destroy(queue);
+        return 1;
+    }
+    ts.tv_nsec += 50 * 1000000L;
+    if (ts.tv_nsec >= 1000000000L) {
+        ts.tv_sec++;
+        ts.tv_nsec -= 1000000000L;
+    }
+
+    item = strdup("late");
+    rc = os_queue_push_ex_timedwait(queue, item, &ts);
+    if (rc == 0) {
+        fprintf(stderr, "FAIL: expected timedwait push to fail on full queue\n");
+        free(item);
+        os_queue_destroy(queue);
+        return 1;
+    }
+    free(item);
+
+    os_queue_free_data(queue, free);
+    os_queue_shutdown(queue);
+    os_queue_destroy(queue);
+    return 0;
+}
+
+static int test_block_push(void)
+{
+    os_queue *queue;
+    char payload[16];
+
+    queue = os_queue_init(4);
+    if (!queue) {
+        return 1;
+    }
+
+    snprintf(payload, sizeof(payload), "blocked");
+    if (os_queue_push_ex_block(queue, payload) != 0) {
+        fprintf(stderr, "FAIL: os_queue_push_ex_block\n");
+        os_queue_destroy(queue);
+        return 1;
+    }
+
+    if (os_queue_pop_ex(queue) != payload) {
+        fprintf(stderr, "FAIL: pop after block push\n");
+        os_queue_destroy(queue);
+        return 1;
+    }
+
+    os_queue_shutdown(queue);
+    os_queue_destroy(queue);
+    return 0;
+}
+
+#define STRESS_PRODUCERS 4
+#define STRESS_CONSUMERS 4
+#define STRESS_PER_PRODUCER 2000
+
+struct stress_ctx {
+    os_queue *queue;
+    unsigned int produced;
+    unsigned int consumed;
+    unsigned int sum_in;
+    unsigned int sum_out;
+};
+
+static void *stress_producer(void *arg)
+{
+    struct stress_ctx *ctx = (struct stress_ctx *)arg;
+    unsigned int i;
+
+    for (i = 0; i < STRESS_PER_PRODUCER; i++) {
+        unsigned int *payload = malloc(sizeof(unsigned int));
+
+        if (!payload) {
+            return (void *)(intptr_t)1;
+        }
+        *payload = i + 1;
+        __sync_add_and_fetch(&ctx->sum_in, *payload);
+        if (os_queue_push_ex_block(ctx->queue, payload) != 0) {
+            free(payload);
+            return (void *)(intptr_t)1;
+        }
+        __sync_add_and_fetch(&ctx->produced, 1);
+    }
+
+    return NULL;
+}
+
+static void *stress_consumer(void *arg)
+{
+    struct stress_ctx *ctx = (struct stress_ctx *)arg;
+
+    while (1) {
+        unsigned int *payload = (unsigned int *)os_queue_pop_ex(ctx->queue);
+
+        if (!payload) {
+            break;
+        }
+        __sync_add_and_fetch(&ctx->sum_out, *payload);
+        __sync_add_and_fetch(&ctx->consumed, 1);
+        free(payload);
+    }
+
+    return NULL;
+}
+
+/* Multi-producer / multi-consumer contention under lock. */
+static int test_multithread_stress(void)
+{
+    struct stress_ctx ctx;
+    pthread_t producers[STRESS_PRODUCERS];
+    pthread_t consumers[STRESS_CONSUMERS];
+    unsigned int expected;
+    int i;
+    void *ret;
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.queue = os_queue_init(64);
+    if (!ctx.queue) {
+        fprintf(stderr, "FAIL: stress queue init\n");
+        return 1;
+    }
+
+    for (i = 0; i < STRESS_CONSUMERS; i++) {
+        if (pthread_create(&consumers[i], NULL, stress_consumer, &ctx) != 0) {
+            fprintf(stderr, "FAIL: consumer create %d\n", i);
+            return 1;
+        }
+    }
+    for (i = 0; i < STRESS_PRODUCERS; i++) {
+        if (pthread_create(&producers[i], NULL, stress_producer, &ctx) != 0) {
+            fprintf(stderr, "FAIL: producer create %d\n", i);
+            return 1;
+        }
+    }
+
+    for (i = 0; i < STRESS_PRODUCERS; i++) {
+        pthread_join(producers[i], &ret);
+        if (ret != NULL) {
+            fprintf(stderr, "FAIL: producer %d error\n", i);
+            os_queue_shutdown(ctx.queue);
+            for (i = 0; i < STRESS_CONSUMERS; i++) {
+                pthread_join(consumers[i], NULL);
+            }
+            os_queue_destroy(ctx.queue);
+            return 1;
+        }
+    }
+
+    os_queue_shutdown(ctx.queue);
+
+    for (i = 0; i < STRESS_CONSUMERS; i++) {
+        pthread_join(consumers[i], NULL);
+    }
+
+    expected = STRESS_PRODUCERS * STRESS_PER_PRODUCER;
+    if (ctx.produced != expected || ctx.consumed != expected) {
+        fprintf(stderr, "FAIL: stress counts produced=%u consumed=%u expected=%u\n",
+                ctx.produced, ctx.consumed, expected);
+        os_queue_destroy(ctx.queue);
+        return 1;
+    }
+    if (ctx.sum_in != ctx.sum_out) {
+        fprintf(stderr, "FAIL: stress checksum in=%u out=%u\n",
+                ctx.sum_in, ctx.sum_out);
+        os_queue_destroy(ctx.queue);
+        return 1;
+    }
+
+    os_queue_destroy(ctx.queue);
+    printf("PASS: os_queue multithread stress (%u producers x %u items)\n",
+           STRESS_PRODUCERS, STRESS_PER_PRODUCER);
+    return 0;
+}
+
+int main(void)
+{
+    if (test_basic_push_pop() != 0) {
+        return 1;
+    }
+    if (test_timedwait_timeout_on_full() != 0) {
+        return 1;
+    }
+    if (test_block_push() != 0) {
+        return 1;
+    }
+    if (test_multithread_stress() != 0) {
+        return 1;
+    }
+
+    printf("PASS: os_queue tests (push/pop, timedwait, block, stress)\n");
+    return 0;
+}
+
+#endif

--- a/src/shared/tests/queue_op_test.c
+++ b/src/shared/tests/queue_op_test.c
@@ -150,6 +150,49 @@ static int test_block_push(void)
     return 0;
 }
 
+static int test_reject_null_push(void)
+{
+    os_queue *queue;
+    struct timespec ts;
+
+    queue = os_queue_init(4);
+    if (!queue) {
+        fprintf(stderr, "FAIL: os_queue_init null push\n");
+        return 1;
+    }
+
+    if (os_queue_push_ex(queue, NULL) == 0) {
+        fprintf(stderr, "FAIL: os_queue_push_ex accepted NULL\n");
+        os_queue_destroy(queue);
+        return 1;
+    }
+    if (os_queue_push_ex_block(queue, NULL) == 0) {
+        fprintf(stderr, "FAIL: os_queue_push_ex_block accepted NULL\n");
+        os_queue_destroy(queue);
+        return 1;
+    }
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+        fprintf(stderr, "FAIL: clock_gettime null push\n");
+        os_queue_destroy(queue);
+        return 1;
+    }
+    ts.tv_sec += 1;
+    if (os_queue_push_ex_timedwait(queue, NULL, &ts) == 0) {
+        fprintf(stderr, "FAIL: os_queue_push_ex_timedwait accepted NULL\n");
+        os_queue_destroy(queue);
+        return 1;
+    }
+    if (os_queue_elements(queue) != 0) {
+        fprintf(stderr, "FAIL: null push mutated queue\n");
+        os_queue_destroy(queue);
+        return 1;
+    }
+
+    os_queue_shutdown(queue);
+    os_queue_destroy(queue);
+    return 0;
+}
+
 #define STRESS_PRODUCERS 4
 #define STRESS_CONSUMERS 4
 #define STRESS_PER_PRODUCER 2000
@@ -283,11 +326,14 @@ int main(void)
     if (test_block_push() != 0) {
         return 1;
     }
+    if (test_reject_null_push() != 0) {
+        return 1;
+    }
     if (test_multithread_stress() != 0) {
         return 1;
     }
 
-    printf("PASS: os_queue tests (push/pop, timedwait, block, stress)\n");
+    printf("PASS: os_queue tests (push/pop, timedwait, block, null, stress)\n");
     return 0;
 }
 

--- a/src/shared/tests/queue_op_test.c
+++ b/src/shared/tests/queue_op_test.c
@@ -10,6 +10,7 @@
 #ifndef WIN32
 
 #include <pthread.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/shared/tests/string_test.c
+++ b/src/shared/tests/string_test.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "string_op.h"
@@ -6,9 +7,11 @@
 
 int main(int argc, char **argv)
 {
-    int i = 0;
     char *tmp;
     char buf[] = "/var/www/html/Testing This Interface$%^&*().txt";
+
+    (void)argc;
+    (void)argv;
 
     tmp = os_shell_escape(buf);
     char clean[] = "/var/www/html/index.html";
@@ -20,6 +23,7 @@ int main(int argc, char **argv)
     tmp = os_shell_escape(clean);
     printf("Sent: '%s'\n", clean);
     printf("Fixed: '%s'\n", tmp);
+    free(tmp);
 
     return (0);
 }

--- a/src/tests/regressions/Makefile
+++ b/src/tests/regressions/Makefile
@@ -1,0 +1,60 @@
+# Unified analysisd / pipeline regression suite.
+# Run from src/ after a normal server build (live objects + libs):
+#
+#   make TARGET=server -j$(nproc)
+#   make -f tests/regressions/Makefile
+#   make -f tests/regressions/Makefile check
+#
+# Or from src/:
+#   make regression
+
+CC ?= cc
+CFLAGS += -I./ -I./headers -I./analysisd -Wall -Wextra
+CFLAGS += -DARGV0=\"ossec-analysisd\"
+
+EVENTINFO_OBJS = analysisd/eventinfo-live.o analysisd/eventinfo_list-live.o
+CORRELATION_OBJS = $(EVENTINFO_OBJS) analysisd/correlation_shard-live.o
+BASIC_LIBS = -Wl,--start-group shared.a os_regex.a -Wl,--end-group -lpcre2-8 -lm -lpthread
+
+REGRESSION_BINS = \
+	issue_1079_last_events_uaf \
+	issue_correlation_agent_shard \
+	issue_1748_sid_list_crash \
+	issue_1274_auth_ipv6_key
+
+.PHONY: all check clean
+
+all: $(REGRESSION_BINS)
+
+check: all
+	@failed=0; \
+	for bin in $(REGRESSION_BINS); do \
+		echo "=== $$bin ==="; \
+		./$$bin || failed=1; \
+	done; \
+	if [ $$failed -ne 0 ]; then \
+		echo "FAIL: one or more regression tests failed"; \
+		exit 1; \
+	fi; \
+	echo "PASS: all analysisd regressions"
+
+issue_1079_last_events_uaf: tests/regressions/issue_1079_last_events_uaf.c $(EVENTINFO_OBJS) shared.a
+	$(CC) $(CFLAGS) -o $@ tests/regressions/issue_1079_last_events_uaf.c $(EVENTINFO_OBJS) $(BASIC_LIBS)
+
+issue_correlation_agent_shard: tests/regressions/issue_correlation_agent_shard.c $(CORRELATION_OBJS) shared.a
+	$(CC) $(CFLAGS) -DARGV0=\"issue_correlation_agent_shard\" \
+		-o $@ tests/regressions/issue_correlation_agent_shard.c $(CORRELATION_OBJS) $(BASIC_LIBS)
+
+issue_1748_sid_list_crash: tests/regressions/issue_1748_sid_list_crash.c $(EVENTINFO_OBJS) shared.a
+	$(CC) $(CFLAGS) -o $@ tests/regressions/issue_1748_sid_list_crash.c $(EVENTINFO_OBJS) $(BASIC_LIBS)
+
+issue_1274_auth_ipv6_key: tests/regressions/issue_1274_auth_ipv6_key.c addagent/validate.o shared.a os_crypto.a
+	$(CC) $(CFLAGS) -o $@ tests/regressions/issue_1274_auth_ipv6_key.c addagent/validate.o \
+		-Wl,--start-group shared.a os_regex.a os_crypto.a os_net.a os_xml.a os_zlib.a libcJSON.a -Wl,--end-group \
+		-lpcre2-8 -lm -lpthread -lssl -lcrypto -lz
+
+addagent/validate.o: addagent/validate.c
+	$(CC) $(CFLAGS) -c addagent/validate.c -o $@
+
+clean:
+	rm -f $(REGRESSION_BINS)

--- a/src/tests/regressions/Makefile.1079
+++ b/src/tests/regressions/Makefile.1079
@@ -1,0 +1,6 @@
+# Thin wrappers kept for historic docs; prefer:
+#   make -f tests/regressions/Makefile
+# or from src/:
+#   make regression
+
+include tests/regressions/Makefile

--- a/src/tests/regressions/Makefile.1274
+++ b/src/tests/regressions/Makefile.1274
@@ -1,0 +1,2 @@
+# Thin wrapper; prefer make -f tests/regressions/Makefile
+include tests/regressions/Makefile

--- a/src/tests/regressions/Makefile.correlation_shard
+++ b/src/tests/regressions/Makefile.correlation_shard
@@ -1,0 +1,2 @@
+# Thin wrapper; prefer make -f tests/regressions/Makefile
+include tests/regressions/Makefile

--- a/src/tests/regressions/README.md
+++ b/src/tests/regressions/README.md
@@ -1,0 +1,62 @@
+# Analysisd / pipeline regression tests
+#
+# From `src/` after building the server target:
+#
+#   make TARGET=server -j$(nproc)
+#   make regression
+#
+# Or directly:
+#
+#   make -f tests/regressions/Makefile
+#   make -f tests/regressions/Makefile check
+#
+# Shared queue/thread unit tests (automated):
+#
+#   make -C shared/tests check
+#
+# Interactive helpers (prime/hash/merge/ip) are optional:
+#   make -C shared/tests legacy_helpers
+#
+# Covered binaries (make check):
+#   - issue_1079_last_events_uaf       frequency last_events ownership
+#   - issue_correlation_agent_shard    location EventList isolation +
+#                                      if_matched_sid cross-location
+#   - issue_1748_sid_list_crash        sid_prev_matched overflow + free callback
+#   - issue_1274_auth_ipv6_key         auth IPv6 key handling
+#
+# Additional scripts without unified Make targets (manual / historical):
+#   issue_1814_control_chars.c, issue_1817_uaf_fix.c, issue_1818_syscheck_uaf.c,
+#   issue_1953_xml_recursion.c, issue_2056_repro_crash.c
+#
+# Notes for new tests:
+#   - Define TLS time globals with `__thread` (`c_time`, `__crt_hour`, `__crt_wday`)
+#     so they link against analysisd objects that use thread-local clock state.
+#   - Call `os_mutex_init(&rule->mutex, NULL)` on any RuleInfo used with Search_*.
+#   - Do not stub `OS_GetLastEvent` when linking `eventinfo_list-live.o`.
+#
+# Correlation / shard semantics (pipeline rule_matching_threads > 1):
+#   - EventList history used by Search_LastEvents is **per location-hashed shard**.
+#   - Frequency/context that must span multiple agents should use if_matched_sid
+#     or if_matched_group (those lists remain global under rule->mutex).
+#   - Migration checklist: inventory multi-agent frequency rules → convert to
+#     if_matched_sid/group → keep pure Search_LastEvents only for local correlation.
+#   - Ops: events_received, events_dropped*, alerts_dropped*, archives_dropped*,
+#     raw_input_queue_*, fts_queue_*, and *_delta fields in ossec-analysisd.state.
+#     Raise queue sizes, lower EPS, or tune analysisd.*_push_wait_ms /
+#     input_demux_threads / raw_input_queue_size — no sync fallback for mid-pipe
+#     drops (alerts still sync-fall back).
+#   - Rate-limited merror WARN "pipeline queue pressure" also fires under drop load.
+#
+# Soak SLO / Nested replacement checklist (rule_matching_threads >= 2):
+#   1. Build/install ossec-analysisd; refresh etc/internal_options.conf knobs.
+#   2. ossec-control stop; kill leftover ossec-analysisd PIDs; confirm none remain.
+#   3. ossec-control start; confirm exactly one analysisd PID and pipeline log line
+#      (input_demux, shards); expect shard correlation reminder when shards > 1.
+#   4. .state: events_received increasing; statistical/raw/fts queue_* present;
+#      events_dropped_delta and events_dropped_shard_delta ~0 after settle;
+#      alerts flowing; Check_Hour uses statistical writer when stats enabled.
+#   5. Short burst should be absorbed by raw/demux wait_ms without sustained
+#      mid-pipe deltas; sustained overload may increment drops (expected).
+#
+# Wave 4 product planes (SCA/syscollector/winevt/dbsync/upgrade): deferred until
+# Waves 1–3 soak SLOs hold and product names a cutover plane.

--- a/src/tests/regressions/issue_1079_last_events_uaf.c
+++ b/src/tests/regressions/issue_1079_last_events_uaf.c
@@ -1,0 +1,197 @@
+/*
+ * Regression test for Issue 1079: frequency alert context shows wrong logs.
+ *
+ * Search_LastSids copies full_log strings, then OS_MoveRuleLastEvents transfers
+ * them onto the firing Eventinfo (alert_last_events). Raw pointers to
+ * Eventinfo->full_log must not be used — they become stale when those events
+ * leave the sid list / ring.
+ *
+ * Build (from src/):
+ *   make -f tests/regressions/Makefile.1079
+ *
+ * Run:
+ *   ./issue_1079_last_events_uaf
+ *
+ * With valgrind:
+ *   valgrind --error-exitcode=42 --leak-check=no -q ./issue_1079_last_events_uaf
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include "shared.h"
+#include "analysisd/eventinfo.h"
+#include "analysisd/config.h"
+#include "analysisd/rules.h"
+
+/* Globals required by analysisd code */
+_Config Config;
+__thread time_t c_time;
+OSDecoderInfo *NULL_Decoder = NULL;
+
+static Eventinfo *make_event(const char *full_log, const char *srcip, time_t when)
+{
+    Eventinfo *lf;
+
+    os_calloc(1, sizeof(Eventinfo), lf);
+    os_strdup(full_log, lf->full_log);
+    lf->log = lf->full_log;
+    os_strdup(srcip, lf->srcip);
+    lf->time = when;
+    lf->size = strlen(lf->log);
+
+    return lf;
+}
+
+static void setup_freq_rule(RuleInfo *rule5710, RuleInfo *rule5712)
+{
+    int ii;
+
+    memset(rule5710, 0, sizeof(RuleInfo));
+    rule5710->sigid = 5710;
+    rule5710->level = 5;
+#ifndef WIN32
+    os_mutex_init(&rule5710->mutex, NULL);
+#endif
+
+    rule5710->sid_prev_matched = OSList_Create();
+    if (!rule5710->sid_prev_matched) {
+        ErrorExit(MEM_ERROR, "issue_1079", errno, strerror(errno));
+    }
+
+    memset(rule5712, 0, sizeof(RuleInfo));
+    rule5712->sigid = 5712;
+    rule5712->level = 10;
+    rule5712->frequency = 2;
+    rule5712->timeframe = 120;
+    rule5712->context = 1;
+    rule5712->context_opts = SAME_SRCIP;
+    rule5712->sid_search = rule5710->sid_prev_matched;
+    rule5712->last_events_copied = 0;
+#ifndef WIN32
+    os_mutex_init(&rule5712->mutex, NULL);
+#endif
+
+    os_calloc(MAX_LAST_EVENTS + 1, sizeof(char *), rule5712->last_events);
+    for (ii = 0; ii <= MAX_LAST_EVENTS; ii++) {
+        rule5712->last_events[ii] = NULL;
+    }
+}
+
+static int add_to_sid_list(RuleInfo *rule5710, Eventinfo *lf)
+{
+    if (!OSList_AddData(rule5710->sid_prev_matched, lf)) {
+        return (0);
+    }
+
+    lf->generated_rule = rule5710;
+    lf->sid_node_to_delete = rule5710->sid_prev_matched->last_node;
+    return (1);
+}
+
+int main(void)
+{
+    RuleInfo rule5710;
+    RuleInfo rule5712;
+    Eventinfo *failures[3];
+    Eventinfo *trigger;
+    Eventinfo *matched;
+    const char *srcip = "192.168.20.26";
+    const char *accepted =
+        "Mar  1 13:06:53 BOX_B sshd[28131]: Accepted publickey for oracle from 192.168.20.26 port 38562 ssh2";
+    int ii;
+
+    memset(&Config, 0, sizeof(_Config));
+    Config.decoder_order_size = 10;
+    c_time = time(NULL);
+
+    setup_freq_rule(&rule5710, &rule5712);
+
+    failures[0] = make_event(
+        "Mar  1 13:06:40 BOX_A sshd[23510]: Invalid user bad1 from 192.168.20.26",
+        srcip, c_time - 30);
+    failures[1] = make_event(
+        "Mar  1 13:06:45 BOX_A sshd[23512]: Invalid user bad2 from 192.168.20.26",
+        srcip, c_time - 25);
+    failures[2] = make_event(
+        "Mar  1 13:06:50 BOX_A sshd[23514]: Invalid user bad3 from 192.168.20.26",
+        srcip, c_time - 20);
+
+    for (ii = 0; ii < 3; ii++) {
+        if (!add_to_sid_list(&rule5710, failures[ii])) {
+            fprintf(stderr, "ERROR: unable to add failure event %d to sid list\n", ii);
+            return (1);
+        }
+    }
+
+    trigger = make_event(
+        "Mar  1 13:07:04 BOX_A sshd[23518]: Invalid user  from 192.168.20.26",
+        srcip, c_time);
+
+    matched = Search_LastSids(trigger, &rule5712);
+    if (!matched) {
+        fprintf(stderr, "ERROR: Search_LastSids did not match (expected rule 5712)\n");
+        return (1);
+    }
+
+    /* Ownership moved onto the firing event under rule->mutex. */
+    if (!trigger->alert_last_events || !trigger->alert_last_events[0] ||
+        !strstr(trigger->alert_last_events[0], "Invalid user")) {
+        fprintf(stderr, "ERROR: expected Invalid user in trigger->alert_last_events[0]\n");
+        return (1);
+    }
+
+    if (rule5712.last_events_copied) {
+        fprintf(stderr, "ERROR: rule last_events should be cleared after Move\n");
+        return (1);
+    }
+
+    /* Free the event that originally backed the sampled log. */
+    Free_Eventinfo(failures[2]);
+
+    if (!trigger->alert_last_events[0] ||
+        !strstr(trigger->alert_last_events[0], "Invalid user")) {
+        fprintf(stderr, "ERROR: alert_last_events[0] corrupted after source event was freed\n");
+        return (1);
+    }
+
+    if (strstr(trigger->alert_last_events[0], "Accepted publickey") != NULL) {
+        fprintf(stderr, "ERROR: alert_last_events[0] shows unrelated success log after free\n");
+        return (1);
+    }
+
+    /* Deliberately reuse freed memory; copies must remain stable. */
+    for (ii = 0; ii < 4096; ii++) {
+        char *block = (char *)malloc(strlen(accepted) + 64);
+
+        if (!block) {
+            break;
+        }
+
+        snprintf(block, strlen(accepted) + 64, "%s", accepted);
+        free(block);
+    }
+
+    if (strstr(trigger->alert_last_events[0], "Accepted publickey") != NULL) {
+        fprintf(stderr, "ERROR: alert_last_events[0] overwritten by unrelated allocator traffic\n");
+        return (1);
+    }
+
+    printf("PASS: last_events retains correct log text after source Eventinfo is freed\n");
+    printf("  last_events[0]: %s\n", trigger->alert_last_events[0]);
+
+    Free_Eventinfo(failures[0]);
+    Free_Eventinfo(failures[1]);
+    Free_Eventinfo(trigger);
+
+    while (rule5710.sid_prev_matched->currently_size > 0) {
+        OSList_DeleteOldestNode(rule5710.sid_prev_matched);
+    }
+
+    free(rule5712.last_events);
+    free(rule5710.sid_prev_matched);
+
+    return (0);
+}

--- a/src/tests/regressions/issue_1274_auth_ipv6_key.c
+++ b/src/tests/regressions/issue_1274_auth_ipv6_key.c
@@ -1,0 +1,44 @@
+/*
+ * Regression test for issue #1274: ossec-authd -i with IPv6 agent keys.
+ *
+ * Build from src/:
+ *   make -f tests/regressions/Makefile.1274
+ *   ./issue_1274_auth_ipv6_key
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "addagent/manage_agents.h"
+
+int main(void)
+{
+    const char *ipv6_key =
+        "1041 ipv6test3 2001:db8::1 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const char *any_key =
+        "1042 ipv6test4 any 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const char *bad_name_key =
+        "1043 bad:name 2001:db8::1 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    if (!OS_IsValidAgentKey(ipv6_key)) {
+        fprintf(stderr, "FAIL: IPv6 agent key should be valid\n");
+        return (1);
+    }
+
+    if (!OS_IsValidAgentKey(any_key)) {
+        fprintf(stderr, "FAIL: 'any' agent key should be valid\n");
+        return (1);
+    }
+
+    if (OS_IsValidAgentKey(bad_name_key)) {
+        fprintf(stderr, "FAIL: agent name with ':' should be rejected\n");
+        return (1);
+    }
+
+    if (OS_IsValidName("2001:db8::1")) {
+        fprintf(stderr, "FAIL: IPv6 address must not pass OS_IsValidName\n");
+        return (1);
+    }
+
+    printf("PASS: issue #1274 auth IPv6 key validation\n");
+    return (0);
+}

--- a/src/tests/regressions/issue_1748_sid_list_crash.c
+++ b/src/tests/regressions/issue_1748_sid_list_crash.c
@@ -38,11 +38,8 @@
 
 /* Global mocks */
 _Config Config;
-time_t c_time;
+__thread time_t c_time;
 OSDecoderInfo *NULL_Decoder = NULL;
-
-/* Mock functions */
-EventNode *OS_GetLastEvent(void) { return NULL; }
 
 /* Callback function to clear sid_node_to_delete before auto-deletion
  * This is the FIX for issue #1748
@@ -69,7 +66,9 @@ int main(void) {
     test_rule->sigid = 12345;
     test_rule->level = 5;
     test_rule->comment = "Test rule for issue 1748";
-    
+#ifndef WIN32
+    os_mutex_init(&test_rule->mutex, NULL);
+#endif
     /* Create and configure the sid_prev_matched list */
     test_rule->sid_prev_matched = OSList_Create();
     if (!test_rule->sid_prev_matched) {

--- a/src/tests/regressions/issue_1814_control_chars.c
+++ b/src/tests/regressions/issue_1814_control_chars.c
@@ -27,11 +27,11 @@
 
 /* Mocks */
 _Config Config;
-time_t c_time;
+__thread time_t c_time;
 OSDecoderInfo *NULL_Decoder = NULL;
 char *__shost = "localhost";
-int __crt_hour = 0;
-int __crt_wday = 0;
+__thread int __crt_hour = 0;
+__thread int __crt_wday = 0;
 
 EventNode *OS_GetLastEvent(void) {
     return NULL;

--- a/src/tests/regressions/issue_1817_uaf_fix.c
+++ b/src/tests/regressions/issue_1817_uaf_fix.c
@@ -28,12 +28,12 @@
 
 /* Mocks */
 _Config Config;
-time_t c_time;
+__thread time_t c_time;
 OSDecoderInfo *NULL_Decoder = NULL;
 char *__shost = "localhost";
 char *__stats_comment = "stats";
-int __crt_hour = 0;
-int __crt_wday = 0;
+__thread int __crt_hour = 0;
+__thread int __crt_wday = 0;
 int one = 1;
 
 EventNode *OS_GetLastEvent(void) { return NULL; }

--- a/src/tests/regressions/issue_1818_syscheck_uaf.c
+++ b/src/tests/regressions/issue_1818_syscheck_uaf.c
@@ -26,12 +26,12 @@
 
 /* Mocks */
 _Config Config;
-time_t c_time;
+__thread time_t c_time;
 OSDecoderInfo *NULL_Decoder = NULL;
 char *__shost = "localhost";
 char *__stats_comment = "stats";
-int __crt_hour = 0;
-int __crt_wday = 0;
+__thread int __crt_hour = 0;
+__thread int __crt_wday = 0;
 
 EventNode *OS_GetLastEvent(void) { return NULL; }
 

--- a/src/tests/regressions/issue_correlation_agent_shard.c
+++ b/src/tests/regressions/issue_correlation_agent_shard.c
@@ -1,0 +1,266 @@
+/*
+ * Regression: location-hashed EventList shards isolate Search_LastEvents;
+ * if_matched_sid (global sid_search list) still correlates across locations.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "shared.h"
+#include "analysisd/eventinfo.h"
+#include "analysisd/config.h"
+#include "analysisd/rules.h"
+#include "analysisd/correlation_shard.h"
+
+_Config Config;
+__thread time_t c_time;
+OSDecoderInfo null_decoder_storage;
+OSDecoderInfo *NULL_Decoder = &null_decoder_storage;
+const char *__local_name = "issue_correlation_agent_shard";
+
+int getDefine_Int(const char *section, const char *key, int min, int max)
+{
+    (void)section;
+    (void)key;
+    (void)max;
+    return min;
+}
+
+static Eventinfo *make_event(const char *location, const char *log, time_t when)
+{
+    Eventinfo *lf = (Eventinfo *)calloc(1, sizeof(Eventinfo));
+
+    if (!lf) {
+        return NULL;
+    }
+
+    lf->location = strdup(location);
+    lf->hostname = lf->location;
+    lf->full_log = strdup(log);
+    lf->log = lf->full_log;
+    lf->time = when;
+    lf->decoder_info = NULL_Decoder;
+    lf->matched = 0;
+    lf->srcip = strdup("10.0.0.1");
+
+    return lf;
+}
+
+static void free_event_shallow(Eventinfo *lf)
+{
+    if (!lf) {
+        return;
+    }
+    free(lf->location);
+    free(lf->full_log);
+    free(lf->srcip);
+    free(lf);
+}
+
+static int test_eventlist_shard_isolation(void)
+{
+    EventList *shard0;
+    EventList *shard1;
+    RuleInfo freq_rule;
+    Eventinfo *probe;
+    Eventinfo *matched;
+    Eventinfo *a;
+    Eventinfo *b;
+    time_t now = time(NULL);
+    unsigned int id_a;
+    unsigned int id_b;
+    int i;
+
+    c_time = now;
+    memset(&freq_rule, 0, sizeof(freq_rule));
+
+    shard0 = OS_EventList_Create(Config.memorysize);
+    shard1 = OS_EventList_Create(Config.memorysize);
+    if (!shard0 || !shard1) {
+        fprintf(stderr, "ERROR: OS_EventList_Create failed\n");
+        return 1;
+    }
+
+    a = make_event("(001)->10.0.0.1", "agent A", now);
+    b = make_event("(002)->10.0.0.2", "agent B", now);
+    if (!a || !b) {
+        fprintf(stderr, "ERROR: make_event failed\n");
+        return 1;
+    }
+
+    id_a = analysisd_shard_id(a, 2);
+    id_b = analysisd_shard_id(b, 2);
+    if (analysisd_shard_id(a, 8) != analysisd_shard_id(a, 8)) {
+        fprintf(stderr, "ERROR: analysisd_shard_id unstable\n");
+        return 1;
+    }
+    printf("PASS: analysisd_shard_id stable (a=%u b=%u under 2 shards)\n", id_a, id_b);
+
+    os_mutex_init(&freq_rule.mutex, NULL);
+    freq_rule.sigid = 100;
+    freq_rule.level = 5;
+    freq_rule.timeframe = 300;
+    freq_rule.frequency = 0;
+    freq_rule.context = 1;
+    freq_rule.context_opts = SAME_SRCIP;
+    os_calloc(MAX_LAST_EVENTS + 1, sizeof(char *), freq_rule.last_events);
+
+    analysisd_set_event_list(id_a == 0 ? shard1 : shard0);
+    for (i = 0; i < 50; i++) {
+        Eventinfo *noise = make_event("(002)->10.0.0.2", "noise", now + i);
+
+        if (!noise) {
+            fprintf(stderr, "ERROR: noise alloc failed\n");
+            return 1;
+        }
+        noise->generated_rule = &freq_rule;
+        OS_AddEvent(noise);
+    }
+
+    analysisd_set_event_list(id_a == 0 ? shard0 : shard1);
+    probe = make_event("(001)->10.0.0.1", "probe", now + 100);
+    if (!probe) {
+        fprintf(stderr, "ERROR: probe alloc failed\n");
+        return 1;
+    }
+
+    matched = Search_LastEvents(probe, &freq_rule);
+    if (matched) {
+        fprintf(stderr, "ERROR: Search_LastEvents saw other shard's noise\n");
+        return 1;
+    }
+
+    {
+        Eventinfo *hist = make_event("(001)->10.0.0.1", "history", now + 50);
+
+        if (!hist) {
+            fprintf(stderr, "ERROR: history alloc failed\n");
+            return 1;
+        }
+        hist->generated_rule = &freq_rule;
+        OS_AddEvent(hist);
+    }
+
+    matched = Search_LastEvents(probe, &freq_rule);
+    if (!matched) {
+        fprintf(stderr, "ERROR: Search_LastEvents missed same-shard history\n");
+        return 1;
+    }
+
+    printf("PASS: location-hashed EventList shard isolation\n");
+
+    free_event_shallow(a);
+    free_event_shallow(b);
+    free_event_shallow(probe);
+    OS_EventList_Destroy(shard0);
+    OS_EventList_Destroy(shard1);
+    return 0;
+}
+
+/* if_matched_sid uses a shared OSList; history from agent A/B both count. */
+static int test_if_matched_sid_cross_location(void)
+{
+    RuleInfo parent_rule;
+    RuleInfo child_rule;
+    OSList *sid_list;
+    Eventinfo *from_a;
+    Eventinfo *from_b;
+    Eventinfo *probe;
+    Eventinfo *matched;
+    time_t now = time(NULL);
+
+    c_time = now;
+    memset(&parent_rule, 0, sizeof(parent_rule));
+    memset(&child_rule, 0, sizeof(child_rule));
+
+    sid_list = OSList_Create();
+    if (!sid_list || !OSList_SetMaxSize(sid_list, 128)) {
+        fprintf(stderr, "ERROR: OSList_Create/SetMaxSize failed\n");
+        return 1;
+    }
+
+    os_mutex_init(&parent_rule.mutex, NULL);
+    parent_rule.sigid = 5701;
+    parent_rule.level = 3;
+    parent_rule.sid_prev_matched = sid_list;
+
+    os_mutex_init(&child_rule.mutex, NULL);
+    child_rule.sigid = 5710;
+    child_rule.level = 10;
+    child_rule.timeframe = 300;
+    child_rule.frequency = 1; /* need 2 prior fires */
+    child_rule.if_matched_sid = 5701;
+    child_rule.sid_search = sid_list;
+    child_rule.context = 1;
+    os_calloc(MAX_LAST_EVENTS + 1, sizeof(char *), child_rule.last_events);
+
+    from_a = make_event("(001)->10.0.0.1", "fail A", now);
+    from_b = make_event("(002)->10.0.0.2", "fail B", now + 1);
+    probe = make_event("(003)->10.0.0.3", "fail C", now + 2);
+    if (!from_a || !from_b || !probe) {
+        fprintf(stderr, "ERROR: make_event failed for sid test\n");
+        return 1;
+    }
+
+    from_a->generated_rule = &parent_rule;
+    from_b->generated_rule = &parent_rule;
+    if (!OSList_AddData(sid_list, from_a) || !OSList_AddData(sid_list, from_b)) {
+        fprintf(stderr, "ERROR: OSList_AddData failed\n");
+        return 1;
+    }
+
+    /* Pure EventList path cannot see cross-agent history (different shard keys). */
+    {
+        EventList *empty = OS_EventList_Create(Config.memorysize);
+        RuleInfo local_only;
+
+        if (!empty) {
+            fprintf(stderr, "ERROR: empty EventList create failed\n");
+            return 1;
+        }
+        memset(&local_only, 0, sizeof(local_only));
+        os_mutex_init(&local_only.mutex, NULL);
+        local_only.sigid = 99;
+        local_only.level = 5;
+        local_only.timeframe = 300;
+        local_only.frequency = 1;
+        local_only.context = 1;
+        os_calloc(MAX_LAST_EVENTS + 1, sizeof(char *), local_only.last_events);
+        analysisd_set_event_list(empty);
+        matched = Search_LastEvents(probe, &local_only);
+        if (matched) {
+            fprintf(stderr, "ERROR: empty EventList unexpectedly matched\n");
+            return 1;
+        }
+        OS_EventList_Destroy(empty);
+    }
+
+    matched = Search_LastSids(probe, &child_rule);
+    if (!matched) {
+        fprintf(stderr, "ERROR: Search_LastSids missed cross-location parent fires\n");
+        return 1;
+    }
+
+    printf("PASS: if_matched_sid Search_LastSids correlates across locations\n");
+    return 0;
+}
+
+int main(void)
+{
+    memset(&Config, 0, sizeof(Config));
+    memset(&null_decoder_storage, 0, sizeof(null_decoder_storage));
+    null_decoder_storage.type = SYSLOG;
+    Config.decoder_order_size = 8;
+    Config.memorysize = 8192;
+
+    if (test_eventlist_shard_isolation() != 0) {
+        return 1;
+    }
+    if (test_if_matched_sid_cross_location() != 0) {
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Replace the single-threaded `ossec-analysisd` hot path with an always-on, multi-stage pipeline so decode, rule matching, and alert/archive output can scale across cores on Linux servers.

- Queue-backed stages: raw input → demux → typed decode workers (events / syscheck / rootcheck / hostinfo) → correlation shards → dedicated writers (alerts, statistical, archive, firewall, FTS).
- Host/location sharding for `Search_LastEvents` so concurrent rule-match workers keep per-location ordering without a global analysis lock; cross-agent frequency still uses `if_matched_sid` / `if_matched_group`.
- Tunables in `internal_options.conf` for thread counts (0 = auto), queue depths, and mid-pipe push wait; pipeline metrics exported to `ossec-analysisd.state` (throughput, drops, queue wait).
- Thread-safe shared state for log rollover/I/O, CDB lists, stats, alert IDs, and last-events snapshots so active response and JSON/custom log output stay correct under concurrency.

