### PR TITLE
Fix SELinux denials when logrotate touches OSSEC logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
+- @atomicturtle - Label /var/ossec/logs as var_log_t for logrotate and allow logrotate_t on ossec_log_t (#1948)
 - @atomicturtle - Pass CFLAGS/LDFLAGS into bundled ossec-lua/ossec-luac via MYCFLAGS/MYLDFLAGS (#1568)
 - @atomicturtle - Open csyslogd syslog_output sockets before chroot so hostnames work without losing OS_Connect multi-address fallback (#1744)
 - @atomicturtle - Emit a single To: plus one comma-separated Cc: for granular/extra recipients so ISPs stop rejecting duplicate To headers (#1901)

--- a/contrib/selinux/README.md
+++ b/contrib/selinux/README.md
@@ -1,17 +1,68 @@
-## Ossec-agent SELinux module
-SELinux module provides additional security protection for ossec application
+## OSSEC SELinux module
 
-## Installation
-1. Run semodule -i ossec\_agent.pp.bz2 on a running SELinux installation
-2. Run restorecon -R /var/ossec
-3. Restart ossec agent via systemd/init/etc
-4. Check if it get right context ( ps -AZ )
+Optional SELinux policy for confining the OSSEC agent under
+`/var/ossec`. Server/manager confinement is not covered yet (see #1948).
 
-You should do chcon manually if your put ossec installation in different place, see .fc file for details
+### Quick fix for logrotate AVCs (#1948)
 
-## Configuration
-Nothing to configure :)
+If SELinux blocks logrotate on `/var/ossec/logs/*` and you are **not**
+using this module, label the logs like other system logs:
 
-## Bug reports & contribution
-Contact: ivan.agarkov@gmail.com
+```bash
+semanage fcontext -a -t var_log_t '/var/ossec/logs(/.*)?'
+restorecon -Rv /var/ossec/logs
+```
 
+Do **not** use `logrotate_exec_t` / `logrotate_tmp_t` / similar — those
+are for logrotate's own files, not for application logs.
+
+RPM packages apply the `var_log_t` mapping automatically when this
+module is not loaded.
+
+### Installing this module
+
+Requires `checkpolicy`, `policycoreutils`, and `selinux-policy-devel`
+(package names vary by distro). On Fedora/RHEL also install
+`policycoreutils-python-utils` for `semanage`.
+
+```bash
+cd contrib/selinux/ossec_agent
+make
+semodule -i ossec_agent.pp
+# or: semodule -i ../ossec_agent.pp.bz2
+restorecon -Rv /var/ossec
+systemctl restart ossec   # or ossec-hids / ossec-hids-agent
+ps -eZ | grep ossec
+```
+
+If `semodule -i ossec_agent.pp.bz2` fails looking for
+`/usr/libexec/selinux/hll/bz2`, decompress first:
+
+```bash
+bunzip2 -k ossec_agent.pp.bz2
+semodule -i ossec_agent.pp
+```
+
+After the module is installed, logs use `ossec_log_t` (see `.fc`).
+Remove any conflicting local mapping first:
+
+```bash
+semanage fcontext -d '/var/ossec/logs(/.*)?' 2>/dev/null || true
+restorecon -Rv /var/ossec/logs
+```
+
+Custom install prefix: adjust paths in `ossec_agent.fc` and re-run
+`make` / `restorecon`.
+
+### Building
+
+```bash
+cd contrib/selinux/ossec_agent && make
+```
+
+Ship/update the compressed module from the repo root with
+`make -C contrib/selinux/ossec_agent pp-bz2`.
+
+### Bug reports & contribution
+
+Original author: ivan.agarkov@gmail.com

--- a/contrib/selinux/ossec_agent/Makefile
+++ b/contrib/selinux/ossec_agent/Makefile
@@ -1,0 +1,18 @@
+# Build the OSSEC agent SELinux module (requires selinux-policy-devel).
+AWK ?= awk
+NAME = ossec_agent
+SHAREDIR ?= /usr/share/selinux/devel
+
+all: $(NAME).pp
+
+$(NAME).pp: $(NAME).te $(NAME).fc $(NAME).if
+	@$(MAKE) -f $(SHAREDIR)/Makefile $@
+
+pp-bz2: $(NAME).pp
+	bzip2 -c -9 $(NAME).pp > ../$(NAME).pp.bz2
+
+clean:
+	rm -f $(NAME).pp $(NAME).fc.tmp $(NAME).if.tmp $(NAME).te.tmp
+	rm -rf tmp
+
+.PHONY: all pp-bz2 clean

--- a/contrib/selinux/ossec_agent/ossec_agent.te
+++ b/contrib/selinux/ossec_agent/ossec_agent.te
@@ -1,4 +1,4 @@
-policy_module(ossec_agent, 1.0.4)
+policy_module(ossec_agent, 1.0.5)
 # selinux module for OSSEC (tm) agent
 # (C) Ivan Agarkov, 2017
 # exec file types
@@ -98,3 +98,13 @@ optional_policy(`
   domtrans_pattern(staff_t, ossec_admin_exec_t, ossec_admin_t)
 ')
 
+# logrotate must manage OSSEC logs (#1948). logging_log_file() adds the
+# logfile attribute, but some policy builds still need an explicit allow.
+optional_policy(`
+  gen_require(`
+    type logrotate_t;
+  ')
+  manage_dirs_pattern(logrotate_t, ossec_log_t, ossec_log_t)
+  manage_files_pattern(logrotate_t, ossec_log_t, ossec_log_t)
+  manage_lnk_files_pattern(logrotate_t, ossec_log_t, ossec_log_t)
+')

--- a/contrib/specs/ossec-hids.logrotate
+++ b/contrib/specs/ossec-hids.logrotate
@@ -1,8 +1,15 @@
-# Logrotate config for OSSEC HIDS
-/var/ossec/logs/ossec.log {
+# Logrotate config for OSSEC HIDS (#1948)
+# Paths stay under /var/ossec/logs so one SELinux fcontext covers them.
+
+/var/ossec/logs/ossec.log
+/var/ossec/logs/active-responses.log
+/var/ossec/logs/alerts/alerts.log
+/var/ossec/logs/firewall/firewall.log
+{
     missingok
     notifempty
     copytruncate
+    sharedscripts
     rotate 4
     weekly
 }

--- a/ossec-hids.spec
+++ b/ossec-hids.spec
@@ -480,6 +480,13 @@ chmod 0664 %{_localstatedir}/ossec/logs/ossec.log
 if command -v semanage >/dev/null 2>&1; then
     semanage fcontext -a -t bin_t '/var/ossec/bin(/.*)?' >/dev/null 2>&1 || :
     restorecon -Rv /var/ossec/bin >/dev/null 2>&1 || :
+    # Stock logrotate can rotate var_log_t. Skip if contrib ossec_agent
+    # module is loaded (it labels logs as ossec_log_t instead). (#1948)
+    if ! semodule -l 2>/dev/null | grep -q '^ossec_agent'; then
+        semanage fcontext -a -t var_log_t '/var/ossec/logs(/.*)?' >/dev/null 2>&1 || \
+            semanage fcontext -m -t var_log_t '/var/ossec/logs(/.*)?' >/dev/null 2>&1 || :
+        restorecon -Rv /var/ossec/logs >/dev/null 2>&1 || :
+    fi
 fi
 
 
@@ -531,6 +538,13 @@ fi
 if command -v semanage >/dev/null 2>&1; then
     semanage fcontext -a -t bin_t '/var/ossec/bin(/.*)?' >/dev/null 2>&1 || :
     restorecon -Rv /var/ossec/bin >/dev/null 2>&1 || :
+    # Stock logrotate can rotate var_log_t. Skip if contrib ossec_agent
+    # module is loaded (it labels logs as ossec_log_t instead). (#1948)
+    if ! semodule -l 2>/dev/null | grep -q '^ossec_agent'; then
+        semanage fcontext -a -t var_log_t '/var/ossec/logs(/.*)?' >/dev/null 2>&1 || \
+            semanage fcontext -m -t var_log_t '/var/ossec/logs(/.*)?' >/dev/null 2>&1 || :
+        restorecon -Rv /var/ossec/logs >/dev/null 2>&1 || :
+    fi
 fi
 
 
@@ -582,11 +596,21 @@ if [ $1 = 0 ]; then
 fi
 
 
+%postun agent
+# Remove SELinux context rules only if the package is being completely removed
+if [ $1 -eq 0 ]; then
+    if command -v semanage >/dev/null 2>&1; then
+        semanage fcontext -d '/var/ossec/bin(/.*)?' >/dev/null 2>&1 || :
+        semanage fcontext -d '/var/ossec/logs(/.*)?' >/dev/null 2>&1 || :
+    fi
+fi
+
 %postun server
 # Remove the SELinux context rule only if the package is being completely removed
 if [ $1 -eq 0 ]; then
     if command -v semanage >/dev/null 2>&1; then
-        semanage fcontext -d '/var/ossec/bin(/.*)?'
+        semanage fcontext -d '/var/ossec/bin(/.*)?' >/dev/null 2>&1 || :
+        semanage fcontext -d '/var/ossec/logs(/.*)?' >/dev/null 2>&1 || :
     fi
 fi
 


### PR DESCRIPTION
Label /var/ossec/logs as var_log_t from RPM post when the contrib ossec_agent module is not loaded, expand logrotate coverage, and allow logrotate_t to manage ossec_log_t in the optional policy (#1948).