### PR TITLE
Refactor Unix MQ retry loops with table-driven waits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Scott R. Shinn (https://www.atomicorp.com)
 - @atomicturtle
 - @reyjrar
 - @hyn172
+- @awiddersheim
 
 **Release Notes**
 
@@ -19,6 +20,7 @@ Work toward the next minor release after 4.2.0.
 **General**
 
 - @hyn172 / @atomicturtle - [PR 504](https://github.com/ossec/ossec-hids/pull/504) - Add Windows interactive (logon type 2) success detail rule 18262
+- @awiddersheim / @atomicturtle - [PR 578](https://github.com/ossec/ossec-hids/pull/578) - Refactor Unix MQ start/send retry loops without changing wait budgets
 
 **Bug Fixes**
 

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -13,48 +13,63 @@
 
 #ifndef WIN32
 
+/* Table-driven retries preserve historical wait budgets while avoiding
+ * nested sleep ladders (see PR #578 / @awiddersheim).
+ */
+
+/* Wait for the queue socket path to appear. Returns 0 if present, -1 if not.
+ * delays[] are sleeps between existence checks (total wait 1+5+15 = 21s).
+ */
+static int mq_wait_for_path(const char *path, const unsigned int *delays, size_t ndelays)
+{
+    size_t i;
+
+    if (File_DateofChange(path) >= 0) {
+        return (0);
+    }
+
+    for (i = 0; i < ndelays; i++) {
+        sleep(delays[i]);
+        if (File_DateofChange(path) >= 0) {
+            return (0);
+        }
+    }
+
+    return (-1);
+}
+
 /* Start the Message Queue. type: WRITE||READ */
 int StartMQ(const char *path, short int type)
 {
+    int rc;
+    size_t i;
+    static const unsigned int path_waits[] = { 1, 5, 15 };
+    static const unsigned int connect_waits[] = { 1, 2 };
+
     if (type == READ) {
         return (OS_BindUnixDomain(path, 0660, OS_MAXSTR + 512));
     }
 
-    /* We give up to 21 seconds for the other end to start */
-    else {
-        int rc = 0;
-        if (File_DateofChange(path) < 0) {
-            sleep(1);
-            if (File_DateofChange(path) < 0) {
-                sleep(5);
-                if (File_DateofChange(path) < 0) {
-                    sleep(15);
-                    if (File_DateofChange(path) < 0) {
-                        merror(QUEUE_ERROR, __local_name, path, "Queue not found");
-                        return (-1);
-                    }
-                }
-            }
-        }
-
-        /* Wait up to 3 seconds to connect to the unix domain.
-         * After three errors, exit.
-         */
-        if ((rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256)) < 0) {
-            sleep(1);
-            if ((rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256)) < 0) {
-                sleep(2);
-                if ((rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256)) < 0) {
-                    merror(QUEUE_ERROR, __local_name, path,
-                           strerror(errno));
-                    return (-1);
-                }
-            }
-        }
-
-        debug1(MSG_SOCKET_SIZE, __local_name, OS_getsocketsize(rc));
-        return (rc);
+    /* Give the other end up to 21 seconds to create the socket. */
+    if (mq_wait_for_path(path, path_waits,
+                         sizeof(path_waits) / sizeof(path_waits[0])) < 0) {
+        merror(QUEUE_ERROR, __local_name, path, "Queue not found");
+        return (-1);
     }
+
+    /* Up to 3 connect attempts with 1s then 2s between failures (~3s sleeps). */
+    rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
+    for (i = 0; rc < 0 && i < sizeof(connect_waits) / sizeof(connect_waits[0]); i++) {
+        sleep(connect_waits[i]);
+        rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
+    }
+    if (rc < 0) {
+        merror(QUEUE_ERROR, __local_name, path, strerror(errno));
+        return (-1);
+    }
+
+    debug1(MSG_SOCKET_SIZE, __local_name, OS_getsocketsize(rc));
+    return (rc);
 }
 
 /* Send a message to the queue */
@@ -62,6 +77,8 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc)
 {
     int __mq_rcode;
     char tmpstr[OS_MAXSTR + 1];
+    size_t i;
+    static const unsigned int send_waits[] = { 1, 3, 5, 10 };
 
     tmpstr[OS_MAXSTR] = '\0';
 
@@ -92,49 +109,32 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc)
         return (-1);
     }
 
-    /* We attempt 5 times to send the message if
-     * the receiver socket is busy.
-     * After the first error, we wait 1 second.
-     * After the second error, we wait more 3 seconds.
-     * After the third error, we wait 5 seconds.
-     * After the fourth error, we wait 10 seconds.
-     * If we failed again, the message is not going
-     * to be delivered and an error is sent back.
+    /* Five send attempts; after the first failure, sleep 1/3/5/10s
+     * between retries (total sleep budget 19s). OS_SOCKTERR is fatal
+     * only on the initial attempt, matching historical behavior.
      */
-    if ((__mq_rcode = OS_SendUnix(queue, tmpstr, 0)) < 0) {
-        /* Error on the socket */
+    __mq_rcode = OS_SendUnix(queue, tmpstr, 0);
+    if (__mq_rcode < 0) {
         if (__mq_rcode == OS_SOCKTERR) {
             merror("%s: socketerr (not available).", __local_name);
             close(queue);
             return (-1);
         }
 
-        /* Unable to send. Socket busy */
-        sleep(1);
-        if (OS_SendUnix(queue, tmpstr, 0) < 0) {
-            /* When the socket is to busy, we may get some
-             * error here. Just sleep 2 second and try
-             * again.
-             */
-            sleep(3);
-            /* merror("%s: socket busy", __local_name); */
-            if (OS_SendUnix(queue, tmpstr, 0) < 0) {
-                sleep(5);
+        for (i = 0; i < sizeof(send_waits) / sizeof(send_waits[0]); i++) {
+            sleep(send_waits[i]);
+            if (send_waits[i] >= 5) {
                 merror("%s: socket busy ..", __local_name);
-                if (OS_SendUnix(queue, tmpstr, 0) < 0) {
-                    sleep(10);
-                    merror("%s: socket busy ..", __local_name);
-                    if (OS_SendUnix(queue, tmpstr, 0) < 0) {
-                        /* Message is going to be lost
-                         * if the application does not care
-                         * about checking the error
-                         */
-                        close(queue);
-                        return (-1);
-                    }
-                }
+            }
+
+            if (OS_SendUnix(queue, tmpstr, 0) >= 0) {
+                return (0);
             }
         }
+
+        /* Message is lost if the caller ignores the error. */
+        close(queue);
+        return (-1);
     }
 
     return (0);


### PR DESCRIPTION
Preserve the historical path/connect/send sleep budgets while replacing nested retry ladders, based on PR #578 from @awiddersheim.