### PR TITLE
Backup agent state and alert on duplicated IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Scott R. Shinn (https://www.atomicorp.com)
 - @doke2
 - @bchurchill
 - @alex-front
+- @hcw2016
 
 **Release Notes**
 
@@ -27,6 +28,7 @@ Work toward the next minor release after 4.2.0.
 - @awiddersheim / @atomicturtle - [PR 578](https://github.com/ossec/ossec-hids/pull/578) - Refactor Unix MQ start/send retry loops without changing wait budgets
 - @bchurchill / @atomicturtle - [PR 633](https://github.com/ossec/ossec-hids/pull/633) - Enable Linux compile/link hardening by default (PIE, FORTIFY, stack protector, full RELRO)
 - @alex-front / @atomicturtle - [PR 1036](https://github.com/ossec/ossec-hids/pull/1036) - Add cPanel/cpsrvd decoders and rules (login, session, access)
+- @hcw2016 / @atomicturtle - [PR 1166](https://github.com/ossec/ossec-hids/pull/1166) - Backup agent state before remove/force-delete and alert on duplicated IP
 
 **Bug Fixes**
 

--- a/contrib/ossec-testing/tests/manage_agents.ini
+++ b/contrib/ossec-testing/tests/manage_agents.ini
@@ -1,0 +1,6 @@
+[duplicated ip alert]
+log 1 pass = ossec: Duplicated IP 192.0.2.10
+
+rule = 520
+alert = 3
+decoder = ossec

--- a/etc/rules/ossec_rules.xml
+++ b/etc/rules/ossec_rules.xml
@@ -122,6 +122,12 @@
     <group>rootcheck,</group>
   </rule>
 
+  <rule id="520" level="3">
+    <if_sid>500</if_sid>
+    <pcre2>Duplicated IP</pcre2>
+    <description>Trying to add an agent with duplicated IP.</description>
+  </rule>
+
   <!-- Process monitoring rules -->
   <rule id="530" level="0">
     <if_sid>500</if_sid>

--- a/src/Makefile
+++ b/src/Makefile
@@ -471,6 +471,8 @@ endif
 	$(call INSTALL_CMD,0750,${OSSEC_USER},${OSSEC_GROUP}) -d ${PREFIX}/queue/ossec
 	$(call INSTALL_CMD,0750,${OSSEC_USER},${OSSEC_GROUP}) -d ${PREFIX}/queue/syscheck
 	$(call INSTALL_CMD,0750,${OSSEC_USER},${OSSEC_GROUP}) -d ${PREFIX}/queue/diff
+	$(call INSTALL_CMD,0550,root,${OSSEC_GROUP}) -d ${PREFIX}/backup
+	$(call INSTALL_CMD,0750,${OSSEC_USER},${OSSEC_GROUP}) -d ${PREFIX}/backup/agents
 
 	$(call INSTALL_CMD,0550,root,${OSSEC_GROUP}) -d ${PREFIX}/etc
 ifeq (${INSTALL_LOCALTIME},yes)

--- a/src/addagent/manage_agents.c
+++ b/src/addagent/manage_agents.c
@@ -220,13 +220,13 @@ int add_agent(int json_output)
             }
 
             if (env_remove_dup && (antiquity >= force_antiquity || antiquity < 0)) {
-                /* TODO: Save backup */
+                OS_BackupAgentInfo(id_exist);
 #ifdef REUSE_ID
                 strncpy(id, id_exist, FILE_SIZE);
 #endif
                 OS_RemoveAgent(id_exist);
             } else {
-                /* TODO: Send alert */
+                OS_NotifyDuplicatedIP(ip);
 
                 if (json_output) {
                     cJSON *json_root = cJSON_CreateObject();
@@ -537,6 +537,9 @@ int remove_agent(int json_output)
 #endif
 
             fclose(fp);
+
+            /* Preserve agent state before wiping queue files */
+            OS_BackupAgentInfo(u_id);
 
             /* Remove counter for ID */
             delete_agentinfo(full_name);

--- a/src/addagent/manage_agents.h
+++ b/src/addagent/manage_agents.h
@@ -41,6 +41,8 @@ char *getFullnameById(const char *id);
 char *OS_AddNewAgent(const char *name, const char *ip, const char *id);
 int  OS_RemoveAgent(const char *id);
 double OS_AgentAntiquity(const char *id);
+void OS_BackupAgentInfo(const char *id);
+void OS_NotifyDuplicatedIP(const char *ip);
 void FormatID(char *id);
 
 /* Print available agents */

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -10,6 +10,7 @@
 #include <time.h>
 #include "manage_agents.h"
 #include "os_crypto/md5/md5_op.h"
+#include "os_net/os_net.h"
 
 /* Global variables */
 fpos_t fp_pos;
@@ -603,6 +604,159 @@ double OS_AgentAntiquity(const char *id)
 
     return difftime(time(NULL), file_stat.st_mtime);
 }
+
+#ifndef WIN32
+/* Build a path relative to chroot or under DEFAULTDIR when not chrooted. */
+static void ossec_relpath(char *out, size_t outlen, const char *rel, const char *suffix)
+{
+    if (isChroot()) {
+        if (suffix && *suffix) {
+            snprintf(out, outlen, "%s/%s", rel, suffix);
+        } else {
+            snprintf(out, outlen, "%s", rel);
+        }
+    } else if (suffix && *suffix) {
+        snprintf(out, outlen, "%s%s/%s", DEFAULTDIR, rel, suffix);
+    } else {
+        snprintf(out, outlen, "%s%s", DEFAULTDIR, rel);
+    }
+}
+
+static void backup_link(const char *src, const char *dst)
+{
+    if (link(src, dst) < 0) {
+        debug1("%s: DEBUG: Unable to backup '%s' -> '%s': %s",
+               ARGV0, src, dst, strerror(errno));
+    }
+}
+
+/* Backup agent-info / syscheck / rootcheck before removing an agent. */
+void OS_BackupAgentInfo(const char *id)
+{
+    char path_backup[OS_SIZE_1024];
+    char path_src[OS_SIZE_1024];
+    char path_dst[OS_SIZE_1024];
+    char base[OS_SIZE_1024];
+    char timestamp[32];
+    char *full_name;
+    char *name_copy;
+    char *ip;
+    const char *syscheck_dir;
+    const char *rootcheck_dir;
+    time_t timer = time(NULL);
+    struct tm *tm_info;
+
+    full_name = getFullnameById(id);
+    if (!full_name) {
+        merror("%s: ERROR: Agent id '%s' not found for backup.", ARGV0, id);
+        return;
+    }
+
+    name_copy = strdup(full_name);
+    if (!name_copy) {
+        free(full_name);
+        return;
+    }
+
+    ip = strrchr(name_copy, '-');
+    if (!ip || !*(ip + 1)) {
+        free(name_copy);
+        free(full_name);
+        return;
+    }
+    *ip = '\0';
+    ip++;
+
+    tm_info = localtime(&timer);
+    if (!tm_info) {
+        free(name_copy);
+        free(full_name);
+        return;
+    }
+    strftime(timestamp, sizeof(timestamp), "%Y-%m-%d-%H%M%S", tm_info);
+
+    ossec_relpath(base, sizeof(base), AGNBACKUP_DIR, NULL);
+    mkdir(base, 0750);
+
+    snprintf(path_backup, sizeof(path_backup), "%s/%s-%s-%s",
+             base, name_copy, ip, timestamp);
+    if (mkdir(path_backup, 0750) < 0) {
+        merror("%s: ERROR: Couldn't create backup directory '%s': %s",
+               ARGV0, path_backup, strerror(errno));
+        free(name_copy);
+        free(full_name);
+        return;
+    }
+
+    syscheck_dir = isChroot() ? SYSCHECK_DIR : DEFAULTDIR SYSCHECK_DIR;
+    rootcheck_dir = isChroot() ? ROOTCHECK_DIR : DEFAULTDIR ROOTCHECK_DIR;
+
+    ossec_relpath(path_src, sizeof(path_src), AGENTINFO_DIR, full_name);
+    snprintf(path_dst, sizeof(path_dst), "%s/agent-info", path_backup);
+    backup_link(path_src, path_dst);
+
+    snprintf(path_src, sizeof(path_src), "%s/(%s) %s->syscheck",
+             syscheck_dir, name_copy, ip);
+    snprintf(path_dst, sizeof(path_dst), "%s/syscheck", path_backup);
+    backup_link(path_src, path_dst);
+
+    snprintf(path_src, sizeof(path_src), "%s/.(%s) %s->syscheck.cpt",
+             syscheck_dir, name_copy, ip);
+    snprintf(path_dst, sizeof(path_dst), "%s/syscheck.cpt", path_backup);
+    backup_link(path_src, path_dst);
+
+    snprintf(path_src, sizeof(path_src), "%s/(%s) %s->syscheck-registry",
+             syscheck_dir, name_copy, ip);
+    snprintf(path_dst, sizeof(path_dst), "%s/syscheck-registry", path_backup);
+    backup_link(path_src, path_dst);
+
+    snprintf(path_src, sizeof(path_src), "%s/.(%s) %s->syscheck-registry.cpt",
+             syscheck_dir, name_copy, ip);
+    snprintf(path_dst, sizeof(path_dst), "%s/syscheck-registry.cpt", path_backup);
+    backup_link(path_src, path_dst);
+
+    snprintf(path_src, sizeof(path_src), "%s/(%s) %s->rootcheck",
+             rootcheck_dir, name_copy, ip);
+    snprintf(path_dst, sizeof(path_dst), "%s/rootcheck", path_backup);
+    backup_link(path_src, path_dst);
+
+    free(name_copy);
+    free(full_name);
+}
+
+/* Best-effort alert when a duplicate agent IP is refused.
+ * Skips the long StartMQ wait if analysisd is not running.
+ */
+void OS_NotifyDuplicatedIP(const char *ip)
+{
+    int queue;
+    char msg[OS_SIZE_256];
+    const char *qpath;
+
+    if (!ip || !*ip) {
+        return;
+    }
+
+    qpath = isChroot() ? DEFAULTQUEUE : DEFAULTQPATH;
+    if (File_DateofChange(qpath) < 0) {
+        return;
+    }
+
+    queue = OS_ConnectUnixDomain(qpath, OS_MAXSTR + 256);
+    if (queue < 0) {
+        return;
+    }
+
+    snprintf(msg, sizeof(msg), "ossec: Duplicated IP %s", ip);
+    if (SendMSG(queue, msg, "manage_agents", LOCALFILE_MQ) < 0) {
+        merror("%s: ERROR: Unable to send duplicated IP alert.", ARGV0);
+    }
+    close(queue);
+}
+#else
+void OS_BackupAgentInfo(__attribute__((unused)) const char *id) {}
+void OS_NotifyDuplicatedIP(__attribute__((unused)) const char *ip) {}
+#endif
 
 /* Print available agents */
 int print_agents(int print_status, int active_only, int csv_output, cJSON *json_output)

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -125,6 +125,9 @@ http://www.ossec.net/main/license/\n"
 /* Rootcheck directory */
 #define ROOTCHECK_DIR    "/queue/rootcheck"
 
+/* Backup of agent state before force-delete / remove */
+#define AGNBACKUP_DIR    "/backup/agents"
+
 /* Diff queue */
 #define DIFF_DIR        "/queue/diff"
 #define DIFF_DIR_PATH   DEFAULTDIR DIFF_DIR


### PR DESCRIPTION
Finish the manage_agents TODOs from #1166: hardlink agent-info/syscheck/ rootcheck under backup/agents before remove or -F force-delete, and emit a best-effort ossec: Duplicated IP alert (rule 520) when a duplicate is refused.