### PR TITLE
Stop treating MJ12bot as a malicious user agent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
+- @atomicturtle - Stop treating MJ12bot as a malicious user agent in rule 31508 (#1317)
 - @atomicturtle - Ignore snap and /dev/loop df 100% alerts under rule 532 (#1418)
 - @atomicturtle - Label /var/ossec/logs as var_log_t for logrotate and allow logrotate_t on ossec_log_t (#1948)
 - @atomicturtle - Pass CFLAGS/LDFLAGS into bundled ossec-lua/ossec-luac via MYCFLAGS/MYLDFLAGS (#1568)

--- a/etc/rules/web_appsec_rules.xml
+++ b/etc/rules/web_appsec_rules.xml
@@ -87,7 +87,7 @@
   <!-- BAD/Annoying user agents -->
   <rule id="31508" level="6">
     <if_sid>31100</if_sid>
-    <pcre2> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af\.sourceforge\.net|MJ12bot/v| Jorgee"|"Proxy Gear Pro|"DataCha0s|muhstik</pcre2>
+    <pcre2> "ZmEu"| "libwww-perl/|"the beast"|"Morfeus|"ZmEu|"Nikto|"w3af\.sourceforge\.net| Jorgee"|"Proxy Gear Pro|"DataCha0s|muhstik</pcre2>
     <description>Blacklisted user agent (known malicious user agent).</description>
   </rule>
 


### PR DESCRIPTION
Majestic's crawler respects robots.txt; listing it in rule 31508 caused false positives for legitimate crawl traffic (#1317).