### PR TITLE
Stop rule 533 false positives from netstat Recv-Q churn.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
+- @atomicturtle - Strip Recv-Q/Send-Q from default netstat listen check to stop rule 533 false positives (#495, #2063)
 - @reyjrar / @atomicturtle - [PR 235](https://github.com/ossec/ossec-hids/pull/235) - Canonicalize Windows FIM paths so realtime and scheduled scans use the same slash form
 - @lazyp / @atomicturtle - [PR 564](https://github.com/ossec/ossec-hids/pull/564) - Skip leading XML declarations (and UTF-8 BOM) in OS_ReadXML
 - @AdUser / @atomicturtle - [PR 2105](https://github.com/ossec/ossec-hids/pull/2105) - Insert SQL NULL for missing alert src_ip/dst_ip in os_dbd (not the string 'NULL')

--- a/etc/rules/ossec_rules.xml
+++ b/etc/rules/ossec_rules.xml
@@ -149,6 +149,11 @@
     <description>Ignoring external medias.</description> 
   </rule>
 
+  <!-- Default install command strips Recv-Q/Send-Q via awk (see install.sh).
+       Existing configs still using raw netstat output will false-positive on
+       queue churn; update the localfile command to:
+       netstat -tan |grep LISTEN |egrep -v '(127.0.0.1| ::1)' | awk '{print $1,$4,$5,$6}' | sort
+  -->
   <rule id="533" level="7">
     <if_sid>530</if_sid>
     <pcre2>ossec: output: 'netstat -tan</pcre2>

--- a/install.sh
+++ b/install.sh
@@ -348,7 +348,8 @@ SetupLogs()
       echo "" >> $NEWCONFIG
       echo "  <localfile>" >> $NEWCONFIG
       echo "    <log_format>full_command</log_format>" >> $NEWCONFIG
-      echo "    <command>netstat -tan |grep LISTEN |egrep -v '(127.0.0.1| ::1)' | sort</command>" >> $NEWCONFIG
+      # Print proto/local/foreign/state only — Recv-Q/Send-Q churn causes rule 533 FPs (#495/#2063)
+      echo "    <command>netstat -tan |grep LISTEN |egrep -v '(127.0.0.1| ::1)' | awk '{print \$1,\$4,\$5,\$6}' | sort</command>" >> $NEWCONFIG
       echo "  </localfile>" >> $NEWCONFIG
       echo "" >> $NEWCONFIG
       echo "  <localfile>" >> $NEWCONFIG


### PR DESCRIPTION
Default listen check now keeps only proto/addresses/state so queue counters no longer trip check_diff (#495, #2063). Existing installs should update the localfile command the same way.