### PR TITLE
Fix PIX/ASA login decoders for masked users and enable failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Scott R. Shinn (https://www.atomicorp.com)
 - @doke2
 - @bchurchill
 - @alex-front
+- @crlorentzen
 
 **Release Notes**
 
@@ -33,6 +34,8 @@ Work toward the next minor release after 4.2.0.
 - @reyjrar / @atomicturtle - [PR 235](https://github.com/ossec/ossec-hids/pull/235) - Canonicalize Windows FIM paths so realtime and scheduled scans use the same slash form
 - @lazyp / @atomicturtle - [PR 564](https://github.com/ossec/ossec-hids/pull/564) - Skip leading XML declarations (and UTF-8 BOM) in OS_ReadXML
 - @doke2 / @atomicturtle - [PR 663](https://github.com/ossec/ossec-hids/pull/663) - Log AGENTCONFIG path when reading shared agent.conf in syscheckd
+- @crlorentzen / @atomicturtle - [PR 1124](https://github.com/ossec/ossec-hids/pull/1124) - Fix PIX/ASA 6-308001/605004/605005 field extraction (masked/empty users, remote IP)
+
 
 
 **OSSEC changelog (4.2.0) <support@atomicorp.com>**

--- a/contrib/ossec-testing/tests/pix.ini
+++ b/contrib/ossec-testing/tests/pix.ini
@@ -1,0 +1,34 @@
+[asa enable failed]
+log 1 pass = %%ASA-6-308001: Console enable password incorrect for 3 tries (from ssh (remote 198.18.1.100))
+
+rule = 4324
+alert = 9
+decoder = pix
+
+[asa login denied masked user]
+log 1 pass = %%ASA-6-605004: Login denied from 198.18.1.100/56332 to outside:198.18.1.254/ssh for user "*****"
+
+rule = 4321
+alert = 9
+decoder = pix
+
+[asa login permitted]
+log 1 pass = %%ASA-6-605005: Login permitted from 198.18.1.100/47849 to outside:198.18.1.254/ssh for user "us3rn@m3"
+
+rule = 4323
+alert = 3
+decoder = pix
+
+[pix login denied]
+log 1 pass = %%PIX-6-605004: Login denied from 192.168.2.10/32597 to outside:192.168.2.14/ssh for user "root"
+
+rule = 4321
+alert = 9
+decoder = pix
+
+[pix login permitted empty user]
+log 1 pass = %%PIX-6-605005: Login permitted from 192.168.1.2/2953 to inside:192.168.1.1/telnet for user ""
+
+rule = 4323
+alert = 3
+decoder = pix

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1403,8 +1403,11 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   - %PIX-6-305012: Teardown dynamic UDP translation from inside:1.1.1.1/12 to outside:1.2.1.2/11 duration 0:00:11.
   - %PIX-3-305005: No translation group found for icmp src outside:x.x.x.x dst inside:x.x.x.x (type 3, code 0)
   - %ASA-2-106001: Inbound TCP connection denied from 1.2.3.4/1234 to 213.207.99.248/445 flags SYN on interface outside (Message repeated 2 times)
+  - %ASA-6-308001: Console enable password incorrect for 3 tries (from ssh (remote 198.18.1.100))
   - %PIX-6-605005: Login permitted from 192.168.1.2/2953 to inside:192.168.1.1/telnet for user ""
   - %PIX-6-605004: Login denied from 192.168.2.10/32597 to outside:192.168.2.14/ssh for user "root"
+  - %ASA-6-605004: Login denied from 198.18.1.100/56332 to outside:198.18.1.254/ssh for user "*****"
+  - %ASA-6-605005: Login permitted from 198.18.1.100/47849 to outside:198.18.1.254/ssh for user "us3rn@m3"
   - %PIX-6-305011: Built dynamic UDP translation from inside:192.168.1.2/1026 to outside:192.168.2.14/1163
   - %PIX-6-305011: Built dynamic TCP translation from inside:192.168.1.3/54946 to outside:192.168.2.14/1033
   - %PIX-6-302015: Built outbound UDP connection 156 for outside:192.168.2.10/1514 (192.168.2.10/1514) to inside:192.168.1.2/1026 (192.168.2.14/1163)
@@ -1513,17 +1516,19 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <order>id, srcip</order>
 </decoder>
 
+<!-- 6-308001: extract id and remote IP from "(remote x.x.x.x)". -->
 <decoder name="pix-srcip">
   <parent>pix</parent>
   <prematch_pcre2 offset="after_parent">^6-308001</prematch_pcre2>
-  <pcre2 offset="after_parent">^(\S+): .+ (\S+)</pcre2>
+  <pcre2 offset="after_parent">^(\S+):.*?\(remote ([^)]+)\)</pcre2>
   <order>id, srcip</order>
 </decoder>
 
+<!-- 6-605004/605005: user may be empty, masked as *****, or contain @. -->
 <decoder name="pix-srcip-port">
   <parent>pix</parent>
   <prematch_pcre2 offset="after_parent">^6-605004|^6-605005</prematch_pcre2>
-  <pcre2 offset="after_parent">^(\S+): Login (\S+) from (\S+)/(\d+?) .+user "([A-Za-z0-9@_-]+?)"</pcre2>
+  <pcre2 offset="after_parent">^(\S+): Login (\S+) from (\S+)/(\d+).*user "([^"]*)"</pcre2>
   <order>id, action, srcip, srcport, user</order>
 </decoder>
 


### PR DESCRIPTION
Supersedes #1124: extract the remote IP for 6-308001, and allow empty or asterisk-masked usernames on 6-605004/605005 so rule IDs match.