### PR TITLE
Add cPanel/cpsrvd decoders and rules (supersedes #1036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Scott R. Shinn (https://www.atomicorp.com)
 - @lazyp
 - @awiddersheim
 - @doke2
+- @alex-front
 
 **Release Notes**
 
@@ -23,6 +24,7 @@ Work toward the next minor release after 4.2.0.
 
 - @hyn172 / @atomicturtle - [PR 504](https://github.com/ossec/ossec-hids/pull/504) - Add Windows interactive (logon type 2) success detail rule 18262
 - @awiddersheim / @atomicturtle - [PR 578](https://github.com/ossec/ossec-hids/pull/578) - Refactor Unix MQ start/send retry loops without changing wait budgets
+- @alex-front / @atomicturtle - [PR 1036](https://github.com/ossec/ossec-hids/pull/1036) - Add cPanel/cpsrvd decoders and rules (login, session, access)
 
 **Bug Fixes**
 

--- a/contrib/ossec-testing/tests/cpanel.ini
+++ b/contrib/ossec-testing/tests/cpanel.ini
@@ -1,38 +1,51 @@
 [successful login]
-log 1 fail = [2016-04-18 13:07:02 -0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
-log 2 fail = [2016-04-18 13:07:15 -0400] info [cpsrvd] 10.1.5.19 - reseller (possessor: root) - SUCCESS LOGIN cpaneld
-log 3 fail = [2016-04-18 13:08:27 -0400] info [cpsrvd] 10.1.5.19 - emailaccount@reseller.com (possessor: reseller) - SUCCESS LOGIN webmaild
+log 1 pass = [2016-04-18 13:07:02 -0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
+log 2 pass = [2016-04-18 13:07:15 -0400] info [cpsrvd] 10.1.5.19 - reseller (possessor: root) - SUCCESS LOGIN cpaneld
+log 3 pass = [2016-04-18 13:08:27 -0400] info [cpsrvd] 10.1.5.19 - emailaccount@reseller.com (possessor: reseller) - SUCCESS LOGIN webmaild
 
-rule = 11007
+rule = 11002
 alert = 3
-decoder = postgresql_log
+decoder = cpanel-login-success
 
 
 [cpanel attacks]
-log 1 fail = [2017-01-25 06:01:10 -0500] info [cpsrvd] 10.1.5.19 - test "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN cpaneld: invalid cpanel user test (loadcpdata failed)
-
-rule = 11001
-alert = 5
-decoder = postgresql_log
-
-[cpanel attacks 2]
-log 1 fail = [2016-11-18 09:32:19 +0000] info [cpsrvd] 10.1.5.19 - admin "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN whostmgrd: user password hash is missing from system (user probably does not exist)
+log 1 pass = [2017-01-25 06:01:10 -0500] info [cpsrvd] 10.1.5.19 - test "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN cpaneld: invalid cpanel user test (loadcpdata failed)
 
 rule = 11000
 alert = 5
-decoder = cpanel-login
+decoder = cpanel-login-failed
+
+[cpanel attacks 2]
+log 1 pass = [2016-11-18 09:32:19 +0000] info [cpsrvd] 10.1.5.19 - admin "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN whostmgrd: user password hash is missing from system (user probably does not exist)
+
+rule = 11000
+alert = 5
+decoder = cpanel-login-failed
 
 [successful login 2]
-log 1 fail = [2016-04-18 13:07:02 +0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
+log 1 pass = [2016-04-18 13:07:02 +0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
 
-rule = 11006
+rule = 11002
 alert = 3
-decoder = cpanel-login
+decoder = cpanel-login-success
+
+[session new]
+log 1 pass = [2017-02-03 01:21:31 -0500] info [cpsrvd] 10.101.1.18 NEW testuser:XImQi9d3anWMNSc9 address=10.101.1.18,app=cpaneld,creator=pupkin,method=handle_form_login,path=form,possessed=0
+
+rule = 11003
+alert = 3
+decoder = cpanel-session-new
 
 [session purge]
-log 1 fail = [2017-01-25 06:15:38 -0500] info [cpsrvd] 10.1.5.19 PURGE root:Nmm4xzhSpA2Sddv3 logout
+log 1 pass = [2017-01-25 06:15:38 -0500] info [cpsrvd] 10.1.5.19 PURGE root:Nmm4xzhSpA2Sddv3 logout
 
-rule = 11009
+rule = 11004
 alert = 3
-decoder = postgresql_log
+decoder = cpanel-session-logout
 
+[cpanel access failed]
+log 1 pass = 46.118.10.79 - paul [11/18/2016:09:35:43 -0000] "GET" FAILED LOGIN cpdavd: Could not fetch system home directory for paul
+
+rule = 11005
+alert = 5
+decoder = cpanel-access-failed

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -802,9 +802,10 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   - Examples:
   - [2007-08-31 18:37:09.454 ADT] 192.168.2.99: LOG:  connection authorized: user=ossec_user database=ossecdb
   - [2007-08-31 18:37:15.525 ADT] 192.168.2.99: ERROR:  relation "alert2" does not exist
+  - Timezone token must start with a letter so cPanel numeric offsets (+/-0400) are not stolen.
   -->
 <decoder name="postgresql_log">
-  <prematch_pcre2>^\[\d{4}-\d{2}-\d{2} \S+ [A-Za-z0-9@_-]+?\] </prematch_pcre2>
+  <prematch_pcre2>^\[\d{4}-\d{2}-\d{2} \S+ [A-Za-z][A-Za-z0-9@_+-]*\] </prematch_pcre2>
   <pcre2 offset="after_prematch">^\S+ ([A-Za-z0-9@_-]+?): </pcre2>
   <order>status</order>
 </decoder>
@@ -3268,8 +3269,9 @@ s=2 SFwdQ=0 SDupQ=0 SErr=0 RQ=2 RIQ=0 RFwdQ=0 RDupQ=0 RTCP=0 SFwdR=0 SFail=0 SFE
 
 <!-- OpenBSD httpd -->
 <decoder name="openbsd-httpd">
-  <prematch_pcre2> \[\d+/[A-Za-z0-9@_-]+/\d+:\d+:\d+:\d+ -\d+\] "</prematch_pcre2>
-  <pcre2>^(\S+) (\S+) \S+ \S+ \[\d+/[A-Za-z0-9@_-]+/\d+:\d+:\d+:\d+ -\d+\] "(\S+) (\S+) HTTP/\d\.\d" (\d+?) \d$</pcre2>
+  <!-- Month must be alphabetic (e.g. Nov) so numeric cPanel dates like 11/18/2016 are not stolen. -->
+  <prematch_pcre2> \[\d+/[A-Za-z]+/\d+:\d+:\d+:\d+ -\d+\] "</prematch_pcre2>
+  <pcre2>^(\S+) (\S+) \S+ \S+ \[\d+/[A-Za-z]+/\d+:\d+:\d+:\d+ -\d+\] "(\S+) (\S+) HTTP/\d\.\d" (\d+?) \d$</pcre2>
   <order>url, srcip, protocol, url, status</order>
   <type>web-log</type>
 </decoder>
@@ -3363,6 +3365,59 @@ s=2 SFwdQ=0 SDupQ=0 SErr=0 RQ=2 RIQ=0 RFwdQ=0 RDupQ=0 RTCP=0 SFwdR=0 SFail=0 SFE
   <prematch_pcre2>"command attempted on cowrie honeypot</prematch_pcre2>
   <pcre2>^\{"direction": "\S+", "protocol": "(\S+)", "ids_type": "(\S+)", "timestamp": "\d{4}-\d{2}-\d{2}\w\d{2}:\d{2}:\d{2}.\d+", "app": "cowrie", "transport": "\S+", "dest_port": (\d+?), "src_port": (\d+?), "severity": "\S+", "vendor_product": "Cowrie", "sensor": \S+, "src_ip": "(\S+)", "command": "\S+", "signature": "(.+)", "ssh_version": .+, "type": "cowrie\.sessions", "dest_ip": "(\S+)"\}</pcre2>
   <order>protocol, extra_data, dstport, srcport, srcip, action, dstip</order>
+</decoder>
+
+
+<!-- cPanel / cpsrvd (login_log, session_log, access_log).
+  - Examples:
+  - [2016-11-18 09:32:19 +0000] info [cpsrvd] 10.1.5.19 - admin "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN whostmgrd: user password hash is missing from system (user probably does not exist)
+  - [2017-01-25 06:01:10 -0500] info [cpsrvd] 10.1.5.19 - test "POST /login/?login_only=1 HTTP/1.1" FAILED LOGIN cpaneld: invalid cpanel user test (loadcpdata failed)
+  - [2016-04-18 13:07:02 -0400] info [cpsrvd] 10.1.5.19 - root - SUCCESS LOGIN whostmgrd
+  - [2016-04-18 13:07:15 -0400] info [cpsrvd] 10.1.5.19 - reseller (possessor: root) - SUCCESS LOGIN cpaneld
+  - [2017-02-03 01:21:31 -0500] info [cpsrvd] 10.101.1.18 NEW testuser:XImQi9d3anWMNSc9 address=10.101.1.18,app=cpaneld,creator=pupkin,method=handle_form_login,path=form,possessed=0
+  - [2017-01-25 06:15:38 -0500] info [cpsrvd] 10.1.5.19 PURGE root:Nmm4xzhSpA2Sddv3 logout
+  - 46.118.10.79 - paul [11/18/2016:09:35:43 -0000] "GET" FAILED LOGIN cpdavd: Could not fetch system home directory for paul
+  -->
+<decoder name="cpanel">
+  <prematch_pcre2>^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [+-]\d{4}\] info \[cpsrvd\] </prematch_pcre2>
+</decoder>
+
+<decoder name="cpanel-login-failed">
+  <parent>cpanel</parent>
+  <use_own_name>true</use_own_name>
+  <prematch_pcre2 offset="after_parent">FAILED LOGIN</prematch_pcre2>
+  <pcre2 offset="after_parent">^(\S+) - (\S+)</pcre2>
+  <order>srcip,user</order>
+</decoder>
+
+<decoder name="cpanel-login-success">
+  <parent>cpanel</parent>
+  <use_own_name>true</use_own_name>
+  <prematch_pcre2 offset="after_parent">SUCCESS LOGIN</prematch_pcre2>
+  <pcre2 offset="after_parent">^(\S+) - (.+?) - SUCCESS LOGIN</pcre2>
+  <order>srcip,user</order>
+</decoder>
+
+<decoder name="cpanel-session-new">
+  <parent>cpanel</parent>
+  <use_own_name>true</use_own_name>
+  <prematch_pcre2 offset="after_parent"> NEW </prematch_pcre2>
+  <pcre2 offset="after_parent">^(\S+) NEW (\w+):</pcre2>
+  <order>srcip,user</order>
+</decoder>
+
+<decoder name="cpanel-session-logout">
+  <parent>cpanel</parent>
+  <use_own_name>true</use_own_name>
+  <prematch_pcre2 offset="after_parent"> PURGE .+ logout</prematch_pcre2>
+  <pcre2 offset="after_parent">^(\S+) PURGE (\w+):</pcre2>
+  <order>srcip,user</order>
+</decoder>
+
+<decoder name="cpanel-access-failed">
+  <prematch_pcre2>^\S+ \S+ \S+ \[\d+/\d+/\d+:\d+:\d+:\d+ [+-]\d+\] "\w+" FAILED LOGIN</prematch_pcre2>
+  <pcre2>^(\S+) \S+ (\S+)</pcre2>
+  <order>srcip,user</order>
 </decoder>
 
 <!-- EOF -->

--- a/etc/ossec-agent.conf
+++ b/etc/ossec-agent.conf
@@ -70,4 +70,21 @@
     <log_format>apache</log_format>
     <location>/var/www/logs/error_log</location>
   </localfile>
+
+  <!-- cPanel (optional)
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/login_log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/access_log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/session_log</location>
+  </localfile>
+  -->
 </ossec_config>

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -76,6 +76,7 @@
     <include>exim_rules.xml</include>
     <include>openbsd-dhcpd_rules.xml</include>
     <include>dnsmasq_rules.xml</include>
+    <include>cpanel_rules.xml</include>
     <include>local_rules.xml</include>
   </rules>
 
@@ -205,4 +206,21 @@
     <log_format>apache</log_format>
     <location>/var/www/logs/error_log</location>
   </localfile>
+
+  <!-- cPanel (optional)
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/login_log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/access_log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/session_log</location>
+  </localfile>
+  -->
 </ossec_config>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -74,6 +74,7 @@
     <include>exim_rules.xml</include>
     <include>openbsd-dhcpd_rules.xml</include>
     <include>dnsmasq_rules.xml</include>
+    <include>cpanel_rules.xml</include>
     <include>local_rules.xml</include>
   </rules>
 
@@ -214,5 +215,22 @@
     <log_format>syslog</log_format>
     <location>/var/log/exim_mainlog</location>
   </localfile>
+
+  <!-- cPanel (optional)
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/login_log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/access_log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/session_log</location>
+  </localfile>
+  -->
 
 </ossec_config>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -34,6 +34,7 @@
     <include>openbsd-dhcpd_rules.xml</include>
     <include>nsd_rules.xml</include>
     <include>unbound_rules.xml</include>
+    <include>cpanel_rules.xml</include>
   </rules>  
 
   <syscheck>
@@ -186,4 +187,21 @@
     <log_format>apache</log_format>
     <location>/var/www/logs/error_log</location>
   </localfile>
+
+  <!-- cPanel (optional)
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/login_log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/access_log</location>
+  </localfile>
+
+  <localfile>
+    <log_format>syslog</log_format>
+    <location>/usr/local/cpanel/logs/session_log</location>
+  </localfile>
+  -->
 </ossec_config>

--- a/etc/rules/cpanel_rules.xml
+++ b/etc/rules/cpanel_rules.xml
@@ -1,0 +1,61 @@
+<!--
+  -  Official cPanel rules for OSSEC.
+  -
+  -  Authors: Alexandr Garaga (@alex-front), Paul Klymenko
+  -
+  -  This program is a free software; you can redistribute it
+  -  and/or modify it under the terms of the GNU General Public
+  -  License (version 2) as published by the FSF - Free Software
+  -  Foundation.
+  -
+  -  License details: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+  -->
+
+<group name="syslog,cpanel,">
+
+  <rule id="11000" level="5">
+    <if_sid>2501</if_sid>
+    <decoded_as>cpanel-login-failed</decoded_as>
+    <description>cPanel authentication failure.</description>
+    <group>authentication_failed,</group>
+  </rule>
+
+  <rule id="11001" level="10" frequency="4" timeframe="360">
+    <if_matched_sid>11000</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple cPanel authentication failures.</description>
+    <group>authentication_failures,</group>
+  </rule>
+
+  <rule id="11002" level="3">
+    <decoded_as>cpanel-login-success</decoded_as>
+    <description>cPanel authentication success.</description>
+    <group>authentication_success,</group>
+  </rule>
+
+  <rule id="11003" level="3">
+    <decoded_as>cpanel-session-new</decoded_as>
+    <description>cPanel session created.</description>
+    <group>authentication_success,</group>
+  </rule>
+
+  <rule id="11004" level="3">
+    <decoded_as>cpanel-session-logout</decoded_as>
+    <description>cPanel session logout.</description>
+  </rule>
+
+  <rule id="11005" level="5">
+    <if_sid>2501</if_sid>
+    <decoded_as>cpanel-access-failed</decoded_as>
+    <description>cPanel access_log authentication failure.</description>
+    <group>authentication_failed,</group>
+  </rule>
+
+  <rule id="11006" level="10" frequency="4" timeframe="360">
+    <if_matched_sid>11005</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple cPanel access_log authentication failures.</description>
+    <group>authentication_failures,</group>
+  </rule>
+
+</group>


### PR DESCRIPTION
Dedicated cpanel-* decoders cover login/session/access events for both timezone offset signs, and postgresql_log/openbsd-httpd prematches are tightened so they no longer steal those formats.