### PR TITLE
Use one To: and one Cc: for multi-recipient maild alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
+- @atomicturtle - Emit a single To: plus one comma-separated Cc: for granular/extra recipients so ISPs stop rejecting duplicate To headers (#1901)
 - @atomicturtle - Strip Recv-Q/Send-Q from default netstat listen check to stop rule 533 false positives (#495, #2063)
 - @reyjrar / @atomicturtle - [PR 235](https://github.com/ossec/ossec-hids/pull/235) - Canonicalize Windows FIM paths so realtime and scheduled scans use the same slash form
 - @lazyp / @atomicturtle - [PR 564](https://github.com/ossec/ossec-hids/pull/564) - Skip leading XML declarations (and UTF-8 BOM) in OS_ReadXML

--- a/src/os_maild/curlmail.c
+++ b/src/os_maild/curlmail.c
@@ -446,6 +446,7 @@ static int send_one_mail(CURL *curl, MailConfig *mail, struct tm *p,
                 for (i = 1; mail->to[i] != NULL; ++i) {
                     char sanitized_cc[HEADER_MAX];
                     size_t addr_len;
+                    size_t need;
 
                     mail_sanitize_header_value(mail->to[i], sanitized_cc, sizeof(sanitized_cc));
                     addr_len = strlen(sanitized_cc);
@@ -454,16 +455,17 @@ static int send_one_mail(CURL *curl, MailConfig *mail, struct tm *p,
                         continue;
                     }
 
-                    if (cc_len > 0) {
-                        if (cc_len + 2 >= sizeof(cc_value)) {
-                            break;
-                        }
-                        cc_value[cc_len++] = ',';
-                        cc_value[cc_len++] = ' ';
+                    need = addr_len + (cc_len > 0 ? 2 : 0);
+                    if (cc_len + need >= sizeof(cc_value) ||
+                        cc_len + need > MAIL_CC_VALUE_MAX) {
+                        merror("%s: Cc header buffer full; refusing truncated recipient set.",
+                               ARGV0);
+                        goto done;
                     }
 
-                    if (cc_len + addr_len >= sizeof(cc_value)) {
-                        break;
+                    if (cc_len > 0) {
+                        cc_value[cc_len++] = ',';
+                        cc_value[cc_len++] = ' ';
                     }
 
                     memcpy(cc_value + cc_len, sanitized_cc, addr_len);
@@ -476,6 +478,7 @@ static int send_one_mail(CURL *curl, MailConfig *mail, struct tm *p,
                 for (i = 0; mail->gran_to[i] != NULL; ++i) {
                     char sanitized_cc[HEADER_MAX];
                     size_t addr_len;
+                    size_t need;
 
                     if (mail_gran_format(mail, gran_override, i) != FULL_FORMAT) {
                         continue;
@@ -488,16 +491,17 @@ static int send_one_mail(CURL *curl, MailConfig *mail, struct tm *p,
                         continue;
                     }
 
-                    if (cc_len > 0) {
-                        if (cc_len + 2 >= sizeof(cc_value)) {
-                            break;
-                        }
-                        cc_value[cc_len++] = ',';
-                        cc_value[cc_len++] = ' ';
+                    need = addr_len + (cc_len > 0 ? 2 : 0);
+                    if (cc_len + need >= sizeof(cc_value) ||
+                        cc_len + need > MAIL_CC_VALUE_MAX) {
+                        merror("%s: Cc header buffer full; refusing truncated recipient set.",
+                               ARGV0);
+                        goto done;
                     }
 
-                    if (cc_len + addr_len >= sizeof(cc_value)) {
-                        break;
+                    if (cc_len > 0) {
+                        cc_value[cc_len++] = ',';
+                        cc_value[cc_len++] = ' ';
                     }
 
                     memcpy(cc_value + cc_len, sanitized_cc, addr_len);
@@ -509,10 +513,10 @@ static int send_one_mail(CURL *curl, MailConfig *mail, struct tm *p,
             if (cc_len > 0) {
                 n = snprintf(cc_header_line, sizeof(cc_header_line),
                              "Cc: %s\r\n", cc_value);
-                if (n < 0 || (size_t)n >= sizeof(cc_header_line)) {
-                    merror("%s: Cc header truncated; omitting Cc recipients.",
-                           ARGV0);
-                    cc_header_line[0] = '\0';
+                if (n < 0 || (size_t)n >= sizeof(cc_header_line) ||
+                    n > MAIL_HEADER_LINE_MAX + 2) {
+                    merror("%s: Cc header truncated; refusing send.", ARGV0);
+                    goto done;
                 }
             }
         }

--- a/src/os_maild/curlmail.c
+++ b/src/os_maild/curlmail.c
@@ -435,40 +435,75 @@ static int send_one_mail(CURL *curl, MailConfig *mail, struct tm *p,
         cc_header_line[0] = '\0';
         replyto_header_line[0] = '\0';
 
-        /* Build CC header from additional recipients (mail->to[1..]). */
-        if (mail_has_cc_recipients(mail->to, sms_only)) {
+        /* Build one Cc: from additional global recipients and granular FULL_FORMAT. */
+        if (!sms_only) {
             char cc_value[HEADER_MAX];
             size_t cc_len = 0;
 
             cc_value[0] = '\0';
 
-            for (i = 1; mail->to[i] != NULL; ++i) {
-                char sanitized_cc[HEADER_MAX];
-                size_t addr_len;
+            if (mail_has_cc_recipients(mail->to, 0)) {
+                for (i = 1; mail->to[i] != NULL; ++i) {
+                    char sanitized_cc[HEADER_MAX];
+                    size_t addr_len;
 
-                mail_sanitize_header_value(mail->to[i], sanitized_cc, sizeof(sanitized_cc));
-                addr_len = strlen(sanitized_cc);
+                    mail_sanitize_header_value(mail->to[i], sanitized_cc, sizeof(sanitized_cc));
+                    addr_len = strlen(sanitized_cc);
 
-                if (addr_len == 0) {
-                    continue;
-                }
+                    if (addr_len == 0) {
+                        continue;
+                    }
 
-                /* Add comma+space between multiple CC addresses. */
-                if (cc_len > 0) {
-                    if (cc_len + 2 >= sizeof(cc_value)) {
+                    if (cc_len > 0) {
+                        if (cc_len + 2 >= sizeof(cc_value)) {
+                            break;
+                        }
+                        cc_value[cc_len++] = ',';
+                        cc_value[cc_len++] = ' ';
+                    }
+
+                    if (cc_len + addr_len >= sizeof(cc_value)) {
                         break;
                     }
-                    cc_value[cc_len++] = ',';
-                    cc_value[cc_len++] = ' ';
-                }
 
-                if (cc_len + addr_len >= sizeof(cc_value)) {
-                    break;
+                    memcpy(cc_value + cc_len, sanitized_cc, addr_len);
+                    cc_len += addr_len;
+                    cc_value[cc_len] = '\0';
                 }
+            }
 
-                memcpy(cc_value + cc_len, sanitized_cc, addr_len);
-                cc_len += addr_len;
-                cc_value[cc_len] = '\0';
+            if (mail->gran_to) {
+                for (i = 0; mail->gran_to[i] != NULL; ++i) {
+                    char sanitized_cc[HEADER_MAX];
+                    size_t addr_len;
+
+                    if (mail_gran_format(mail, gran_override, i) != FULL_FORMAT) {
+                        continue;
+                    }
+
+                    mail_sanitize_header_value(mail->gran_to[i], sanitized_cc,
+                                               sizeof(sanitized_cc));
+                    addr_len = strlen(sanitized_cc);
+                    if (addr_len == 0) {
+                        continue;
+                    }
+
+                    if (cc_len > 0) {
+                        if (cc_len + 2 >= sizeof(cc_value)) {
+                            break;
+                        }
+                        cc_value[cc_len++] = ',';
+                        cc_value[cc_len++] = ' ';
+                    }
+
+                    if (cc_len + addr_len >= sizeof(cc_value)) {
+                        break;
+                    }
+
+                    memcpy(cc_value + cc_len, sanitized_cc, addr_len);
+                    cc_len += addr_len;
+                    cc_value[cc_len] = '\0';
+                }
             }
 
             if (cc_len > 0) {

--- a/src/os_maild/curlmail.c
+++ b/src/os_maild/curlmail.c
@@ -507,8 +507,13 @@ static int send_one_mail(CURL *curl, MailConfig *mail, struct tm *p,
             }
 
             if (cc_len > 0) {
-                (void)snprintf(cc_header_line, sizeof(cc_header_line),
-                               "Cc: %s\r\n", cc_value);
+                n = snprintf(cc_header_line, sizeof(cc_header_line),
+                             "Cc: %s\r\n", cc_value);
+                if (n < 0 || (size_t)n >= sizeof(cc_header_line)) {
+                    merror("%s: Cc header truncated; omitting Cc recipients.",
+                           ARGV0);
+                    cc_header_line[0] = '\0';
+                }
             }
         }
 

--- a/src/os_maild/mail_utils.c
+++ b/src/os_maild/mail_utils.c
@@ -47,7 +47,7 @@ int mail_append_header_line(char *buf, size_t cap, const char *line)
 {
     size_t used;
     size_t room;
-    int n;
+    size_t line_len;
 
     if (!buf || cap == 0 || !line) {
         return (-1);
@@ -58,13 +58,14 @@ int mail_append_header_line(char *buf, size_t cap, const char *line)
         return (-1);
     }
 
+    line_len = strlen(line);
     room = cap - used - 1;
-    n = snprintf(buf + used, room + 1, "%s", line);
-    if (n < 0 || (size_t)n > room) {
-        buf[cap - 1] = '\0';
+    if (line_len > room) {
+        /* Do not partially write; leave existing contents intact. */
         return (-1);
     }
 
+    memcpy(buf + used, line, line_len + 1);
     return (0);
 }
 
@@ -82,7 +83,8 @@ int mail_append_address(char *buf, size_t cap, const char *addr)
     char piece[320];
     int n;
 
-    if (!buf || cap == 0 || !addr || addr[0] == '\0') {
+    if (!buf || cap == 0 || !addr || addr[0] == '\0' ||
+        mail_address_has_crlf(addr)) {
         return (-1);
     }
 

--- a/src/os_maild/mail_utils.c
+++ b/src/os_maild/mail_utils.c
@@ -77,6 +77,28 @@ int mail_has_cc_recipients(char **to, int sms_only)
     return (to[1] != NULL);
 }
 
+int mail_append_address(char *buf, size_t cap, const char *addr)
+{
+    char piece[320];
+    int n;
+
+    if (!buf || cap == 0 || !addr || addr[0] == '\0') {
+        return (-1);
+    }
+
+    if (buf[0] != '\0') {
+        n = snprintf(piece, sizeof(piece), ", <%s>", addr);
+    } else {
+        n = snprintf(piece, sizeof(piece), "<%s>", addr);
+    }
+
+    if (n < 0 || (size_t)n >= sizeof(piece)) {
+        return (-1);
+    }
+
+    return mail_append_header_line(buf, cap, piece);
+}
+
 int mail_safe_envelope_value(const char *src, char *dst, size_t dst_size)
 {
     if (!dst || dst_size == 0) {

--- a/src/os_maild/mail_utils.h
+++ b/src/os_maild/mail_utils.h
@@ -24,6 +24,9 @@ int mail_append_header_line(char *buf, size_t cap, const char *line);
 /* True when additional email_to CC recipients exist (not for SMS-only sends). */
 int mail_has_cc_recipients(char **to, int sms_only);
 
+/* Append "<addr>" or ", <addr>" to a comma-separated address list. */
+int mail_append_address(char *buf, size_t cap, const char *addr);
+
 /* Copy envelope field into dst; returns 0 on success, -1 if CRLF or empty. */
 int mail_safe_envelope_value(const char *src, char *dst, size_t dst_size);
 

--- a/src/os_maild/mail_utils.h
+++ b/src/os_maild/mail_utils.h
@@ -12,6 +12,11 @@
 
 #include <stddef.h>
 
+/* RFC 5322: header lines must be at most 998 octets excluding CRLF. */
+#define MAIL_HEADER_LINE_MAX 998
+#define MAIL_CC_PREFIX_LEN   4 /* "Cc: " */
+#define MAIL_CC_VALUE_MAX    (MAIL_HEADER_LINE_MAX - MAIL_CC_PREFIX_LEN)
+
 /* True if address contains CR or LF (SMTP command injection risk). */
 int mail_address_has_crlf(const char *addr);
 

--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -54,8 +54,44 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     char *msg;
     char snd_msg[128];
     char buffer[2049];
+    char cc_addrs[MAIL_CC_VALUE_MAX + 1];
+    char cc_hdr[MAIL_HEADER_LINE_MAX + 3];
+    char safe_addr[256];
 
     buffer[2048] = '\0';
+    cc_addrs[0] = '\0';
+
+    if (!to || !to[0] || !smtpserver || !from) {
+        return (OS_INVALID);
+    }
+
+    /* Finalize Cc before any RCPT TO (envelope/header must match). */
+    if (to[1]) {
+        i = 1;
+        while (to[i] != NULL) {
+            if (mail_address_has_crlf(to[i])) {
+                merror("%s: Skipping recipient with CR/LF in address (SMTP injection risk).",
+                       ARGV0);
+                i++;
+                continue;
+            }
+
+            mail_sanitize_header_value(to[i], safe_addr, sizeof(safe_addr));
+            if (safe_addr[0] == '\0') {
+                i++;
+                continue;
+            }
+
+            if (mail_append_address(cc_addrs, sizeof(cc_addrs), safe_addr) != 0) {
+                merror("%s: Cc header buffer full; refusing truncated recipient set.",
+                       ARGV0);
+                return (OS_INVALID);
+            }
+            i++;
+        }
+    }
+
+    i = 0;
 
     if (smtpserver[0] == '/') {
         sendmail = popen(smtpserver, "w");
@@ -135,8 +171,12 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
         MAIL_DEBUG("DEBUG: Sent '%s', received: '%s'", snd_msg, msg);
         free(msg);
 
-        /* Build "RCPT TO" msg */
+        /* Build "RCPT TO" msg — skip CR/LF addresses already excluded from Cc. */
         while (to[i]) {
+            if (mail_address_has_crlf(to[i])) {
+                i++;
+                continue;
+            }
             memset(snd_msg, '\0', 128);
             snprintf(snd_msg, 127, RCPTTO, to[i]);
             OS_SendTCP(socket, snd_msg);
@@ -199,45 +239,21 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
         }
     }
 
-    /* Add one Cc: header for remaining recipients (RFC 5322; no duplicate To:). */
-    if (to[1]) {
-        char cc_addrs[2048];
-        char cc_hdr[2200];
-        char safe_addr[256];
-
-        cc_addrs[0] = '\0';
-        i = 1;
-        while (to[i] != NULL) {
-            if (mail_address_has_crlf(to[i])) {
-                merror("%s: Skipping recipient with CR/LF in address (SMTP injection risk).",
-                       ARGV0);
-                i++;
-                continue;
+    /* Emit the Cc: set finalized before RCPT TO. */
+    if (cc_addrs[0] != '\0') {
+        int n = snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
+        if (n < 0 || (size_t)n >= sizeof(cc_hdr) || n > MAIL_HEADER_LINE_MAX + 2) {
+            merror("%s: Cc header truncated; refusing send.", ARGV0);
+            if (sendmail) {
+                pclose(sendmail);
+            } else if (socket >= 0) {
+                close(socket);
             }
-
-            mail_sanitize_header_value(to[i], safe_addr, sizeof(safe_addr));
-            if (safe_addr[0] == '\0') {
-                i++;
-                continue;
-            }
-
-            if (mail_append_address(cc_addrs, sizeof(cc_addrs), safe_addr) != 0) {
-                merror("%s: Cc header buffer full; remaining recipients omitted.",
-                       ARGV0);
-                break;
-            }
-            i++;
-        }
-
-        if (cc_addrs[0] != '\0') {
-            int n = snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
-            if (n < 0 || (size_t)n >= sizeof(cc_hdr)) {
-                merror("%s: Cc header truncated; omitting Cc recipients.", ARGV0);
-            } else if (sendmail) {
-                fprintf(sendmail, "%s", cc_hdr);
-            } else {
-                OS_SendTCP(socket, cc_hdr);
-            }
+            return (OS_INVALID);
+        } else if (sendmail) {
+            fprintf(sendmail, "%s", cc_hdr);
+        } else {
+            OS_SendTCP(socket, cc_hdr);
         }
     }
 

--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -11,6 +11,7 @@
 
 #include "shared.h"
 #include "os_net/os_net.h"
+#include "mail_utils.h"
 
 /* Return codes (from SMTP server) */
 #define VALIDBANNER     "220"
@@ -202,30 +203,37 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
     if (to[1]) {
         char cc_addrs[2048];
         char cc_hdr[2200];
+        char safe_addr[256];
 
         cc_addrs[0] = '\0';
         i = 1;
         while (to[i] != NULL) {
-            char piece[320];
-            int n;
-
-            if (cc_addrs[0] != '\0') {
-                n = snprintf(piece, sizeof(piece), ", <%s>", to[i]);
-            } else {
-                n = snprintf(piece, sizeof(piece), "<%s>", to[i]);
+            if (mail_address_has_crlf(to[i])) {
+                merror("%s: Skipping recipient with CR/LF in address (SMTP injection risk).",
+                       ARGV0);
+                i++;
+                continue;
             }
-            if (n > 0 && (size_t)n < sizeof(piece)) {
-                size_t used = strlen(cc_addrs);
-                if (used + strlen(piece) + 1 < sizeof(cc_addrs)) {
-                    memcpy(cc_addrs + used, piece, strlen(piece) + 1);
-                }
+
+            mail_sanitize_header_value(to[i], safe_addr, sizeof(safe_addr));
+            if (safe_addr[0] == '\0') {
+                i++;
+                continue;
+            }
+
+            if (mail_append_address(cc_addrs, sizeof(cc_addrs), safe_addr) != 0) {
+                merror("%s: Cc header buffer full; remaining recipients omitted.",
+                       ARGV0);
+                break;
             }
             i++;
         }
 
         if (cc_addrs[0] != '\0') {
-            snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
-            if (sendmail) {
+            int n = snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
+            if (n < 0 || (size_t)n >= sizeof(cc_hdr)) {
+                merror("%s: Cc header truncated; omitting Cc recipients.", ARGV0);
+            } else if (sendmail) {
                 fprintf(sendmail, "%s", cc_hdr);
             } else {
                 OS_SendTCP(socket, cc_hdr);

--- a/src/os_maild/sendcustomemail.c
+++ b/src/os_maild/sendcustomemail.c
@@ -198,24 +198,38 @@ int OS_SendCustomEmail(char **to, char *subject, char *smtpserver, char *from, c
         }
     }
 
-    /* Add CCs */
+    /* Add one Cc: header for remaining recipients (RFC 5322; no duplicate To:). */
     if (to[1]) {
+        char cc_addrs[2048];
+        char cc_hdr[2200];
+
+        cc_addrs[0] = '\0';
         i = 1;
-        while (1) {
-            if (to[i] == NULL) {
-                break;
-            }
+        while (to[i] != NULL) {
+            char piece[320];
+            int n;
 
-            memset(snd_msg, '\0', 128);
-            snprintf(snd_msg, 127, TO, to[i]);
-
-            if (sendmail) {
-                fprintf(sendmail, "%s", snd_msg);
+            if (cc_addrs[0] != '\0') {
+                n = snprintf(piece, sizeof(piece), ", <%s>", to[i]);
             } else {
-                OS_SendTCP(socket, snd_msg);
+                n = snprintf(piece, sizeof(piece), "<%s>", to[i]);
             }
-
+            if (n > 0 && (size_t)n < sizeof(piece)) {
+                size_t used = strlen(cc_addrs);
+                if (used + strlen(piece) + 1 < sizeof(cc_addrs)) {
+                    memcpy(cc_addrs + used, piece, strlen(piece) + 1);
+                }
+            }
             i++;
+        }
+
+        if (cc_addrs[0] != '\0') {
+            snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
+            if (sendmail) {
+                fprintf(sendmail, "%s", cc_hdr);
+            } else {
+                OS_SendTCP(socket, cc_hdr);
+            }
         }
     }
 

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -128,8 +128,8 @@ static int sms_build_to_headers(MailConfig *mail, const int *gran_override,
                                 char *final_to, size_t final_to_cap,
                                 int *crlf_warned)
 {
-    char snd_msg[128];
     char safe_addr[256];
+    char addr_list[480];
     int i;
 
     if (!mail->gran_to) {
@@ -137,6 +137,7 @@ static int sms_build_to_headers(MailConfig *mail, const int *gran_override,
     }
 
     final_to[0] = '\0';
+    addr_list[0] = '\0';
 
     i = 0;
     while (mail->gran_to[i] != NULL) {
@@ -150,10 +151,13 @@ static int sms_build_to_headers(MailConfig *mail, const int *gran_override,
             continue;
         }
 
-        memset(snd_msg, '\0', 128);
         mail_safe_header_addr(mail->gran_to[i], safe_addr, sizeof(safe_addr));
-        snprintf(snd_msg, 127, TO, safe_addr);
-        if (mail_append_header_line(final_to, final_to_cap, snd_msg) != 0) {
+        if (safe_addr[0] == '\0') {
+            i++;
+            continue;
+        }
+
+        if (mail_append_address(addr_list, sizeof(addr_list), safe_addr) != 0) {
             merror("%s: SMS To header buffer full; remaining recipients omitted.",
                    ARGV0);
             break;
@@ -162,7 +166,17 @@ static int sms_build_to_headers(MailConfig *mail, const int *gran_override,
         i++;
     }
 
-    return (final_to[0] != '\0');
+    if (addr_list[0] == '\0') {
+        return (0);
+    }
+
+    /* One To: header with comma-separated addresses (RFC 5322). */
+    if (snprintf(final_to, final_to_cap, "To: %s\r\n", addr_list) < 0 ||
+        final_to[0] == '\0') {
+        return (0);
+    }
+
+    return (1);
 }
 
 int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg,
@@ -299,20 +313,12 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg,
                 }
                 free(msg);
 
-                memset(snd_msg, '\0', 128);
-                mail_safe_header_addr(mail->gran_to[i], safe_addr, sizeof(safe_addr));
-                snprintf(snd_msg, 127, TO, safe_addr);
-                if (mail_append_header_line(final_to, sizeof(final_to), snd_msg) != 0) {
-                    merror("%s: SMS To header buffer full; remaining recipients omitted.",
-                           ARGV0);
-                    break;
-                }
-
                 i++;
             }
         }
 
-        if (final_to[0] == '\0') {
+        if (!sms_build_to_headers(mail, gran_override, final_to, sizeof(final_to),
+                                  &crlf_warned)) {
             close(socket);
             return (OS_INVALID);
         }
@@ -676,59 +682,64 @@ int OS_Sendmail(MailConfig *mail, struct tm *p, MailNode *batch,
         }
     }
 
-    /* Add CCs */
-    if (mail_has_cc_recipients(mail->to, 0)) {
-        i = 1;
-        while (1) {
-            if (mail->to[i] == NULL) {
-                break;
-            }
+    /* Add one Cc: header for extra global + granular recipients (RFC 5322).
+     * Multiple To: fields cause rejects (Gmail 550 duplicate To, etc.). */
+    {
+        char cc_addrs[2048];
+        char cc_hdr[2200];
 
-            if (mail_skip_unsafe_recipient(mail->to[i], &crlf_warned)) {
+        cc_addrs[0] = '\0';
+
+        if (mail_has_cc_recipients(mail->to, 0)) {
+            i = 1;
+            while (mail->to[i] != NULL) {
+                if (mail_skip_unsafe_recipient(mail->to[i], &crlf_warned)) {
+                    i++;
+                    continue;
+                }
+
+                mail_safe_header_addr(mail->to[i], safe_addr, sizeof(safe_addr));
+                if (safe_addr[0] != '\0' &&
+                    mail_append_address(cc_addrs, sizeof(cc_addrs), safe_addr) != 0) {
+                    merror("%s: Cc header buffer full; remaining recipients omitted.",
+                           ARGV0);
+                    break;
+                }
                 i++;
-                continue;
             }
-
-            memset(snd_msg, '\0', 128);
-            mail_safe_header_addr(mail->to[i], safe_addr, sizeof(safe_addr));
-            snprintf(snd_msg, 127, TO, safe_addr);
-
-            if (sendmail) {
-                fprintf(sendmail, "%s", snd_msg);
-            } else {
-                OS_SendTCP(socket, snd_msg);
-            }
-
-            i++;
         }
-    }
 
-    /* More CCs - from granular options */
-    if (mail->gran_to) {
-        i = 0;
-        while (mail->gran_to[i] != NULL) {
-            if (mail_gran_format(mail, gran_override, i) != FULL_FORMAT) {
+        if (mail->gran_to) {
+            i = 0;
+            while (mail->gran_to[i] != NULL) {
+                if (mail_gran_format(mail, gran_override, i) != FULL_FORMAT) {
+                    i++;
+                    continue;
+                }
+
+                if (mail_skip_unsafe_recipient(mail->gran_to[i], &crlf_warned)) {
+                    i++;
+                    continue;
+                }
+
+                mail_safe_header_addr(mail->gran_to[i], safe_addr, sizeof(safe_addr));
+                if (safe_addr[0] != '\0' &&
+                    mail_append_address(cc_addrs, sizeof(cc_addrs), safe_addr) != 0) {
+                    merror("%s: Cc header buffer full; remaining recipients omitted.",
+                           ARGV0);
+                    break;
+                }
                 i++;
-                continue;
             }
+        }
 
-            if (mail_skip_unsafe_recipient(mail->gran_to[i], &crlf_warned)) {
-                i++;
-                continue;
-            }
-
-            memset(snd_msg, '\0', 128);
-            mail_safe_header_addr(mail->gran_to[i], safe_addr, sizeof(safe_addr));
-            snprintf(snd_msg, 127, TO, safe_addr);
-
+        if (cc_addrs[0] != '\0') {
+            snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
             if (sendmail) {
-                fprintf(sendmail, "%s", snd_msg);
+                fprintf(sendmail, "%s", cc_hdr);
             } else {
-                OS_SendTCP(socket, snd_msg);
+                OS_SendTCP(socket, cc_hdr);
             }
-
-            i++;
-            continue;
         }
     }
 

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -171,9 +171,13 @@ static int sms_build_to_headers(MailConfig *mail, const int *gran_override,
     }
 
     /* One To: header with comma-separated addresses (RFC 5322). */
-    if (snprintf(final_to, final_to_cap, "To: %s\r\n", addr_list) < 0 ||
-        final_to[0] == '\0') {
-        return (0);
+    {
+        int n = snprintf(final_to, final_to_cap, "To: %s\r\n", addr_list);
+        if (n < 0 || (size_t)n >= final_to_cap) {
+            merror("%s: SMS To header truncated; recipients omitted.", ARGV0);
+            final_to[0] = '\0';
+            return (0);
+        }
     }
 
     return (1);
@@ -734,8 +738,10 @@ int OS_Sendmail(MailConfig *mail, struct tm *p, MailNode *batch,
         }
 
         if (cc_addrs[0] != '\0') {
-            snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
-            if (sendmail) {
+            int n = snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
+            if (n < 0 || (size_t)n >= sizeof(cc_hdr)) {
+                merror("%s: Cc header truncated; omitting Cc recipients.", ARGV0);
+            } else if (sendmail) {
                 fprintf(sendmail, "%s", cc_hdr);
             } else {
                 OS_SendTCP(socket, cc_hdr);

--- a/src/os_maild/sendmail.c
+++ b/src/os_maild/sendmail.c
@@ -158,9 +158,10 @@ static int sms_build_to_headers(MailConfig *mail, const int *gran_override,
         }
 
         if (mail_append_address(addr_list, sizeof(addr_list), safe_addr) != 0) {
-            merror("%s: SMS To header buffer full; remaining recipients omitted.",
+            merror("%s: SMS To header buffer full; refusing truncated recipient set.",
                    ARGV0);
-            break;
+            final_to[0] = '\0';
+            return (0);
         }
 
         i++;
@@ -288,7 +289,12 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg,
         }
         free(msg);
 
-        final_to[0] = '\0';
+        /* Build the To: set first so RCPT TO cannot include omitted recipients. */
+        if (!sms_build_to_headers(mail, gran_override, final_to, sizeof(final_to),
+                                  &crlf_warned)) {
+            close(socket);
+            return (OS_INVALID);
+        }
 
         if (mail->gran_to) {
             i = 0;
@@ -319,12 +325,6 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg,
 
                 i++;
             }
-        }
-
-        if (!sms_build_to_headers(mail, gran_override, final_to, sizeof(final_to),
-                                  &crlf_warned)) {
-            close(socket);
-            return (OS_INVALID);
         }
 
         OS_SendTCP(socket, DATAMSG);
@@ -432,6 +432,72 @@ int OS_Sendsms(MailConfig *mail, struct tm *p, MailMsg *sms_msg,
     return (0);
 }
 
+static int mail_build_full_cc(MailConfig *mail, const int *gran_override,
+                              char *cc_addrs, size_t cc_cap, int *crlf_warned)
+{
+    char safe_addr[256];
+    unsigned int i;
+
+    if (!cc_addrs || cc_cap == 0) {
+        return (-1);
+    }
+
+    cc_addrs[0] = '\0';
+
+    if (mail_has_cc_recipients(mail->to, 0)) {
+        i = 1;
+        while (mail->to[i] != NULL) {
+            if (mail_skip_unsafe_recipient(mail->to[i], crlf_warned)) {
+                i++;
+                continue;
+            }
+
+            mail_safe_header_addr(mail->to[i], safe_addr, sizeof(safe_addr));
+            if (safe_addr[0] == '\0') {
+                i++;
+                continue;
+            }
+
+            if (mail_append_address(cc_addrs, cc_cap, safe_addr) != 0) {
+                merror("%s: Cc header buffer full; refusing truncated recipient set.",
+                       ARGV0);
+                return (-1);
+            }
+            i++;
+        }
+    }
+
+    if (mail->gran_to) {
+        i = 0;
+        while (mail->gran_to[i] != NULL) {
+            if (mail_gran_format(mail, gran_override, i) != FULL_FORMAT) {
+                i++;
+                continue;
+            }
+
+            if (mail_skip_unsafe_recipient(mail->gran_to[i], crlf_warned)) {
+                i++;
+                continue;
+            }
+
+            mail_safe_header_addr(mail->gran_to[i], safe_addr, sizeof(safe_addr));
+            if (safe_addr[0] == '\0') {
+                i++;
+                continue;
+            }
+
+            if (mail_append_address(cc_addrs, cc_cap, safe_addr) != 0) {
+                merror("%s: Cc header buffer full; refusing truncated recipient set.",
+                       ARGV0);
+                return (-1);
+            }
+            i++;
+        }
+    }
+
+    return (0);
+}
+
 int OS_Sendmail(MailConfig *mail, struct tm *p, MailNode *batch,
                 const int *gran_override, const char *group_subject,
                 unsigned int group_subject_level)
@@ -442,6 +508,8 @@ int OS_Sendmail(MailConfig *mail, struct tm *p, MailNode *batch,
     char *msg;
     char snd_msg[128];
     char safe_addr[256];
+    char cc_addrs[MAIL_CC_VALUE_MAX + 1];
+    char cc_hdr[MAIL_HEADER_LINE_MAX + 3];
     int crlf_warned = 0;
     int valid_rcpt = 0;
 
@@ -459,6 +527,11 @@ int OS_Sendmail(MailConfig *mail, struct tm *p, MailNode *batch,
 
 #define mail_send_fail(code) do { free_mail_batch(batch); return (code); } while (0)
 
+    /* Finalize Cc set before any RCPT TO so envelope and headers stay aligned. */
+    if (mail_build_full_cc(mail, gran_override, cc_addrs, sizeof(cc_addrs),
+                           &crlf_warned) != 0) {
+        mail_send_fail(OS_INVALID);
+    }
     if (mail->smtpserver[0] == '/') {
         sendmail = popen(mail->smtpserver, "w");
         if (!sendmail) {
@@ -686,66 +759,21 @@ int OS_Sendmail(MailConfig *mail, struct tm *p, MailNode *batch,
         }
     }
 
-    /* Add one Cc: header for extra global + granular recipients (RFC 5322).
-     * Multiple To: fields cause rejects (Gmail 550 duplicate To, etc.). */
-    {
-        char cc_addrs[2048];
-        char cc_hdr[2200];
-
-        cc_addrs[0] = '\0';
-
-        if (mail_has_cc_recipients(mail->to, 0)) {
-            i = 1;
-            while (mail->to[i] != NULL) {
-                if (mail_skip_unsafe_recipient(mail->to[i], &crlf_warned)) {
-                    i++;
-                    continue;
-                }
-
-                mail_safe_header_addr(mail->to[i], safe_addr, sizeof(safe_addr));
-                if (safe_addr[0] != '\0' &&
-                    mail_append_address(cc_addrs, sizeof(cc_addrs), safe_addr) != 0) {
-                    merror("%s: Cc header buffer full; remaining recipients omitted.",
-                           ARGV0);
-                    break;
-                }
-                i++;
+    /* Emit the Cc: set finalized before RCPT TO (RFC 5322 single header). */
+    if (cc_addrs[0] != '\0') {
+        int n = snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
+        if (n < 0 || (size_t)n >= sizeof(cc_hdr) || n > MAIL_HEADER_LINE_MAX + 2) {
+            merror("%s: Cc header truncated; refusing send.", ARGV0);
+            if (sendmail) {
+                pclose(sendmail);
+            } else if (socket >= 0) {
+                close(socket);
             }
-        }
-
-        if (mail->gran_to) {
-            i = 0;
-            while (mail->gran_to[i] != NULL) {
-                if (mail_gran_format(mail, gran_override, i) != FULL_FORMAT) {
-                    i++;
-                    continue;
-                }
-
-                if (mail_skip_unsafe_recipient(mail->gran_to[i], &crlf_warned)) {
-                    i++;
-                    continue;
-                }
-
-                mail_safe_header_addr(mail->gran_to[i], safe_addr, sizeof(safe_addr));
-                if (safe_addr[0] != '\0' &&
-                    mail_append_address(cc_addrs, sizeof(cc_addrs), safe_addr) != 0) {
-                    merror("%s: Cc header buffer full; remaining recipients omitted.",
-                           ARGV0);
-                    break;
-                }
-                i++;
-            }
-        }
-
-        if (cc_addrs[0] != '\0') {
-            int n = snprintf(cc_hdr, sizeof(cc_hdr), "Cc: %s\r\n", cc_addrs);
-            if (n < 0 || (size_t)n >= sizeof(cc_hdr)) {
-                merror("%s: Cc header truncated; omitting Cc recipients.", ARGV0);
-            } else if (sendmail) {
-                fprintf(sendmail, "%s", cc_hdr);
-            } else {
-                OS_SendTCP(socket, cc_hdr);
-            }
+            mail_send_fail(OS_INVALID);
+        } else if (sendmail) {
+            fprintf(sendmail, "%s", cc_hdr);
+        } else {
+            OS_SendTCP(socket, cc_hdr);
         }
     }
 

--- a/src/os_maild/tests/mail_utils_test.c
+++ b/src/os_maild/tests/mail_utils_test.c
@@ -99,16 +99,12 @@ static void test_append_address_comma_list(void)
 
 static void test_append_address_bounds(void)
 {
-    char buf[40];
-    char long_addr[64];
-
-    memset(long_addr, 'x', sizeof(long_addr) - 1);
-    long_addr[sizeof(long_addr) - 1] = '\0';
-    memcpy(long_addr + sizeof(long_addr) - 12, "@example.com", 12);
+    char buf[24];
 
     buf[0] = '\0';
     assert(mail_append_address(buf, sizeof(buf), "a@b.co") == 0);
-    assert(mail_append_address(buf, sizeof(buf), long_addr) == -1);
+    /* Second address will not fit in 24 bytes once ", <...>" is added. */
+    assert(mail_append_address(buf, sizeof(buf), "longer@example.com") == -1);
 }
 
 int main(void)

--- a/src/os_maild/tests/mail_utils_test.c
+++ b/src/os_maild/tests/mail_utils_test.c
@@ -84,6 +84,33 @@ static void test_append_header_line_no_underflow(void)
     assert(strlen(buf) < sizeof(buf));
 }
 
+static void test_append_address_comma_list(void)
+{
+    char buf[128];
+
+    buf[0] = '\0';
+    assert(mail_append_address(buf, sizeof(buf), "a@example.com") == 0);
+    assert(strcmp(buf, "<a@example.com>") == 0);
+    assert(mail_append_address(buf, sizeof(buf), "b@example.com") == 0);
+    assert(strcmp(buf, "<a@example.com>, <b@example.com>") == 0);
+    assert(mail_append_address(buf, sizeof(buf), "") == -1);
+    assert(mail_append_address(buf, sizeof(buf), NULL) == -1);
+}
+
+static void test_append_address_bounds(void)
+{
+    char buf[40];
+    char long_addr[64];
+
+    memset(long_addr, 'x', sizeof(long_addr) - 1);
+    long_addr[sizeof(long_addr) - 1] = '\0';
+    memcpy(long_addr + sizeof(long_addr) - 12, "@example.com", 12);
+
+    buf[0] = '\0';
+    assert(mail_append_address(buf, sizeof(buf), "a@b.co") == 0);
+    assert(mail_append_address(buf, sizeof(buf), long_addr) == -1);
+}
+
 int main(void)
 {
     test_cc_guard_sms_only_null_to();
@@ -91,6 +118,8 @@ int main(void)
     test_append_header_line_bounds();
     test_safe_envelope_value();
     test_append_header_line_no_underflow();
+    test_append_address_comma_list();
+    test_append_address_bounds();
 
     printf("mail_utils_test: OK\n");
     return (0);

--- a/src/os_maild/tests/mail_utils_test.c
+++ b/src/os_maild/tests/mail_utils_test.c
@@ -105,6 +105,18 @@ static void test_append_address_bounds(void)
     assert(mail_append_address(buf, sizeof(buf), "a@b.co") == 0);
     /* Second address will not fit in 24 bytes once ", <...>" is added. */
     assert(mail_append_address(buf, sizeof(buf), "longer@example.com") == -1);
+    assert(strcmp(buf, "<a@b.co>") == 0);
+}
+
+static void test_append_address_rejects_crlf(void)
+{
+    char buf[64];
+
+    buf[0] = '\0';
+    assert(mail_append_address(buf, sizeof(buf), "bad\r@ex.com") == -1);
+    assert(buf[0] == '\0');
+    assert(mail_append_address(buf, sizeof(buf), "bad\n@ex.com") == -1);
+    assert(buf[0] == '\0');
 }
 
 int main(void)
@@ -116,6 +128,7 @@ int main(void)
     test_append_header_line_no_underflow();
     test_append_address_comma_list();
     test_append_address_bounds();
+    test_append_address_rejects_crlf();
 
     printf("mail_utils_test: OK\n");
     return (0);


### PR DESCRIPTION
Granular and extra global addresses were each emitted as a separate To header, which Gmail and other ISPs reject as RFC 5322-invalid (#1901).