### PR TITLE
Resolve csyslogd syslog_output hostnames before chroot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
+- @atomicturtle - Resolve csyslogd syslog_output hostnames before chroot so hostname servers no longer crash (#1744)
 - @atomicturtle - Emit a single To: plus one comma-separated Cc: for granular/extra recipients so ISPs stop rejecting duplicate To headers (#1901)
 - @atomicturtle - Strip Recv-Q/Send-Q from default netstat listen check to stop rule 533 false positives (#495, #2063)
 - @reyjrar / @atomicturtle - [PR 235](https://github.com/ossec/ossec-hids/pull/235) - Canonicalize Windows FIM paths so realtime and scheduled scans use the same slash form

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
-- @atomicturtle - Resolve csyslogd syslog_output hostnames before chroot so hostname servers no longer crash (#1744)
+- @atomicturtle - Open csyslogd syslog_output sockets before chroot so hostnames work without losing OS_Connect multi-address fallback (#1744)
 - @atomicturtle - Emit a single To: plus one comma-separated Cc: for granular/extra recipients so ISPs stop rejecting duplicate To headers (#1901)
 - @atomicturtle - Strip Recv-Q/Send-Q from default netstat listen check to stop rule 533 false positives (#495, #2063)
 - @reyjrar / @atomicturtle - [PR 235](https://github.com/ossec/ossec-hids/pull/235) - Canonicalize Windows FIM paths so realtime and scheduled scans use the same slash form

--- a/src/config/csyslogd-config.c
+++ b/src/config/csyslogd-config.c
@@ -48,6 +48,7 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
     syslog_config[s]->port = "514";
     syslog_config[s]->format = DEFAULT_CSYSLOG;
     syslog_config[s]->use_fqdn = 0;
+    syslog_config[s]->socket = -1;
     /* local 0 facility (16) + severity 4 - warning. --default */
     syslog_config[s]->priority = (16 * 8) + 4;
 

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -45,18 +45,7 @@ void OS_CSyslogD(SyslogConfig **syslog_config)
     }
     debug1("%s: INFO: File queue connected.", ARGV0 );
 
-    /* Sockets are opened in main() before chroot so hostname DNS and
-     * OS_Connect() multi-address / IPv4 fallback still work (#1744). */
-    s = 0;
-    while (syslog_config[s]) {
-        if (syslog_config[s]->socket < 0) {
-            merror(CONNS_ERROR, ARGV0, syslog_config[s]->server);
-        } else {
-            merror("%s: INFO: Forwarding alerts via syslog to: '%s:%s'.",
-                   ARGV0, syslog_config[s]->server, syslog_config[s]->port);
-        }
-        s++;
-    }
+    /* UDP sockets were opened in main() before chroot (#1744). */
 
     /* Infinite loop reading the alerts and inserting them */
     while (1) {

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -9,7 +9,6 @@
 
 #include "shared.h"
 #include "csyslogd.h"
-#include "os_net/os_net.h"
 
 /* Global variables */
 char __shost[512];
@@ -46,18 +45,16 @@ void OS_CSyslogD(SyslogConfig **syslog_config)
     }
     debug1("%s: INFO: File queue connected.", ARGV0 );
 
-    /* Connect to syslog */
+    /* Sockets are opened in main() before chroot so hostname DNS and
+     * OS_Connect() multi-address / IPv4 fallback still work (#1744). */
     s = 0;
     while (syslog_config[s]) {
-        syslog_config[s]->socket = OS_ConnectUDP(syslog_config[s]->port,
-                                                 syslog_config[s]->server);
         if (syslog_config[s]->socket < 0) {
             merror(CONNS_ERROR, ARGV0, syslog_config[s]->server);
         } else {
             merror("%s: INFO: Forwarding alerts via syslog to: '%s:%s'.",
                    ARGV0, syslog_config[s]->server, syslog_config[s]->port);
         }
-
         s++;
     }
 

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -129,14 +129,12 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Resolve hostnames to IPs before chroot — DNS is unavailable afterwards
-     * and historically caused crashes when <server> was not a numeric IP (#1744).
-     * Also run under -t so misconfigured hostnames fail config test. */
+    /* Validate syslog_output servers. Hostnames are connected before chroot
+     * below so OS_Connect() keeps multi-address / IPv4 fallback (#1744). */
     if (syslog_config) {
         unsigned int s = 0;
 
         while (syslog_config[s]) {
-            char *resolved;
             int ip_check;
 
             if (!syslog_config[s]->server || syslog_config[s]->server[0] == '\0') {
@@ -145,27 +143,24 @@ int main(int argc, char **argv)
 
             /* OS_IsValidIP: 1 = host IP, 2 = IP/CIDR (not a valid syslog target). */
             ip_check = OS_IsValidIP(syslog_config[s]->server, NULL);
-            if (ip_check == 1) {
-                s++;
-                continue;
-            }
             if (ip_check == 2) {
                 ErrorExit("%s: ERROR: syslog_output server '%s' must be a "
                           "hostname or IP address, not a network/CIDR.",
                           ARGV0, syslog_config[s]->server);
             }
 
-            resolved = OS_GetHost(syslog_config[s]->server, 5);
-            if (!resolved || resolved[0] == '\0') {
-                free(resolved);
-                ErrorExit("%s: ERROR: Unable to resolve syslog_output server "
-                          "hostname '%s'.", ARGV0, syslog_config[s]->server);
+            /* Under -t, probe hostname resolution without collapsing to one IP. */
+            if (test_config && ip_check == 0) {
+                char *probe = OS_GetHost(syslog_config[s]->server, 5);
+
+                if (!probe || probe[0] == '\0') {
+                    free(probe);
+                    ErrorExit("%s: ERROR: Unable to resolve syslog_output server "
+                              "hostname '%s'.", ARGV0, syslog_config[s]->server);
+                }
+                free(probe);
             }
 
-            verbose("%s: INFO: Resolved syslog_output server '%s' to '%s'.",
-                    ARGV0, syslog_config[s]->server, resolved);
-            free(syslog_config[s]->server);
-            syslog_config[s]->server = resolved;
             s++;
         }
     }
@@ -186,6 +181,24 @@ int main(int argc, char **argv)
         verbose("%s: INFO: Remote syslog server not configured. "
                 "Clean exit.", ARGV0);
         exit(0);
+    }
+
+    /* Connect before chroot: DNS works here and OS_ConnectUDP can walk the
+     * full addrinfo list (IPv6 then IPv4 fallback). FDs survive chroot. */
+    {
+        unsigned int s = 0;
+
+        while (syslog_config[s]) {
+            syslog_config[s]->socket = OS_ConnectUDP(syslog_config[s]->port,
+                                                     syslog_config[s]->server);
+            if (syslog_config[s]->socket < 0) {
+                merror(CONNS_ERROR, ARGV0, syslog_config[s]->server);
+            } else {
+                verbose("%s: INFO: Connected syslog_output to '%s:%s'.",
+                        ARGV0, syslog_config[s]->server, syslog_config[s]->port);
+            }
+            s++;
+        }
     }
 
     /* Privilege separation */

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -194,8 +194,9 @@ int main(int argc, char **argv)
             if (syslog_config[s]->socket < 0) {
                 merror(CONNS_ERROR, ARGV0, syslog_config[s]->server);
             } else {
-                verbose("%s: INFO: Connected syslog_output to '%s:%s'.",
-                        ARGV0, syslog_config[s]->server, syslog_config[s]->port);
+                /* Use merror for visibility at default log level (historical). */
+                merror("%s: INFO: Forwarding alerts via syslog to: '%s:%s'.",
+                       ARGV0, syslog_config[s]->server, syslog_config[s]->port);
             }
             s++;
         }

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -137,19 +137,27 @@ int main(int argc, char **argv)
 
         while (syslog_config[s]) {
             char *resolved;
+            int ip_check;
 
-            if (!syslog_config[s]->server) {
+            if (!syslog_config[s]->server || syslog_config[s]->server[0] == '\0') {
+                ErrorExit("%s: ERROR: syslog_output server is empty.", ARGV0);
+            }
+
+            /* OS_IsValidIP: 1 = host IP, 2 = IP/CIDR (not a valid syslog target). */
+            ip_check = OS_IsValidIP(syslog_config[s]->server, NULL);
+            if (ip_check == 1) {
                 s++;
                 continue;
             }
-
-            if (OS_IsValidIP(syslog_config[s]->server, NULL) == 1) {
-                s++;
-                continue;
+            if (ip_check == 2) {
+                ErrorExit("%s: ERROR: syslog_output server '%s' must be a "
+                          "hostname or IP address, not a network/CIDR.",
+                          ARGV0, syslog_config[s]->server);
             }
 
             resolved = OS_GetHost(syslog_config[s]->server, 5);
-            if (!resolved) {
+            if (!resolved || resolved[0] == '\0') {
+                free(resolved);
                 ErrorExit("%s: ERROR: Unable to resolve syslog_output server "
                           "hostname '%s'.", ARGV0, syslog_config[s]->server);
             }

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -8,6 +8,7 @@
  */
 
 #include "csyslogd.h"
+#include "os_net/os_net.h"
 
 /* Prototypes */
 static void help_csyslogd(int status) __attribute__((noreturn));
@@ -125,6 +126,39 @@ int main(int argc, char **argv)
         ltmp = strchr(__shost, '.');
         if (ltmp) {
             *ltmp = '\0';
+        }
+    }
+
+    /* Resolve hostnames to IPs before chroot — DNS is unavailable afterwards
+     * and historically caused crashes when <server> was not a numeric IP (#1744).
+     * Also run under -t so misconfigured hostnames fail config test. */
+    if (syslog_config) {
+        unsigned int s = 0;
+
+        while (syslog_config[s]) {
+            char *resolved;
+
+            if (!syslog_config[s]->server) {
+                s++;
+                continue;
+            }
+
+            if (OS_IsValidIP(syslog_config[s]->server, NULL) == 1) {
+                s++;
+                continue;
+            }
+
+            resolved = OS_GetHost(syslog_config[s]->server, 5);
+            if (!resolved) {
+                ErrorExit("%s: ERROR: Unable to resolve syslog_output server "
+                          "hostname '%s'.", ARGV0, syslog_config[s]->server);
+            }
+
+            verbose("%s: INFO: Resolved syslog_output server '%s' to '%s'.",
+                    ARGV0, syslog_config[s]->server, resolved);
+            free(syslog_config[s]->server);
+            syslog_config[s]->server = resolved;
+            s++;
         }
     }
 


### PR DESCRIPTION
DNS is unavailable after Privsep_Chroot, so hostname <server> values historically crashed or failed to connect (#1744). Resolve with OS_GetHost at startup (and under -t) before dropping privileges.