### PR TITLE
Decode named client IPs with optional BIND @cookie prefix.

### DIFF
--- a/contrib/ossec-testing/tests/named.ini
+++ b/contrib/ossec-testing/tests/named.ini
@@ -1,11 +1,12 @@
 [Query cache denied]
 log 1 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.3#1036: query (cache) denied
-log 2 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.4#32769: query (cache) denied 
-log 3 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.3#1036: query (cache) denied 
-log 4 fail = Aug 29 15:33:13 ns3 name[464]: client 217.148.39.4#32769: query (cache) denied 
+log 2 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.4#32769: query (cache) denied
+log 3 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.3#1036: query (cache) denied
+log 4 fail = Aug 29 15:33:13 ns3 name[464]: client 217.148.39.4#32769: query (cache) denied
 log 5 pass = Aug 29 15:33:13 ns3 named[464]: client 217.148.39.3#1036: query (cache)
 log 6 pass = Mar 13 01:42:45 net19 named[6147]: client 31.150.218.239#6173 (odcdavcxkvin.games.yuanyou8.com): query (cache) 'odcdavcxkvin.games.yuanyou8.com/A/IN' denied
+log 7 pass = Oct 26 10:32:22 valhalla named[43400]: client @0x7f2b68014d40 173.27.216.50#80 (sl): query (cache) 'sl/ANY/IN' denied
 
-rule = 12108 
+rule = 12108
 alert = 5
-decoder = named 
+decoder = named

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -999,6 +999,8 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   - Examples:
   -  valhalla named[7885]: client 192.168.1.231#1142: update 'hayaletgemi.edu/IN' denied
   - named[12637]: client 1.2.3.4#32769: query (cache) 'somedomain.com/MX/IN' denied
+  - Oct 26 00:00:53 valhalla named[43400]: client @0x7f2b78046e40 76.188.251.143#80 (sl): query (cache) 'sl/ANY/IN' denied
+  - Nov 25 13:27:03 tiny named[478]: client @0xb464d6a2d0 127.0.0.1#25298 (www.slashdot.org): query: www.slashdot.org IN A + (127.0.0.1)
   -  Oct 22 10:12:33 junction named[31687]: /etc/blocked.slave:9892: syntax error near ';'
   -  Oct 22 10:12:33 junction named[31687]: reloading configuration failed: unexpected token
  -->
@@ -1009,7 +1011,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="named-query">
   <parent>named</parent>
   <prematch_pcre2>: query:? </prematch_pcre2>
-  <pcre2>client @\S+ (\S+)#\d+[ ]*?\S*: </pcre2>
+  <pcre2>client (?:@\S+ )?(\S+)#\d+[ ]*?\S*: </pcre2>
   <order>srcip,url</order>
 </decoder>
 
@@ -1022,7 +1024,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="named_client">
   <parent>named</parent>
   <prematch_pcre2>^client </prematch_pcre2>
-  <pcre2 offset="after_prematch">^(\S+)#</pcre2>
+  <pcre2 offset="after_prematch">^(?:@\S+ )?(\S+)#</pcre2>
   <order>srcip</order>
 </decoder>
 


### PR DESCRIPTION
Support both classic and modern query formats so srcip is extracted for Ubuntu-style logs (#1927). Complements PR #1936 by also matching pre-cookie clients.