### PR TITLE
Normalize Windows FIM paths for realtime and scheduled scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+**OSSEC changelog (4.3.0) <support@atomicorp.com>**
+
+**Release Maintainers**
+
+Dan Parriott
+
+Scott R. Shinn (https://www.atomicorp.com)
+
+**Contributors on this release**
+
+- @atomicturtle
+- @reyjrar
+
+**Release Notes**
+
+Work toward the next minor release after 4.2.0.
+
+**Bug Fixes**
+
+- @reyjrar / @atomicturtle - [PR 235](https://github.com/ossec/ossec-hids/pull/235) - Canonicalize Windows FIM paths so realtime and scheduled scans use the same slash form
+
+
 **OSSEC changelog (4.2.0) <support@atomicorp.com>**
 
 **Release Maintainers**

--- a/etc/templates/config/syscheck.template
+++ b/etc/templates/config/syscheck.template
@@ -20,18 +20,18 @@
     <ignore>/etc/dumpdates</ignore>
     <ignore>/etc/svc/volatile</ignore>
 
-    <!-- Windows files to ignore -->
-    <ignore>C:\WINDOWS/System32/LogFiles</ignore>
-    <ignore>C:\WINDOWS/Debug</ignore>
-    <ignore>C:\WINDOWS/WindowsUpdate.log</ignore>
-    <ignore>C:\WINDOWS/iis6.log</ignore>
-    <ignore>C:\WINDOWS/system32/wbem/Logs</ignore>
-    <ignore>C:\WINDOWS/system32/wbem/Repository</ignore>
-    <ignore>C:\WINDOWS/Prefetch</ignore>
-    <ignore>C:\WINDOWS/PCHEALTH/HELPCTR/DataColl</ignore>
-    <ignore>C:\WINDOWS/SoftwareDistribution</ignore>
-    <ignore>C:\WINDOWS/Temp</ignore>
-    <ignore>C:\WINDOWS/system32/config</ignore>
-    <ignore>C:\WINDOWS/system32/spool</ignore>
-    <ignore>C:\WINDOWS/system32/CatRoot</ignore>
+    <!-- Windows files to ignore (forward-slash form; '\' in ossec.conf is normalized) -->
+    <ignore>C:/WINDOWS/System32/LogFiles</ignore>
+    <ignore>C:/WINDOWS/Debug</ignore>
+    <ignore>C:/WINDOWS/WindowsUpdate.log</ignore>
+    <ignore>C:/WINDOWS/iis6.log</ignore>
+    <ignore>C:/WINDOWS/system32/wbem/Logs</ignore>
+    <ignore>C:/WINDOWS/system32/wbem/Repository</ignore>
+    <ignore>C:/WINDOWS/Prefetch</ignore>
+    <ignore>C:/WINDOWS/PCHEALTH/HELPCTR/DataColl</ignore>
+    <ignore>C:/WINDOWS/SoftwareDistribution</ignore>
+    <ignore>C:/WINDOWS/Temp</ignore>
+    <ignore>C:/WINDOWS/system32/config</ignore>
+    <ignore>C:/WINDOWS/system32/spool</ignore>
+    <ignore>C:/WINDOWS/system32/CatRoot</ignore>
   </syscheck>

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -211,6 +211,11 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             }
         }
 
+#ifdef WIN32
+        /* Canonicalize so realtime and scheduled scans share one path form. */
+        os_normalize_path(tmp_dir);
+#endif
+
         /* Get the options */
         if (!g_attrs || !g_values) {
             merror(SYSCHECK_NO_OPT, __local_name, dirs);
@@ -508,6 +513,7 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
 
 #ifdef WIN32
             ExpandEnvironmentStrings(node[i]->content, dirs, sizeof(dirs) - 1);
+            os_normalize_path(dirs);
 #else
             strncpy(dirs, node[i]->content, sizeof(dirs) - 1);
 #endif
@@ -603,6 +609,7 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
             os_calloc(2048, sizeof(char), new_ig);
 
             ExpandEnvironmentStrings(node[i]->content, new_ig, 2047);
+            os_normalize_path(new_ig);
 
             free(node[i]->content);
             node[i]->content = new_ig;
@@ -738,6 +745,7 @@ int Read_Syscheck(XML_NODE node, void *configp, __attribute__((unused)) void *ma
             os_calloc(2048, sizeof(char), new_nodiff);
 
             ExpandEnvironmentStrings(node[i]->content, new_nodiff, 2047);
+            os_normalize_path(new_nodiff);
 
             free(node[i]->content);
             node[i]->content = new_nodiff;

--- a/src/headers/file_op.h
+++ b/src/headers/file_op.h
@@ -57,6 +57,9 @@ int mkstemp_ex(char *tmp_path) __attribute__((nonnull));
 #ifdef WIN32
 int checkVista();
 extern int isVista;
+
+/* Rewrite '\\' to '/' in place so FIM paths, ignores, and alerts share one form. */
+void os_normalize_path(char *path);
 #endif
 
 int w_ref_parent_folder(const char *path);

--- a/src/shared/file_op.c
+++ b/src/shared/file_op.c
@@ -1738,6 +1738,23 @@ char *getuname()
 #endif /* WIN32 */
 
 
+#ifdef WIN32
+void os_normalize_path(char *path)
+{
+    char *p;
+
+    if (path == NULL) {
+        return;
+    }
+
+    for (p = path; *p != '\0'; p++) {
+        if (*p == '\\') {
+            *p = '/';
+        }
+    }
+}
+#endif /* WIN32 */
+
 int w_ref_parent_folder(const char * path) {
     const char * str;
     char * ptr;

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -374,12 +374,12 @@ int read_dir(const char *dir_name, int opts, OSMatch *restriction)
 #ifdef WIN32
         int di = 0;
         char *(defaultfilesn[]) = {
-            "C:\\autoexec.bat",
-            "C:\\config.sys",
-            "C:\\WINDOWS/System32/eventcreate.exe",
-            "C:\\WINDOWS/System32/eventtriggers.exe",
-            "C:\\WINDOWS/System32/tlntsvr.exe",
-            "C:\\WINDOWS/System32/Tasks",
+            "C:/autoexec.bat",
+            "C:/config.sys",
+            "C:/WINDOWS/System32/eventcreate.exe",
+            "C:/WINDOWS/System32/eventtriggers.exe",
+            "C:/WINDOWS/System32/tlntsvr.exe",
+            "C:/WINDOWS/System32/Tasks",
             NULL
         };
         while (defaultfilesn[di] != NULL) {

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -256,7 +256,6 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
 {
     int lcount;
     size_t offset = 0;
-    char *ptfile;
     char wdchar[32 + 1];
     char final_path[MAX_LINE + 1];
     win32rtfim *rtlocald;
@@ -297,17 +296,13 @@ void CALLBACK RTCallBack(DWORD dwerror, DWORD dwBytes, LPOVERLAPPED overlap)
                                      finalfile, MAX_PATH - 1, NULL, NULL);
         finalfile[lcount] = TEXT('\0');
 
-        /* Change forward slashes to backslashes on finalfile */
-        ptfile = strchr(finalfile, '\\');
-        while (ptfile) {
-            *ptfile = '/';
-            ptfile++;
-
-            ptfile = strchr(ptfile, '\\');
-        }
-
+        /* Build a path that matches scheduled FIM (forward-slash form).
+         * Credit: Brad Lhotsky (@reyjrar) for identifying the realtime vs
+         * full-scan slash mismatch in PR #235.
+         */
         final_path[MAX_LINE] = '\0';
         snprintf(final_path, MAX_LINE, "%s/%s", rtlocald->dir, finalfile);
+        os_normalize_path(final_path);
 
         /* Check the change */
         realtime_checksumfile(final_path);


### PR DESCRIPTION
Canonicalize '\' to '/' in syscheck directories, ignores, nodiff, and realtime callbacks so alerts and config matching share one path form. Supersedes the approach in PR #235; credit to Brad Lhotsky (@reyjrar) for identifying the slash mismatch.