### PR TITLE
Skip leading XML declarations in OS_ReadXML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Scott R. Shinn (https://www.atomicorp.com)
 - @atomicturtle
 - @reyjrar
 - @hyn172
+- @lazyp
 
 **Release Notes**
 
@@ -23,6 +24,7 @@ Work toward the next minor release after 4.2.0.
 **Bug Fixes**
 
 - @reyjrar / @atomicturtle - [PR 235](https://github.com/ossec/ossec-hids/pull/235) - Canonicalize Windows FIM paths so realtime and scheduled scans use the same slash form
+- @lazyp / @atomicturtle - [PR 564](https://github.com/ossec/ossec-hids/pull/564) - Skip leading XML declarations (and UTF-8 BOM) in OS_ReadXML
 
 
 **OSSEC changelog (4.2.0) <support@atomicorp.com>**

--- a/src/os_xml/os_xml.c
+++ b/src/os_xml/os_xml.c
@@ -19,6 +19,7 @@
 #include "os_xml_internal.h"
 
 /* Prototypes */
+static int _skip_xml_declaration(FILE *fp) __attribute__((nonnull));
 static int _oscomment(FILE *fp) __attribute__((nonnull));
 static int _writecontent(const char *str, size_t size, unsigned int parent, OS_XML *_lxml) __attribute__((nonnull));
 static int _writememory(const char *str, XML_TYPE type, size_t size,
@@ -118,6 +119,13 @@ int OS_ReadXML(const char *file, OS_XML *_lxml)
     /* Zero the line */
     _line = 1;
 
+    /* Skip a leading <?xml ...?> prolog when present (PR #564 / @lazyp). */
+    if (_skip_xml_declaration(fp) < 0) {
+        xml_error(_lxml, "XMLERR: XML declaration not closed.");
+        fclose(fp);
+        return (-1);
+    }
+
     if ((r = _ReadElem(fp, 0, _lxml, 0)) < 0) { /* First position */
         if (r != LEOF) {
             fclose(fp);
@@ -134,6 +142,61 @@ int OS_ReadXML(const char *file, OS_XML *_lxml)
     }
 
     fclose(fp);
+    return (0);
+}
+
+/* Skip a leading XML declaration. Leaves the stream unchanged when the file
+ * does not start with <?xml. Returns -1 if <?xml is present but never closed.
+ */
+static int _skip_xml_declaration(FILE *fp)
+{
+    long start;
+    unsigned char sig[5];
+    size_t n;
+    int c;
+    int prev = 0;
+    size_t i;
+
+    start = ftell(fp);
+    if (start < 0) {
+        return (0);
+    }
+
+    /* Optional UTF-8 BOM */
+    n = fread(sig, 1, 3, fp);
+    if (n == 3 && sig[0] == 0xEF && sig[1] == 0xBB && sig[2] == 0xBF) {
+        start = ftell(fp);
+    } else {
+        clearerr(fp);
+        if (fseek(fp, start, SEEK_SET) != 0) {
+            return (0);
+        }
+    }
+
+    n = fread(sig, 1, 5, fp);
+    if (n == 5 &&
+            sig[0] == (unsigned char)_R_CONFS &&
+            sig[1] == (unsigned char)_R_HEADER &&
+            sig[2] == 'x' && sig[3] == 'm' && sig[4] == 'l') {
+        for (i = 0; i < n; i++) {
+            if (sig[i] == '\n') {
+                _line++;
+            }
+        }
+        prev = 'l';
+        while ((c = _xml_fgetc(fp)) != EOF) {
+            if (prev == _R_HEADER && c == _R_CONFE) {
+                return (0);
+            }
+            prev = c;
+        }
+        return (-1);
+    }
+
+    clearerr(fp);
+    if (fseek(fp, start, SEEK_SET) != 0) {
+        return (0);
+    }
     return (0);
 }
 

--- a/src/os_xml/os_xml_internal.h
+++ b/src/os_xml/os_xml_internal.h
@@ -13,6 +13,7 @@
 #define _R_CONFS    '<'
 #define _R_CONFE    '>'
 #define _R_COM      '!'
+#define _R_HEADER   '?'
 
 #define LEOF        -2
 

--- a/src/tests/test_os_xml.c
+++ b/src/tests/test_os_xml.c
@@ -915,6 +915,65 @@ START_TEST(test_stringoverflow4)
 }
 END_TEST
 
+START_TEST(test_skip_xml_declaration)
+{
+    /* Leading XML declaration must be skipped; content still parses. */
+    assert_os_xml_eq(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        "<root attr1=\"1\" attr2=\"2\">value</root>",
+        "<root attr1=\"1\" attr2=\"2\">value</root>");
+
+    assert_os_xml_eq(
+        "<?xml version=\"1.0\"?>\n<root/>",
+        "<root></root>");
+
+    /* Files without a declaration still work. */
+    assert_os_xml_eq("<root>ok</root>", "<root>ok</root>");
+}
+END_TEST
+
+START_TEST(test_skip_xml_declaration_bom)
+{
+    char xml_file_name[256];
+    const unsigned char bom[] = { 0xEF, 0xBB, 0xBF };
+    const char *body = "<?xml version=\"1.0\"?><root>bom</root>";
+    FILE *fp;
+    OS_XML xml;
+
+    strncpy(xml_file_name, "/tmp/tmp_file-XXXXXX", sizeof(xml_file_name));
+    {
+        int fd = mkstemp(xml_file_name);
+        ck_assert_int_ne(fd, -1);
+        close(fd);
+    }
+
+    fp = fopen(xml_file_name, "wb");
+    ck_assert_ptr_ne(fp, NULL);
+    ck_assert_int_eq((int)fwrite(bom, 1, sizeof(bom), fp), 3);
+    ck_assert_int_eq((int)fwrite(body, 1, strlen(body), fp), (int)strlen(body));
+    fclose(fp);
+
+    ck_assert_int_eq(OS_ReadXML(xml_file_name, &xml), 0);
+    assert_os_xml_eq_str(&xml, "<root>bom</root>");
+    OS_ClearXML(&xml);
+    unlink(xml_file_name);
+}
+END_TEST
+
+START_TEST(test_unclosed_xml_declaration)
+{
+    char xml_file_name[256];
+    OS_XML xml;
+
+    create_xml_file("<?xml version=\"1.0\" encoding=\"UTF-8\"\n<root/>",
+                    xml_file_name, 256);
+    ck_assert_int_ne(OS_ReadXML(xml_file_name, &xml), 0);
+    ck_assert_str_eq(xml.err, "XMLERR: XML declaration not closed.");
+    OS_ClearXML(&xml);
+    unlink(xml_file_name);
+}
+END_TEST
+
 Suite *test_suite(void)
 {
     Suite *s = suite_create("os_xml");
@@ -965,6 +1024,9 @@ Suite *test_suite(void)
     tcase_add_test(tc_core, test_stringoverflow2);
     tcase_add_test(tc_core, test_stringoverflow3);
     tcase_add_test(tc_core, test_stringoverflow4);
+    tcase_add_test(tc_core, test_skip_xml_declaration);
+    tcase_add_test(tc_core, test_skip_xml_declaration_bom);
+    tcase_add_test(tc_core, test_unclosed_xml_declaration);
     suite_add_tcase(s, tc_core);
 
     return (s);


### PR DESCRIPTION
Allow configs and other XML files that include a standard <?xml ...?> prolog (and optional UTF-8 BOM) to parse successfully. Supersedes PR #564; credit to @lazyp for identifying the failure mode.