### PR TITLE
Ignore snap and loop df 100% disk alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
+- @atomicturtle - Ignore snap and /dev/loop df 100% alerts under rule 532 (#1418)
 - @atomicturtle - Label /var/ossec/logs as var_log_t for logrotate and allow logrotate_t on ossec_log_t (#1948)
 - @atomicturtle - Pass CFLAGS/LDFLAGS into bundled ossec-lua/ossec-luac via MYCFLAGS/MYLDFLAGS (#1568)
 - @atomicturtle - Open csyslogd syslog_output sockets before chroot so hostnames work without losing OS_Connect multi-address fallback (#1744)

--- a/etc/rules/ossec_rules.xml
+++ b/etc/rules/ossec_rules.xml
@@ -145,8 +145,8 @@
 
  <rule id="532" level="0">
     <if_sid>531</if_sid>
-    <pcre2>cdrom|/media|usb|/mount|floppy|dvd</pcre2>
-    <description>Ignoring external medias.</description> 
+    <pcre2>cdrom|/media|usb|/mount|floppy|dvd|/dev/loop|/snap/</pcre2>
+    <description>Ignoring removable media and snap/loop filesystems.</description>
   </rule>
 
   <!-- Default install command strips Recv-Q/Send-Q via awk (see install.sh).


### PR DESCRIPTION
Rule 532 already silenced removable media under 531; extend it for /dev/loop and /snap mounts that are always full by design (#1418).