### PR TITLE
Replace EOL GeoIP Legacy with libmaxminddb for analysisd.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
         sudo apt-get update -qq
         sudo apt-get install -y libevent-dev libsystemd-dev
         wget https://ftp.pcre.org/pub/pcre/pcre2-10.32.tar.gz && tar xzf pcre2-10.32.tar.gz -C src/external
-        if [[ "${GEOIP}" == "yes"  ]]; then ( sudo apt-get install geoip-bin geoip-database libgeoip-dev libgeoip1 ); fi
+        if [[ "${GEOIP}" == "yes"  ]]; then ( sudo apt-get install libmaxminddb-dev ); fi
         if [[ "${PRELUDE}" == "yes" ]]; then ( sudo apt-get install libprelude-dev ); fi
         if [[ "${ZEROMQ}" == "yes" ]]; then ( sudo apt-get install libzmq3-dev libtool autoconf libczmq-dev ); fi
         if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
 - sudo apt-get install -y libevent-dev libsystemd-dev
 - ( wget https://ftp.pcre.org/pub/pcre/pcre2-10.32.tar.gz
   && tar xzf pcre2-10.32.tar.gz -C src/external )
-- if [[ "${GEOIP}" == "yes"  ]]; then ( sudo apt-get install geoip-bin geoip-database libgeoip-dev libgeoip1 ); fi
+- if [[ "${GEOIP}" == "yes"  ]]; then ( sudo apt-get install libmaxminddb-dev ); fi
 - if [[ "${PRELUDE}" == "yes" ]]; then ( sudo apt-get install libprelude-dev ); fi
 - if [[ "${ZEROMQ}" == "yes" ]]; then ( sudo apt-get install libzmq3-dev libtool autoconf libczmq-dev ); fi
 - if [[ "${OSSEC_TYPE}" == "winagent" ]]; then ( sudo apt-get install aptitude && sudo aptitude -y install mingw-w64 nsis ); fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Scott R. Shinn (https://www.atomicorp.com)
 **Contributors on this release**
 
 - @atomicturtle
+- @ddpbsd
 - @reyjrar
 - @hyn172
 - @lazyp
@@ -30,6 +31,7 @@ Work toward the next minor release after 4.2.0.
 - @bchurchill / @atomicturtle - [PR 633](https://github.com/ossec/ossec-hids/pull/633) - Enable Linux compile/link hardening by default (PIE, FORTIFY, stack protector, full RELRO)
 - @alex-front / @atomicturtle - [PR 1036](https://github.com/ossec/ossec-hids/pull/1036) - Add cPanel/cpsrvd decoders and rules (login, session, access)
 - @hcw2016 / @atomicturtle - [PR 1166](https://github.com/ossec/ossec-hids/pull/1166) - Backup agent state before remove/force-delete and alert on duplicated IP
+- @ddpbsd / @atomicturtle - [PR 1828](https://github.com/ossec/ossec-hids/pull/1828) - Replace EOL GeoIP Legacy with libmaxminddb (GeoLite2 MMDB) for analysisd GeoIP
 
 **Bug Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Work toward the next minor release after 4.2.0.
 - @alex-front / @atomicturtle - [PR 1036](https://github.com/ossec/ossec-hids/pull/1036) - Add cPanel/cpsrvd decoders and rules (login, session, access)
 - @hcw2016 / @atomicturtle - [PR 1166](https://github.com/ossec/ossec-hids/pull/1166) - Backup agent state before remove/force-delete and alert on duplicated IP
 - @ddpbsd / @atomicturtle - [PR 1828](https://github.com/ossec/ossec-hids/pull/1828) - Replace EOL GeoIP Legacy with libmaxminddb (GeoLite2 MMDB) for analysisd GeoIP
+- @atomicturtle - GeoIP IDS rules (multi-country auth, impossible-travel) plus ASN/country enrichment; SSH invalid-user dstuser extraction; feed if_matched_group when sid_prev_matched is also set
 
 **Bug Fixes**
 

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -184,8 +184,8 @@
 <decoder name="ssh-invfailed">
   <parent>sshd</parent>
   <prematch_pcre2>^Failed \S+ for invalid user|^Failed \S+ for illegal user</prematch_pcre2>
-  <pcre2 offset="after_prematch">from (\S+) port \d+ \w+$</pcre2>
-  <order>srcip</order>
+  <pcre2 offset="after_prematch">^ (\S+) from (\S+) port \d+</pcre2>
+  <order>user, srcip</order>
 </decoder>
 
 <decoder name="ssh-failed">
@@ -219,8 +219,8 @@
 <decoder name="ssh-invalid-user">
   <parent>sshd</parent>
   <prematch_pcre2>^Invalid user|^Illegal user</prematch_pcre2>
-  <pcre2 offset="after_prematch"> from (\S+)</pcre2>
-  <order>srcip</order>
+  <pcre2 offset="after_prematch">^ (\S+) from (\S+)$</pcre2>
+  <order>user, srcip</order>
 </decoder>
 
 <decoder name="ssh-scan">
@@ -240,8 +240,8 @@
 <decoder name="ssh-disconnected">
   <parent>sshd</parent>
   <prematch_pcre2>^Disconnected from invalid user</prematch_pcre2>
-  <pcre2 offset="after_prematch">\S+ (\S+) </pcre2>
-  <order>srcip</order>
+  <pcre2 offset="after_prematch">^ (\S+) (\S+) </pcre2>
+  <order>user, srcip</order>
 </decoder>
 
 <decoder name="ssh-connection">

--- a/etc/internal_options.conf
+++ b/etc/internal_options.conf
@@ -65,7 +65,8 @@ analysisd.alerts_push_wait_ms=100
 analysisd.state_interval=5
 
 
-# Output GeoIP data at JSON alerts
+# Output GeoIP data at JSON alerts (srcgeoip, src_country, srcasn, ...)
+# Set to 1 when using MaxMind enrichment for SIEM hunts / geoip_rules.xml
 analysisd.geoip_jsonout=0
 
 # Logcollector file loop timeout (check every 2 seconds for file changes)

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -6,6 +6,9 @@
     <email_to>daniel.cid@example.com</email_to>
     <smtp_server>smtp.example.com.</smtp_server>
     <email_from>ossecm@ossec.example.com.</email_from>
+    <!-- MaxMind GeoIP (USE_GEOIP=1). Rocky/RHEL build: dnf install libmaxminddb-devel geolite2-city (runtime also needs libmaxminddb) -->
+    <!-- <geoipdb>/usr/share/GeoIP/GeoLite2-City.mmdb</geoipdb> -->
+    <!-- Optional ASN MMDB: <geoipasn>/usr/share/GeoIP/GeoLite2-ASN.mmdb</geoipasn> -->
   </global>
 
   <rules>
@@ -77,6 +80,7 @@
     <include>openbsd-dhcpd_rules.xml</include>
     <include>dnsmasq_rules.xml</include>
     <include>cpanel_rules.xml</include>
+    <include>geoip_rules.xml</include>
     <include>local_rules.xml</include>
   </rules>
 

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -6,6 +6,9 @@
     <email_to>daniel.cid@example.com</email_to>
     <smtp_server>smtp.example.com.</smtp_server>
     <email_from>ossecm@ossec.example.com.</email_from>
+    <!-- MaxMind GeoIP (USE_GEOIP=1). Rocky/RHEL build: dnf install libmaxminddb-devel geolite2-city (runtime also needs libmaxminddb) -->
+    <!-- <geoipdb>/usr/share/GeoIP/GeoLite2-City.mmdb</geoipdb> -->
+    <!-- Optional ASN MMDB: <geoipasn>/usr/share/GeoIP/GeoLite2-ASN.mmdb</geoipasn> -->
   </global>
 
   <rules>
@@ -75,6 +78,7 @@
     <include>openbsd-dhcpd_rules.xml</include>
     <include>dnsmasq_rules.xml</include>
     <include>cpanel_rules.xml</include>
+    <include>geoip_rules.xml</include>
     <include>local_rules.xml</include>
   </rules>
 

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -7,6 +7,9 @@
     <smtp_server>smtp.example.com.</smtp_server>
     <email_from>ossecm@ossec.example.com.</email_from>
     <!-- <email_reply_to>replyto@ossec.example.com.</email_reply_to> -->
+    <!-- MaxMind GeoIP (USE_GEOIP=1). Rocky/RHEL build: dnf install libmaxminddb-devel geolite2-city (runtime also needs libmaxminddb) -->
+    <!-- <geoipdb>/usr/share/GeoIP/GeoLite2-City.mmdb</geoipdb> -->
+    <!-- Optional ASN MMDB: <geoipasn>/usr/share/GeoIP/GeoLite2-ASN.mmdb</geoipasn> -->
   </global>
 
   <rules>
@@ -35,6 +38,7 @@
     <include>nsd_rules.xml</include>
     <include>unbound_rules.xml</include>
     <include>cpanel_rules.xml</include>
+    <include>geoip_rules.xml</include>
   </rules>  
 
   <syscheck>

--- a/etc/rules/geoip_rules.xml
+++ b/etc/rules/geoip_rules.xml
@@ -1,0 +1,75 @@
+<!--
+  - GeoIP / MaxMind detection rules
+  - Requires analysisd built with USE_GEOIP=1 and <geoipdb> pointing at a
+    GeoLite2-City (or Country) MMDB. Optional <geoipasn> enables ASN rules.
+  - On RHEL/Rocky build hosts: dnf install libmaxminddb-devel geolite2-city
+    (runtime also needs the libmaxminddb package)
+  - Example:
+      <global>
+        <geoipdb>/usr/share/GeoIP/GeoLite2-City.mmdb</geoipdb>
+        <geoipasn>/usr/share/GeoIP/GeoLite2-ASN.mmdb</geoipasn>
+      </global>
+  - Enable JSON fields with analysisd.geoip_jsonout=1
+  -
+  - same_user correlates on dstuser (SSH invalid-user failures need the
+    ssh-invfailed decoder to extract the attempted username).
+  - frequency="0" + different_srcgeoip fires when one prior same-user event
+    has a different country than the current event (OSSEC frequency is
+    off-by-+2 vs naive counting; see rules syntax docs).
+  -->
+
+<group name="geoip,">
+
+  <!-- Same user failing from multiple countries (credential stuffing / ATO) -->
+  <rule id="87601" level="10" frequency="0" timeframe="600">
+    <if_matched_group>authentication_failed</if_matched_group>
+    <same_user />
+    <different_srcgeoip />
+    <srcgeoip_pcre2>.+</srcgeoip_pcre2>
+    <description>Authentication failures for the same user from multiple GeoIP countries.</description>
+    <group>authentication_failures,attack,</group>
+  </rule>
+
+  <!-- Impossible travel: same user succeeds from a different country within 15m -->
+  <rule id="87611" level="12" frequency="0" timeframe="900">
+    <if_matched_group>authentication_success</if_matched_group>
+    <same_user />
+    <different_srcgeoip />
+    <srcgeoip_pcre2>.+</srcgeoip_pcre2>
+    <description>Successful authentications for the same user from multiple GeoIP countries (possible impossible travel).</description>
+    <group>authentication_success,attack,</group>
+  </rule>
+
+  <!--
+    Hosting / cloud ASN auth (opt-in). Requires <geoipasn> MMDB.
+    ASNs: Amazon 16509/14618, Google 15169/396982, Microsoft 8075,
+    DigitalOcean 14061, Hetzner 24940, OVH 16276, Linode 63949,
+    Vultr 20473, Oracle 31898.
+    Uncomment in local_rules.xml (or here) only if cloud/hosting logins are
+    unexpected for your deployment — these replace the parent auth sid.
+
+    <rule id="87620" level="8">
+      <if_group>authentication_success</if_group>
+      <srcasn_pcre2>^(16509|14618|15169|396982|8075|14061|24940|16276|63949|20473|31898)$</srcasn_pcre2>
+      <description>Successful authentication from a common cloud/hosting ASN.</description>
+      <group>authentication_success,geoip_hosting,</group>
+    </rule>
+
+    <rule id="87621" level="7">
+      <if_group>authentication_failed</if_group>
+      <srcasn_pcre2>^(16509|14618|15169|396982|8075|14061|24940|16276|63949|20473|31898)$</srcasn_pcre2>
+      <description>Authentication failure from a common cloud/hosting ASN.</description>
+      <group>authentication_failed,geoip_hosting,</group>
+    </rule>
+  -->
+
+  <!--
+    Example country policy (enable in local_rules.xml; do not ship hard denylists):
+    <rule id="100876" level="10">
+      <if_group>authentication_success</if_group>
+      <src_country_pcre2>^(?!US$).+</src_country_pcre2>
+      <description>Successful auth from outside expected country (US allowlist).</description>
+    </rule>
+  -->
+
+</group>

--- a/etc/templates/config/rules.template
+++ b/etc/templates/config/rules.template
@@ -67,5 +67,6 @@
     <include>dnsmasq_rules.xml</include>
     <include>nsd_rules.xml</include>
     <include>unbound_rules.xml</include>
+    <include>geoip_rules.xml</include>
     <include>local_rules.xml</include>
   </rules>  

--- a/src/Makefile
+++ b/src/Makefile
@@ -277,7 +277,13 @@ endif # USE_ZEROMQ
 
 ifneq (,$(filter ${USE_GEOIP},auto yes y Y 1))
 	DEFINES+=-DLIBGEOIP_ENABLED
-	OSSEC_LDFLAGS+=-lGeoIP
+	MAXMINDDB_CFLAGS:=$(shell pkg-config --cflags libmaxminddb 2>/dev/null)
+	MAXMINDDB_LIBS:=$(shell pkg-config --libs libmaxminddb 2>/dev/null)
+	ifeq (${MAXMINDDB_LIBS},)
+		MAXMINDDB_LIBS:=-lmaxminddb
+	endif
+	OSSEC_CFLAGS+=${MAXMINDDB_CFLAGS}
+	OSSEC_LDFLAGS+=${MAXMINDDB_LIBS}
 endif # USE_GEOIP
 
 ifneq (,$(filter ${USE_CURL},yes y Y 1))
@@ -605,7 +611,7 @@ help: failtarget
 	@echo "                         Use PGSQL_CFLAGS and PGSQL_LIBS to override defaults"
 	@echo
 	@echo "Geoip support: "
-	@echo "   make USE_GEOIP=1      Build with GeoIP support"
+	@echo "   make USE_GEOIP=1      Build with MaxMind libmaxminddb (MMDB) GeoIP support"
 	@echo
 	@echo "External source options: "
 	@echo "   make LUA_ENABLE=no    Disable LUA build"

--- a/src/Makefile
+++ b/src/Makefile
@@ -612,6 +612,7 @@ help: failtarget
 	@echo
 	@echo "Geoip support: "
 	@echo "   make USE_GEOIP=1      Build with MaxMind libmaxminddb (MMDB) GeoIP support"
+	@echo "                         (needs libmaxminddb headers/pkg-config, e.g. libmaxminddb-devel)"
 	@echo
 	@echo "External source options: "
 	@echo "   make LUA_ENABLE=no    Disable LUA build"

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -84,7 +84,7 @@ void OS_Store(const Eventinfo *lf)
 
 void OS_LogOutput(Eventinfo *lf)
 {
-    /* GeoIP fields are filled at decode time (SrcIP_FP / DstIP_FP). */
+    /* GeoIP fields are filled at decode time (DecodeEvent / SrcIP_FP / DstIP_FP). */
 
     printf(
         "** Alert %ld.%ld:%s - %s\n"
@@ -167,7 +167,7 @@ void OS_LogOutput(Eventinfo *lf)
 
 void OS_Log(Eventinfo *lf)
 {
-    /* GeoIP fields are filled at decode time (SrcIP_FP / DstIP_FP). */
+    /* GeoIP fields are filled at decode time (DecodeEvent / SrcIP_FP / DstIP_FP). */
 
     /* Writing to the alert log file */
     {

--- a/src/analysisd/alerts/log.c
+++ b/src/analysisd/alerts/log.c
@@ -84,16 +84,7 @@ void OS_Store(const Eventinfo *lf)
 
 void OS_LogOutput(Eventinfo *lf)
 {
-#ifdef LIBGEOIP_ENABLED
-    if (Config.geoipdb_file) {
-        if (lf->srcip && !lf->srcgeoip) {
-            lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
-        }
-        if (lf->dstip && !lf->dstgeoip) {
-            lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
-        }
-    }
-#endif
+    /* GeoIP fields are filled at decode time (SrcIP_FP / DstIP_FP). */
 
     printf(
         "** Alert %ld.%ld:%s - %s\n"
@@ -176,16 +167,7 @@ void OS_LogOutput(Eventinfo *lf)
 
 void OS_Log(Eventinfo *lf)
 {
-#ifdef LIBGEOIP_ENABLED
-    if (Config.geoipdb_file) {
-        if (lf->srcip && !lf->srcgeoip) {
-            lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
-        }
-        if (lf->dstip && !lf->dstgeoip) {
-            lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
-        }
-    }
-#endif
+    /* GeoIP fields are filled at decode time (SrcIP_FP / DstIP_FP). */
 
     /* Writing to the alert log file */
     {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -55,6 +55,8 @@ sqlite3 *conn;
 #ifdef LIBGEOIP_ENABLED
 MMDB_s geoipdb;
 int geoipdb_ready = 0;
+MMDB_s geoipasn;
+int geoipasn_ready = 0;
 #endif
 
 /** Prototypes **/
@@ -209,6 +211,7 @@ int main_analysisd(int argc, char **argv)
 
 #ifdef LIBGEOIP_ENABLED
     geoipdb_ready = 0;
+    geoipasn_ready = 0;
 #endif
 
 
@@ -305,7 +308,7 @@ int main_analysisd(int argc, char **argv)
 #ifdef LIBGEOIP_ENABLED
     Config.geoip_jsonout = getDefine_Int("analysisd", "geoip_jsonout", 0, 1);
 
-    /* Opening MaxMind MMDB (GeoLite2 Country/City, etc.) */
+    /* Opening MaxMind City/Country MMDB */
     geoipdb_ready = 0;
     if (Config.geoipdb_file) {
         int status = MMDB_open(Config.geoipdb_file, MMDB_MODE_MMAP, &geoipdb);
@@ -314,6 +317,18 @@ int main_analysisd(int argc, char **argv)
                    ARGV0, Config.geoipdb_file, MMDB_strerror(status));
         } else {
             geoipdb_ready = 1;
+        }
+    }
+
+    /* Optional ASN MMDB */
+    geoipasn_ready = 0;
+    if (Config.geoipasn_file) {
+        int status = MMDB_open(Config.geoipasn_file, MMDB_MODE_MMAP, &geoipasn);
+        if (status != MMDB_SUCCESS) {
+            merror("%s: ERROR: Unable to open GeoIP ASN database from: %s (%s) (disabling ASN enrichment).",
+                   ARGV0, Config.geoipasn_file, MMDB_strerror(status));
+        } else {
+            geoipasn_ready = 1;
         }
     }
 #endif
@@ -1104,6 +1119,44 @@ RuleInfo *OS_CheckIfRuleMatch(Eventinfo *lf, RuleNode *curr_node)
                     return(NULL);
             } else {
                 return(NULL);
+            }
+        }
+
+        if (rule->src_country) {
+            if (lf->src_country) {
+                if (!OSMatch_Execute(lf->src_country,
+                                     strlen(lf->src_country),
+                                     rule->src_country))
+                    return (NULL);
+            } else {
+                return (NULL);
+            }
+        } else if (rule->src_country_pcre2) {
+            if (lf->src_country) {
+                if (!OSPcre2_Execute(lf->src_country,
+                                     rule->src_country_pcre2))
+                    return (NULL);
+            } else {
+                return (NULL);
+            }
+        }
+
+        if (rule->srcasn) {
+            if (lf->srcasn) {
+                if (!OSMatch_Execute(lf->srcasn,
+                                     strlen(lf->srcasn),
+                                     rule->srcasn))
+                    return (NULL);
+            } else {
+                return (NULL);
+            }
+        } else if (rule->srcasn_pcre2) {
+            if (lf->srcasn) {
+                if (!OSPcre2_Execute(lf->srcasn,
+                                     rule->srcasn_pcre2))
+                    return (NULL);
+            } else {
+                return (NULL);
             }
         }
 

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -53,7 +53,8 @@ sqlite3 *conn;
 #endif
 
 #ifdef LIBGEOIP_ENABLED
-GeoIP *geoipdb;
+MMDB_s geoipdb;
+int geoipdb_ready = 0;
 #endif
 
 /** Prototypes **/
@@ -207,7 +208,7 @@ int main_analysisd(int argc, char **argv)
     hourly_firewall = 0;
 
 #ifdef LIBGEOIP_ENABLED
-    geoipdb = NULL;
+    geoipdb_ready = 0;
 #endif
 
 
@@ -302,14 +303,17 @@ int main_analysisd(int argc, char **argv)
 
 
 #ifdef LIBGEOIP_ENABLED
-     Config.geoip_jsonout = getDefine_Int("analysisd", "geoip_jsonout", 0, 1);
+    Config.geoip_jsonout = getDefine_Int("analysisd", "geoip_jsonout", 0, 1);
 
-    /* Opening GeoIP DB */
-    if(Config.geoipdb_file) {
-        geoipdb = GeoIP_open(Config.geoipdb_file, GEOIP_INDEX_CACHE);
-        if (geoipdb == NULL)
-        {
-            merror("%s: ERROR: Unable to open GeoIP database from: %s (disabling GeoIP).", ARGV0, Config.geoipdb_file);
+    /* Opening MaxMind MMDB (GeoLite2 Country/City, etc.) */
+    geoipdb_ready = 0;
+    if (Config.geoipdb_file) {
+        int status = MMDB_open(Config.geoipdb_file, MMDB_MODE_MMAP, &geoipdb);
+        if (status != MMDB_SUCCESS) {
+            merror("%s: ERROR: Unable to open GeoIP database from: %s (%s) (disabling GeoIP).",
+                   ARGV0, Config.geoipdb_file, MMDB_strerror(status));
+        } else {
+            geoipdb_ready = 1;
         }
     }
 #endif

--- a/src/analysisd/analysisd_stages.c
+++ b/src/analysisd/analysisd_stages.c
@@ -468,7 +468,11 @@ int analysisd_analyze_event(Eventinfo *lf)
                 lf->sid_node_to_delete = currently_rule->sid_prev_matched->last_node;
             }
             os_mutex_unlock(&currently_rule->mutex);
-        } else if (currently_rule->group_prev_matched) {
+        }
+        /* Also feed group lists when present. Do not use else-if: rules like
+         * 5710/5716 are watched by if_matched_sid (5712/5720) AND must still
+         * appear in if_matched_group histories (40111, geoip_rules, etc.). */
+        if (currently_rule->group_prev_matched) {
             unsigned int j = 0;
 
             os_mutex_lock(&currently_rule->mutex);

--- a/src/analysisd/config.h
+++ b/src/analysisd/config.h
@@ -17,6 +17,8 @@
 #include <maxminddb.h>
 extern MMDB_s geoipdb;
 extern int geoipdb_ready;
+extern MMDB_s geoipasn;
+extern int geoipasn_ready;
 #endif
 
 

--- a/src/analysisd/config.h
+++ b/src/analysisd/config.h
@@ -14,18 +14,14 @@
 #include "config/global-config.h"
 
 #ifdef LIBGEOIP_ENABLED
-#include "GeoIP.h"
+#include <maxminddb.h>
+extern MMDB_s geoipdb;
+extern int geoipdb_ready;
 #endif
 
 
 extern long int __crt_ftell; /* Global ftell pointer */
 extern _Config Config;       /* Global Config structure */
-
-/*
-#ifdef LIBGEOIP_ENABLED
-GeoIP *geoipdb;
-#endif
-*/
 
 int GlobalConf(const char *cfgfile);
 

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -376,13 +376,19 @@ void *SrcIP_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
 
 #ifdef LIBGEOIP_ENABLED
 
-    if(!lf->srcgeoip) { 
-        lf->srcgeoip = GetGeoInfobyIP(lf->srcip);
-    }
+    OS_GeoIP_Enrich(lf, 1);
 
     #ifdef TESTRULE
-        if (lf->srcgeoip && !alert_only)
-            print_out("       srcgeoip: '%s'", lf->srcgeoip);
+        if (!alert_only) {
+            if (lf->srcgeoip)
+                print_out("       srcgeoip: '%s'", lf->srcgeoip);
+            if (lf->src_country)
+                print_out("       src_country: '%s'", lf->src_country);
+            if (lf->srcasn)
+                print_out("       srcasn: '%s'", lf->srcasn);
+            if (lf->srcas_org)
+                print_out("       srcas_org: '%s'", lf->srcas_org);
+        }
     #endif
 
 #endif
@@ -401,12 +407,17 @@ void *DstIP_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
     lf->dstip = field;
 #ifdef LIBGEOIP_ENABLED
 
-    if(!lf->dstgeoip) { 
-        lf->dstgeoip = GetGeoInfobyIP(lf->dstip);
-    }
+    OS_GeoIP_Enrich(lf, 0);
+
     #ifdef TESTRULE
-        if (lf->dstgeoip && !alert_only)
-            print_out("       dstgeoip: '%s'", lf->dstgeoip);
+        if (!alert_only) {
+            if (lf->dstgeoip)
+                print_out("       dstgeoip: '%s'", lf->dstgeoip);
+            if (lf->dst_country)
+                print_out("       dst_country: '%s'", lf->dst_country);
+            if (lf->dstasn)
+                print_out("       dstasn: '%s'", lf->dstasn);
+        }
     #endif
 
 #endif

--- a/src/analysisd/decoders/decoder.c
+++ b/src/analysisd/decoders/decoder.c
@@ -330,6 +330,18 @@ void DecodeEvent(Eventinfo *lf, regex_matching *decoder_match)
 
 out:
     os_regex_set_thread_match(NULL);
+#ifdef LIBGEOIP_ENABLED
+    /* Plugin decoders assign srcip/dstip directly and never hit SrcIP_FP /
+     * DstIP_FP. Enrich here so rule matching and alert logs see GeoIP fields.
+     * OS_GeoIP_Enrich() is a no-op when the FP path already filled them.
+     */
+    if (lf->srcip) {
+        OS_GeoIP_Enrich(lf, 1);
+    }
+    if (lf->dstip) {
+        OS_GeoIP_Enrich(lf, 0);
+    }
+#endif
 #ifdef TESTRULE
     if (!alert_only && lf->decoder_info) {
         print_out("       decoder: '%s'", lf->decoder_info->name);
@@ -417,6 +429,8 @@ void *DstIP_FP(Eventinfo *lf, char *field, __attribute__((unused)) int order)
                 print_out("       dst_country: '%s'", lf->dst_country);
             if (lf->dstasn)
                 print_out("       dstasn: '%s'", lf->dstasn);
+            if (lf->dstas_org)
+                print_out("       dstas_org: '%s'", lf->dstas_org);
         }
     #endif
 

--- a/src/analysisd/decoders/decoder.h
+++ b/src/analysisd/decoders/decoder.h
@@ -67,6 +67,7 @@ int OS_AddOSDecoder(OSDecoderInfo *pi);
 OSDecoderNode *OS_GetFirstOSDecoder(const char *pname);
 int getDecoderfromlist(const char *name);
 char *GetGeoInfobyIP(char *ip_addr);
+void OS_GeoIP_Enrich(struct _Eventinfo *lf, int is_src);
 int SetDecodeXML(void);
 void HostinfoInit(void);
 void SyscheckInit(void);

--- a/src/analysisd/decoders/geoip.c
+++ b/src/analysisd/decoders/geoip.c
@@ -1,6 +1,3 @@
-/* @(#) $Id: ./src/analysisd/decoders/geoip.c, 2014/03/08 dcid Exp $
- */
-
 /* Copyright (C) 2014 Daniel Cid
  * All right reserved.
  *
@@ -21,70 +18,64 @@
 #include "eventinfo.h"
 #include "alerts/alerts.h"
 #include "decoder.h"
-#include "GeoIP.h"
-#include "GeoIPCity.h"
 
 
 char *GetGeoInfobyIP(char *ip_addr)
 {
-    GeoIPRecord *geoiprecord;
+    int gai_error;
+    int mmdb_error;
+    int status;
+    MMDB_lookup_result_s result;
+    MMDB_entry_data_s entry_data;
+    char country_code[3];
+    char geobuffer[256 + 1];
     char *geodata = NULL;
-    char geobuffer[256 +1];
-    extern GeoIP *geoipdb;
 
-    if(!geoipdb)
-    {
-        return(NULL);
+    if (!geoipdb_ready || !ip_addr) {
+        return (NULL);
     }
 
-    if(!ip_addr)
-    {
-        return(NULL);
+    result = MMDB_lookup_string(&geoipdb, ip_addr, &gai_error, &mmdb_error);
+    if (gai_error != 0 || mmdb_error != MMDB_SUCCESS || !result.found_entry) {
+        return (NULL);
     }
 
-    geoiprecord = GeoIP_record_by_name(geoipdb, (const char *)ip_addr);
-    if(geoiprecord == NULL)
-    {
-        return(NULL);
-    }
-    
-    if(geoiprecord->country_code == NULL)
-    {
-        GeoIPRecord_delete(geoiprecord);
-        return(NULL);
+    status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
+    if (status != MMDB_SUCCESS || !entry_data.has_data ||
+            entry_data.type != MMDB_DATA_TYPE_UTF8_STRING ||
+            entry_data.data_size != 2) {
+        return (NULL);
     }
 
-    if(strlen(geoiprecord->country_code) < 2)
-    {
-        GeoIPRecord_delete(geoiprecord);
-        return(NULL);
-    }
-   
+    memcpy(country_code, entry_data.utf8_string, 2);
+    country_code[2] = '\0';
 
-    if(geoiprecord->region != NULL && geoiprecord->region[0] != '\0')
-    {
-        const char *regionname = NULL;
-        regionname = GeoIP_region_name_by_code(geoiprecord->country_code, geoiprecord->region);
-        if(regionname != NULL)
-        {
-            snprintf(geobuffer, 255, "%s / %s", geoiprecord->country_code, regionname);
-            geobuffer[255] = '\0';
-            geodata = strdup(geobuffer);
-        }
-        else
-        {
-            geodata = strdup(geoiprecord->country_code);
-        }
-    }
-    else
-    {
-        geodata = strdup(geoiprecord->country_code);
+    /* Prefer English subdivision name when present (City DBs). */
+    status = MMDB_get_value(&result.entry, &entry_data,
+                            "subdivisions", "0", "names", "en", NULL);
+    if (status == MMDB_SUCCESS && entry_data.has_data &&
+            entry_data.type == MMDB_DATA_TYPE_UTF8_STRING &&
+            entry_data.data_size > 0 && entry_data.data_size < 200) {
+        snprintf(geobuffer, sizeof(geobuffer), "%s / %.*s",
+                 country_code, (int)entry_data.data_size, entry_data.utf8_string);
+        os_strdup(geobuffer, geodata);
+        return (geodata);
     }
 
-    GeoIPRecord_delete(geoiprecord);
-    return(geodata);
- 
+    /* Fall back to subdivision ISO code. */
+    status = MMDB_get_value(&result.entry, &entry_data,
+                            "subdivisions", "0", "iso_code", NULL);
+    if (status == MMDB_SUCCESS && entry_data.has_data &&
+            entry_data.type == MMDB_DATA_TYPE_UTF8_STRING &&
+            entry_data.data_size > 0 && entry_data.data_size < 16) {
+        snprintf(geobuffer, sizeof(geobuffer), "%s / %.*s",
+                 country_code, (int)entry_data.data_size, entry_data.utf8_string);
+        os_strdup(geobuffer, geodata);
+        return (geodata);
+    }
+
+    os_strdup(country_code, geodata);
+    return (geodata);
 }
 
 #endif
-

--- a/src/analysisd/decoders/geoip.c
+++ b/src/analysisd/decoders/geoip.c
@@ -8,7 +8,7 @@
  */
 
 
-/* GeoIP - Every IP address will have its geolocation added to it */
+/* GeoIP - MaxMind MMDB enrichment for event IPs */
 
 #ifdef LIBGEOIP_ENABLED
 
@@ -19,63 +19,213 @@
 #include "alerts/alerts.h"
 #include "decoder.h"
 
+#include <string.h>
 
-char *GetGeoInfobyIP(char *ip_addr)
+/* Copy a UTF-8 MMDB string into a NUL-terminated heap buffer. */
+static char *mmdb_strdup_utf8(const MMDB_entry_data_s *entry_data)
+{
+    char *out;
+
+    if (!entry_data->has_data || entry_data->type != MMDB_DATA_TYPE_UTF8_STRING ||
+            entry_data->data_size == 0) {
+        return (NULL);
+    }
+
+    os_calloc(entry_data->data_size + 1, sizeof(char), out);
+    memcpy(out, entry_data->utf8_string, entry_data->data_size);
+    out[entry_data->data_size] = '\0';
+    return (out);
+}
+
+static void lookup_city(const char *ip_addr,
+                        char **country, char **region, char **city, char **display)
 {
     int gai_error;
     int mmdb_error;
     int status;
     MMDB_lookup_result_s result;
     MMDB_entry_data_s entry_data;
-    char country_code[3];
     char geobuffer[256 + 1];
-    char *geodata = NULL;
+
+    *country = NULL;
+    *region = NULL;
+    *city = NULL;
+    *display = NULL;
 
     if (!geoipdb_ready || !ip_addr) {
-        return (NULL);
+        return;
     }
 
     result = MMDB_lookup_string(&geoipdb, ip_addr, &gai_error, &mmdb_error);
     if (gai_error != 0 || mmdb_error != MMDB_SUCCESS || !result.found_entry) {
-        return (NULL);
+        return;
     }
 
     status = MMDB_get_value(&result.entry, &entry_data, "country", "iso_code", NULL);
     if (status != MMDB_SUCCESS || !entry_data.has_data ||
             entry_data.type != MMDB_DATA_TYPE_UTF8_STRING ||
             entry_data.data_size != 2) {
-        return (NULL);
+        return;
+    }
+    *country = mmdb_strdup_utf8(&entry_data);
+    if (!*country) {
+        return;
     }
 
-    memcpy(country_code, entry_data.utf8_string, 2);
-    country_code[2] = '\0';
-
-    /* Prefer English subdivision name when present (City DBs). */
     status = MMDB_get_value(&result.entry, &entry_data,
                             "subdivisions", "0", "names", "en", NULL);
-    if (status == MMDB_SUCCESS && entry_data.has_data &&
-            entry_data.type == MMDB_DATA_TYPE_UTF8_STRING &&
-            entry_data.data_size > 0 && entry_data.data_size < 200) {
-        snprintf(geobuffer, sizeof(geobuffer), "%s / %.*s",
-                 country_code, (int)entry_data.data_size, entry_data.utf8_string);
-        os_strdup(geobuffer, geodata);
-        return (geodata);
+    if (status == MMDB_SUCCESS) {
+        *region = mmdb_strdup_utf8(&entry_data);
+    }
+    if (!*region) {
+        status = MMDB_get_value(&result.entry, &entry_data,
+                                "subdivisions", "0", "iso_code", NULL);
+        if (status == MMDB_SUCCESS) {
+            *region = mmdb_strdup_utf8(&entry_data);
+        }
     }
 
-    /* Fall back to subdivision ISO code. */
-    status = MMDB_get_value(&result.entry, &entry_data,
-                            "subdivisions", "0", "iso_code", NULL);
-    if (status == MMDB_SUCCESS && entry_data.has_data &&
-            entry_data.type == MMDB_DATA_TYPE_UTF8_STRING &&
-            entry_data.data_size > 0 && entry_data.data_size < 16) {
-        snprintf(geobuffer, sizeof(geobuffer), "%s / %.*s",
-                 country_code, (int)entry_data.data_size, entry_data.utf8_string);
-        os_strdup(geobuffer, geodata);
-        return (geodata);
+    status = MMDB_get_value(&result.entry, &entry_data, "city", "names", "en", NULL);
+    if (status == MMDB_SUCCESS) {
+        *city = mmdb_strdup_utf8(&entry_data);
     }
 
-    os_strdup(country_code, geodata);
-    return (geodata);
+    if (*region) {
+        snprintf(geobuffer, sizeof(geobuffer), "%s / %s", *country, *region);
+    } else {
+        snprintf(geobuffer, sizeof(geobuffer), "%s", *country);
+    }
+    os_strdup(geobuffer, *display);
+}
+
+static void lookup_asn(const char *ip_addr, char **asn, char **as_org)
+{
+    int gai_error;
+    int mmdb_error;
+    int status;
+    MMDB_lookup_result_s result;
+    MMDB_entry_data_s entry_data;
+    char asnbuf[16];
+
+    *asn = NULL;
+    *as_org = NULL;
+
+    if (!geoipasn_ready || !ip_addr) {
+        return;
+    }
+
+    result = MMDB_lookup_string(&geoipasn, ip_addr, &gai_error, &mmdb_error);
+    if (gai_error != 0 || mmdb_error != MMDB_SUCCESS || !result.found_entry) {
+        return;
+    }
+
+    status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_number", NULL);
+    if (status == MMDB_SUCCESS && entry_data.has_data &&
+            entry_data.type == MMDB_DATA_TYPE_UINT32) {
+        snprintf(asnbuf, sizeof(asnbuf), "%u", entry_data.uint32);
+        os_strdup(asnbuf, *asn);
+    }
+
+    status = MMDB_get_value(&result.entry, &entry_data, "autonomous_system_organization", NULL);
+    if (status == MMDB_SUCCESS) {
+        *as_org = mmdb_strdup_utf8(&entry_data);
+    }
+}
+
+void OS_GeoIP_Enrich(Eventinfo *lf, int is_src)
+{
+    const char *ip;
+    char *country = NULL;
+    char *region = NULL;
+    char *city = NULL;
+    char *display = NULL;
+    char *asn = NULL;
+    char *as_org = NULL;
+
+    if (!lf) {
+        return;
+    }
+
+    ip = is_src ? lf->srcip : lf->dstip;
+    if (!ip) {
+        return;
+    }
+
+    lookup_city(ip, &country, &region, &city, &display);
+    lookup_asn(ip, &asn, &as_org);
+
+    if (is_src) {
+        if (!lf->src_country && country) {
+            lf->src_country = country;
+            country = NULL;
+        }
+        if (!lf->src_region && region) {
+            lf->src_region = region;
+            region = NULL;
+        }
+        if (!lf->src_city && city) {
+            lf->src_city = city;
+            city = NULL;
+        }
+        if (!lf->srcgeoip && display) {
+            lf->srcgeoip = display;
+            display = NULL;
+        }
+        if (!lf->srcasn && asn) {
+            lf->srcasn = asn;
+            asn = NULL;
+        }
+        if (!lf->srcas_org && as_org) {
+            lf->srcas_org = as_org;
+            as_org = NULL;
+        }
+    } else {
+        if (!lf->dst_country && country) {
+            lf->dst_country = country;
+            country = NULL;
+        }
+        if (!lf->dst_region && region) {
+            lf->dst_region = region;
+            region = NULL;
+        }
+        if (!lf->dst_city && city) {
+            lf->dst_city = city;
+            city = NULL;
+        }
+        if (!lf->dstgeoip && display) {
+            lf->dstgeoip = display;
+            display = NULL;
+        }
+        if (!lf->dstasn && asn) {
+            lf->dstasn = asn;
+            asn = NULL;
+        }
+        if (!lf->dstas_org && as_org) {
+            lf->dstas_org = as_org;
+            as_org = NULL;
+        }
+    }
+
+    free(country);
+    free(region);
+    free(city);
+    free(display);
+    free(asn);
+    free(as_org);
+}
+
+char *GetGeoInfobyIP(char *ip_addr)
+{
+    char *country = NULL;
+    char *region = NULL;
+    char *city = NULL;
+    char *display = NULL;
+
+    lookup_city(ip_addr, &country, &region, &city, &display);
+    free(country);
+    free(region);
+    free(city);
+    return (display);
 }
 
 #endif

--- a/src/analysisd/decoders/geoip.c
+++ b/src/analysisd/decoders/geoip.c
@@ -151,6 +151,19 @@ void OS_GeoIP_Enrich(Eventinfo *lf, int is_src)
         return;
     }
 
+    /* Skip MMDB work when this side was already enriched (e.g. SrcIP_FP
+     * followed by the DecodeEvent catch-all for plugin decoders).
+     */
+    if (is_src) {
+        if (lf->srcgeoip || lf->src_country || lf->src_region ||
+                lf->src_city || lf->srcasn || lf->srcas_org) {
+            return;
+        }
+    } else if (lf->dstgeoip || lf->dst_country || lf->dst_region ||
+               lf->dst_city || lf->dstasn || lf->dstas_org) {
+        return;
+    }
+
     lookup_city(ip, &country, &region, &city, &display);
     lookup_asn(ip, &asn, &as_org);
 

--- a/src/analysisd/eventinfo.c
+++ b/src/analysisd/eventinfo.c
@@ -208,13 +208,15 @@ Eventinfo *Search_LastSids(Eventinfo *my_lf, RuleInfo *rule)
                 }
             }
 
-            /* GEOIP version of check for repetitions from same src_ip */
+            /* Prefer ISO country codes when available (stable across City vs display strings). */
             if (rule->context_opts & DIFFERENT_SRCGEOIP) {
-                if ((!lf->srcgeoip) || (!my_lf->srcgeoip)) {
+                const char *a = lf->src_country ? lf->src_country : lf->srcgeoip;
+                const char *b = my_lf->src_country ? my_lf->src_country : my_lf->srcgeoip;
+                if ((!a) || (!b)) {
                     continue;
                 }
 
-                if (strcmp(lf->srcgeoip, my_lf->srcgeoip) == 0) {
+                if (strcmp(a, b) == 0) {
                     continue;
                 }
             }
@@ -384,12 +386,13 @@ Eventinfo *Search_LastGroups(Eventinfo *my_lf, RuleInfo *rule)
 
             /* Check for different from same srcgeoip */
             if (rule->context_opts & DIFFERENT_SRCGEOIP) {
-
-                if ((!lf->srcgeoip) || (!my_lf->srcgeoip)) {
+                const char *a = lf->src_country ? lf->src_country : lf->srcgeoip;
+                const char *b = my_lf->src_country ? my_lf->src_country : my_lf->srcgeoip;
+                if ((!a) || (!b)) {
                     continue;
                 }
 
-                if (strcmp(lf->srcgeoip, my_lf->srcgeoip) == 0) {
+                if (strcmp(a, b) == 0) {
                     continue;
                 }
             }
@@ -540,12 +543,13 @@ Eventinfo *Search_LastEvents(Eventinfo *my_lf, RuleInfo *rule)
 
         /* Check for different from same srcgeoip */
         if (rule->context_opts & DIFFERENT_SRCGEOIP) {
-
-            if ((!lf->srcgeoip) || (!my_lf->srcgeoip)) {
+            const char *a = lf->src_country ? lf->src_country : lf->srcgeoip;
+            const char *b = my_lf->src_country ? my_lf->src_country : my_lf->srcgeoip;
+            if ((!a) || (!b)) {
                 continue;
             }
 
-            if (strcmp(lf->srcgeoip, my_lf->srcgeoip) == 0) {
+            if (strcmp(a, b) == 0) {
                 continue;
             }
         }
@@ -608,8 +612,18 @@ void Zero_Eventinfo(Eventinfo *lf)
 
     lf->srcip = NULL;
     lf->srcgeoip = NULL;
+    lf->src_country = NULL;
+    lf->src_region = NULL;
+    lf->src_city = NULL;
+    lf->srcasn = NULL;
+    lf->srcas_org = NULL;
     lf->dstip = NULL;
     lf->dstgeoip = NULL;
+    lf->dst_country = NULL;
+    lf->dst_region = NULL;
+    lf->dst_city = NULL;
+    lf->dstasn = NULL;
+    lf->dstas_org = NULL;
     lf->srcport = NULL;
     lf->dstport = NULL;
     lf->protocol = NULL;
@@ -700,6 +714,27 @@ void Free_Eventinfo(Eventinfo *lf)
         lf->srcgeoip = NULL;
     }
 
+    if (lf->src_country) {
+        free(lf->src_country);
+        lf->src_country = NULL;
+    }
+    if (lf->src_region) {
+        free(lf->src_region);
+        lf->src_region = NULL;
+    }
+    if (lf->src_city) {
+        free(lf->src_city);
+        lf->src_city = NULL;
+    }
+    if (lf->srcasn) {
+        free(lf->srcasn);
+        lf->srcasn = NULL;
+    }
+    if (lf->srcas_org) {
+        free(lf->srcas_org);
+        lf->srcas_org = NULL;
+    }
+
     if (lf->dstip) {
         free(lf->dstip);
     }
@@ -707,6 +742,27 @@ void Free_Eventinfo(Eventinfo *lf)
     if(lf->dstgeoip) {
         free(lf->dstgeoip);
         lf->dstgeoip = NULL;
+    }
+
+    if (lf->dst_country) {
+        free(lf->dst_country);
+        lf->dst_country = NULL;
+    }
+    if (lf->dst_region) {
+        free(lf->dst_region);
+        lf->dst_region = NULL;
+    }
+    if (lf->dst_city) {
+        free(lf->dst_city);
+        lf->dst_city = NULL;
+    }
+    if (lf->dstasn) {
+        free(lf->dstasn);
+        lf->dstasn = NULL;
+    }
+    if (lf->dstas_org) {
+        free(lf->dstas_org);
+        lf->dstas_org = NULL;
     }
 
     if (lf->srcport) {

--- a/src/analysisd/eventinfo.h
+++ b/src/analysisd/eventinfo.h
@@ -29,8 +29,18 @@ typedef struct _Eventinfo {
     /* Extracted from the decoders */
     char *srcip;
     char *srcgeoip;
+    char *src_country;
+    char *src_region;
+    char *src_city;
+    char *srcasn;
+    char *srcas_org;
     char *dstip;
     char *dstgeoip;
+    char *dst_country;
+    char *dst_region;
+    char *dst_city;
+    char *dstasn;
+    char *dstas_org;
     char *srcport;
     char *dstport;
     char *protocol;

--- a/src/analysisd/format/to_json.c
+++ b/src/analysisd/format/to_json.c
@@ -90,8 +90,25 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
     }
 
 #ifdef LIBGEOIP_ENABLED
-    if (lf->srcgeoip && Config.geoip_jsonout) {
-        cJSON_AddStringToObject(root, "srcgeoip", lf->srcgeoip);
+    if (Config.geoip_jsonout) {
+        if (lf->srcgeoip) {
+            cJSON_AddStringToObject(root, "srcgeoip", lf->srcgeoip);
+        }
+        if (lf->src_country) {
+            cJSON_AddStringToObject(root, "src_country", lf->src_country);
+        }
+        if (lf->src_region) {
+            cJSON_AddStringToObject(root, "src_region", lf->src_region);
+        }
+        if (lf->src_city) {
+            cJSON_AddStringToObject(root, "src_city", lf->src_city);
+        }
+        if (lf->srcasn) {
+            cJSON_AddStringToObject(root, "srcasn", lf->srcasn);
+        }
+        if (lf->srcas_org) {
+            cJSON_AddStringToObject(root, "srcas_org", lf->srcas_org);
+        }
     }
 #endif
 
@@ -105,8 +122,25 @@ char *Eventinfo_to_jsonstr(const Eventinfo *lf)
         cJSON_AddStringToObject(root, "dstip", lf->dstip);
     }
 #ifdef LIBGEOIP_ENABLED
-    if (lf->dstgeoip && Config.geoip_jsonout) {
-        cJSON_AddStringToObject(root, "dstgeoip", lf->dstgeoip);
+    if (Config.geoip_jsonout) {
+        if (lf->dstgeoip) {
+            cJSON_AddStringToObject(root, "dstgeoip", lf->dstgeoip);
+        }
+        if (lf->dst_country) {
+            cJSON_AddStringToObject(root, "dst_country", lf->dst_country);
+        }
+        if (lf->dst_region) {
+            cJSON_AddStringToObject(root, "dst_region", lf->dst_region);
+        }
+        if (lf->dst_city) {
+            cJSON_AddStringToObject(root, "dst_city", lf->dst_city);
+        }
+        if (lf->dstasn) {
+            cJSON_AddStringToObject(root, "dstasn", lf->dstasn);
+        }
+        if (lf->dstas_org) {
+            cJSON_AddStringToObject(root, "dstas_org", lf->dstas_org);
+        }
     }
 #endif
 

--- a/src/analysisd/makelists.c
+++ b/src/analysisd/makelists.c
@@ -39,7 +39,8 @@ char __shost[512];
 OSDecoderInfo *NULL_Decoder;
 
 #ifdef LIBGEOIP_ENABLED
-GeoIP *geoipdb;
+MMDB_s geoipdb;
+int geoipdb_ready = 0;
 #endif
 
 /* print help statement */

--- a/src/analysisd/makelists.c
+++ b/src/analysisd/makelists.c
@@ -41,6 +41,8 @@ OSDecoderInfo *NULL_Decoder;
 #ifdef LIBGEOIP_ENABLED
 MMDB_s geoipdb;
 int geoipdb_ready = 0;
+MMDB_s geoipasn;
+int geoipasn_ready = 0;
 #endif
 
 /* print help statement */

--- a/src/analysisd/pipeline.c
+++ b/src/analysisd/pipeline.c
@@ -475,8 +475,38 @@ Eventinfo *analysisd_copy_event_for_log(const Eventinfo *lf)
     if (lf->srcgeoip) {
         os_strdup(lf->srcgeoip, cpy->srcgeoip);
     }
+    if (lf->src_country) {
+        os_strdup(lf->src_country, cpy->src_country);
+    }
+    if (lf->src_region) {
+        os_strdup(lf->src_region, cpy->src_region);
+    }
+    if (lf->src_city) {
+        os_strdup(lf->src_city, cpy->src_city);
+    }
+    if (lf->srcasn) {
+        os_strdup(lf->srcasn, cpy->srcasn);
+    }
+    if (lf->srcas_org) {
+        os_strdup(lf->srcas_org, cpy->srcas_org);
+    }
     if (lf->dstgeoip) {
         os_strdup(lf->dstgeoip, cpy->dstgeoip);
+    }
+    if (lf->dst_country) {
+        os_strdup(lf->dst_country, cpy->dst_country);
+    }
+    if (lf->dst_region) {
+        os_strdup(lf->dst_region, cpy->dst_region);
+    }
+    if (lf->dst_city) {
+        os_strdup(lf->dst_city, cpy->dst_city);
+    }
+    if (lf->dstasn) {
+        os_strdup(lf->dstasn, cpy->dstasn);
+    }
+    if (lf->dstas_org) {
+        os_strdup(lf->dstas_org, cpy->dstas_org);
     }
     if (lf->srcport) {
         os_strdup(lf->srcport, cpy->srcport);

--- a/src/analysisd/rules.c
+++ b/src/analysisd/rules.c
@@ -74,8 +74,12 @@ int Rules_OP_ReadRules(const char *rulefile)
 
     const char *xml_srcip = "srcip";
     const char *xml_srcgeoip = "srcgeoip";
+    const char *xml_src_country = "src_country";
+    const char *xml_srcasn = "srcasn";
     const char *xml_srcport = "srcport";
     const char *xml_srcgeoip_pcre2 = "srcgeoip_pcre2";
+    const char *xml_src_country_pcre2 = "src_country_pcre2";
+    const char *xml_srcasn_pcre2 = "srcasn_pcre2";
     const char *xml_srcport_pcre2 = "srcport_pcre2";
     const char *xml_dstip = "dstip";
     const char *xml_dstgeoip = "dstgeoip";
@@ -348,6 +352,8 @@ int Rules_OP_ReadRules(const char *rulefile)
                 char *srcport = NULL;
                 char *dstport = NULL;
                 char *srcgeoip = NULL;
+                char *src_country = NULL;
+                char *srcasn = NULL;
                 char *dstgeoip = NULL;
 
                 char *status = NULL;
@@ -360,6 +366,8 @@ int Rules_OP_ReadRules(const char *rulefile)
                 char *srcport_pcre2 = NULL;
                 char *dstport_pcre2 = NULL;
                 char *srcgeoip_pcre2 = NULL;
+                char *src_country_pcre2 = NULL;
+                char *srcasn_pcre2 = NULL;
                 char *dstgeoip_pcre2 = NULL;
 
                 char *status_pcre2 = NULL;
@@ -570,6 +578,20 @@ int Rules_OP_ReadRules(const char *rulefile)
 
                         if(!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
+                    } else if (strcasecmp(rule_opt[k]->element, xml_src_country) == 0) {
+                        src_country =
+                            loadmemory(src_country,
+                                       rule_opt[k]->content);
+
+                        if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
+                            config_ruleinfo->alert_opts |= DO_EXTRAINFO;
+                    } else if (strcasecmp(rule_opt[k]->element, xml_srcasn) == 0) {
+                        srcasn =
+                            loadmemory(srcasn,
+                                       rule_opt[k]->content);
+
+                        if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
+                            config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                     } else if(strcasecmp(rule_opt[k]->element,xml_dstgeoip)==0) {
                         dstgeoip =
                             loadmemory(dstgeoip,
@@ -639,6 +661,20 @@ int Rules_OP_ReadRules(const char *rulefile)
                                     rule_opt[k]->content);
 
                         if(!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
+                            config_ruleinfo->alert_opts |= DO_EXTRAINFO;
+                    } else if (strcasecmp(rule_opt[k]->element, xml_src_country_pcre2) == 0) {
+                        src_country_pcre2 =
+                            loadmemory(src_country_pcre2,
+                                       rule_opt[k]->content);
+
+                        if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
+                            config_ruleinfo->alert_opts |= DO_EXTRAINFO;
+                    } else if (strcasecmp(rule_opt[k]->element, xml_srcasn_pcre2) == 0) {
+                        srcasn_pcre2 =
+                            loadmemory(srcasn_pcre2,
+                                       rule_opt[k]->content);
+
+                        if (!(config_ruleinfo->alert_opts & DO_EXTRAINFO))
                             config_ruleinfo->alert_opts |= DO_EXTRAINFO;
                     } else if(strcasecmp(rule_opt[k]->element,xml_dstgeoip_pcre2)==0) {
                         dstgeoip_pcre2 =
@@ -1378,6 +1414,46 @@ int Rules_OP_ReadRules(const char *rulefile)
                     }
                     free(srcgeoip_pcre2);
                     srcgeoip_pcre2 = NULL;
+                }
+
+                if (src_country) {
+                    os_calloc(1, sizeof(OSMatch), config_ruleinfo->src_country);
+                    if (!OSMatch_Compile(src_country, config_ruleinfo->src_country, 0)) {
+                        merror(REGEX_COMPILE, ARGV0, src_country,
+                               config_ruleinfo->src_country->error);
+                        return (-1);
+                    }
+                    free(src_country);
+                    src_country = NULL;
+                } else if (src_country_pcre2) {
+                    os_calloc(1, sizeof(OSPcre2), config_ruleinfo->src_country_pcre2);
+                    if (!OSPcre2_Compile(src_country_pcre2, config_ruleinfo->src_country_pcre2, PCRE2_CASELESS)) {
+                        merror(REGEX_COMPILE, ARGV0, src_country_pcre2,
+                               config_ruleinfo->src_country_pcre2->error);
+                        return (-1);
+                    }
+                    free(src_country_pcre2);
+                    src_country_pcre2 = NULL;
+                }
+
+                if (srcasn) {
+                    os_calloc(1, sizeof(OSMatch), config_ruleinfo->srcasn);
+                    if (!OSMatch_Compile(srcasn, config_ruleinfo->srcasn, 0)) {
+                        merror(REGEX_COMPILE, ARGV0, srcasn,
+                               config_ruleinfo->srcasn->error);
+                        return (-1);
+                    }
+                    free(srcasn);
+                    srcasn = NULL;
+                } else if (srcasn_pcre2) {
+                    os_calloc(1, sizeof(OSPcre2), config_ruleinfo->srcasn_pcre2);
+                    if (!OSPcre2_Compile(srcasn_pcre2, config_ruleinfo->srcasn_pcre2, PCRE2_CASELESS)) {
+                        merror(REGEX_COMPILE, ARGV0, srcasn_pcre2,
+                               config_ruleinfo->srcasn_pcre2->error);
+                        return (-1);
+                    }
+                    free(srcasn_pcre2);
+                    srcasn_pcre2 = NULL;
                 }
 
 

--- a/src/analysisd/rules.h
+++ b/src/analysisd/rules.h
@@ -147,6 +147,8 @@ typedef struct _RuleInfo {
     os_ip **srcip;
     os_ip **dstip;
     OSMatch *srcgeoip;
+    OSMatch *src_country;
+    OSMatch *srcasn;
     OSMatch *dstgeoip;
     OSMatch *srcport;
     OSMatch *dstport;
@@ -161,6 +163,8 @@ typedef struct _RuleInfo {
 
 
     OSPcre2 *srcgeoip_pcre2;
+    OSPcre2 *src_country_pcre2;
+    OSPcre2 *srcasn_pcre2;
     OSPcre2 *dstgeoip_pcre2;
     OSPcre2 *srcport_pcre2;
     OSPcre2 *dstport_pcre2;

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -83,8 +83,7 @@ int main(int argc, char **argv)
     memset(prev_month, '\0', 4);
 
 #ifdef LIBGEOIP_ENABLED
-    extern GeoIP *geoipdb;
-    geoipdb = NULL;
+    geoipdb_ready = 0;
 #endif
 
     while ((c = getopt(argc, argv, "VatvdhU:D:c:q")) != -1) {
@@ -144,12 +143,15 @@ int main(int argc, char **argv)
 #ifdef LIBGEOIP_ENABLED
     Config.geoip_jsonout = getDefine_Int("analysisd", "geoip_jsonout", 0, 1);
 
-    /* Opening GeoIP DB */
-    if(Config.geoipdb_file) {
-        geoipdb = GeoIP_open(Config.geoipdb_file, GEOIP_INDEX_CACHE);
-        if (geoipdb == NULL)
-        {
-            merror("%s: Unable to open GeoIP database from: %s (disabling GeoIP).", ARGV0, Config.geoipdb_file);
+    /* Opening MaxMind MMDB (GeoLite2 Country/City, etc.) */
+    geoipdb_ready = 0;
+    if (Config.geoipdb_file) {
+        int status = MMDB_open(Config.geoipdb_file, MMDB_MODE_MMAP, &geoipdb);
+        if (status != MMDB_SUCCESS) {
+            merror("%s: Unable to open GeoIP database from: %s (%s) (disabling GeoIP).",
+                   ARGV0, Config.geoipdb_file, MMDB_strerror(status));
+        } else {
+            geoipdb_ready = 1;
         }
     }
 #endif

--- a/src/analysisd/testrule.c
+++ b/src/analysisd/testrule.c
@@ -84,6 +84,7 @@ int main(int argc, char **argv)
 
 #ifdef LIBGEOIP_ENABLED
     geoipdb_ready = 0;
+    geoipasn_ready = 0;
 #endif
 
     while ((c = getopt(argc, argv, "VatvdhU:D:c:q")) != -1) {
@@ -143,7 +144,7 @@ int main(int argc, char **argv)
 #ifdef LIBGEOIP_ENABLED
     Config.geoip_jsonout = getDefine_Int("analysisd", "geoip_jsonout", 0, 1);
 
-    /* Opening MaxMind MMDB (GeoLite2 Country/City, etc.) */
+    /* Opening MaxMind City/Country MMDB */
     geoipdb_ready = 0;
     if (Config.geoipdb_file) {
         int status = MMDB_open(Config.geoipdb_file, MMDB_MODE_MMAP, &geoipdb);
@@ -152,6 +153,17 @@ int main(int argc, char **argv)
                    ARGV0, Config.geoipdb_file, MMDB_strerror(status));
         } else {
             geoipdb_ready = 1;
+        }
+    }
+
+    geoipasn_ready = 0;
+    if (Config.geoipasn_file) {
+        int status = MMDB_open(Config.geoipasn_file, MMDB_MODE_MMAP, &geoipasn);
+        if (status != MMDB_SUCCESS) {
+            merror("%s: Unable to open GeoIP ASN database from: %s (%s) (disabling ASN enrichment).",
+                   ARGV0, Config.geoipasn_file, MMDB_strerror(status));
+        } else {
+            geoipasn_ready = 1;
         }
     }
 #endif
@@ -561,8 +573,8 @@ void OS_ReadMSG(char *ut_str)
                     }
                 }
 
-                /* Group list */
-                else if (currently_rule->group_prev_matched) {
+                /* Group list — also when sid_prev_matched is set (not else-if) */
+                if (currently_rule->group_prev_matched) {
                     unsigned int i = 0;
 
                     while (i < currently_rule->group_prev_matched_sz) {

--- a/src/config/global-config.c
+++ b/src/config/global-config.c
@@ -103,6 +103,7 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
     const char *xml_prelude_profile = "prelude_profile";
     const char *xml_prelude_log_level = "prelude_log_level";
     const char *xml_geoipdb_file = "geoipdb";
+    const char *xml_geoipasn_file = "geoipasn";
     const char *xml_zeromq_output = "zeromq_output";
     const char *xml_zeromq_output_uri = "zeromq_uri";
     const char *xml_zeromq_output_server_cert = "zeromq_server_cert";
@@ -231,6 +232,10 @@ int Read_Global(XML_NODE node, void *configp, void *mailp)
             if(Config)
             {
                 Config->geoipdb_file = strdup(node[i]->content);
+            }
+        } else if (strcmp(node[i]->element, xml_geoipasn_file) == 0) {
+            if (Config) {
+                Config->geoipasn_file = strdup(node[i]->content);
             }
         } else if (strcmp(node[i]->element, xml_prelude_profile) == 0) {
             if (Config) {

--- a/src/config/global-config.h
+++ b/src/config/global-config.h
@@ -37,6 +37,8 @@ typedef struct __Config {
 
     /* GeoIP DB */
     char *geoipdb_file;
+    /* Optional GeoLite2-ASN (or compatible) MMDB */
+    char *geoipasn_file;
 
     /* ZEROMQ Export */
     u_int8_t zeromq_output;

--- a/src/util/ossec-regex-convert.c
+++ b/src/util/ossec-regex-convert.c
@@ -34,6 +34,8 @@ const OSConvertionMap conv_map[] = {
     {.old_element = "program_name", .new_element = "program_name_pcre2", .map = OS_CONVERT_MATCH},
     {.old_element = "prematch", .new_element = "prematch_pcre2", .map = OS_CONVERT_REGEX},
     {.old_element = "srcgeoip", .new_element = "srcgeoip_pcre2", .map = OS_CONVERT_MATCH},
+    {.old_element = "src_country", .new_element = "src_country_pcre2", .map = OS_CONVERT_MATCH},
+    {.old_element = "srcasn", .new_element = "srcasn_pcre2", .map = OS_CONVERT_MATCH},
     {.old_element = "dstgeoip", .new_element = "dstgeoip_pcre2", .map = OS_CONVERT_MATCH},
     {.old_element = "srcport", .new_element = "srcport_pcre2", .map = OS_CONVERT_MATCH},
     {.old_element = "dstport", .new_element = "dstport_pcre2", .map = OS_CONVERT_MATCH},


### PR DESCRIPTION
Supersedes #1828: USE_GEOIP now links libmaxminddb, opens a GeoLite2 MMDB via <geoipdb>, and returns heap-allocated country[/subdivision] strings safe for multithreaded analysisd.