### PR TITLE
Fix FIM false positives from xxx hash placeholders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
+- @atomicturtle - Avoid FIM false positives from xxx hash placeholders and checksum read failures (#1590, #1704)
 - @atomicturtle - Match web-accesslog URLs that contain spaces; do not treat POST as a simple ignored request (#914, #922)
 - @atomicturtle - Require more attack-group context and same_location for rule 40501 (#1082)
 - @atomicturtle - Stop treating MJ12bot as a malicious user agent in rule 31508 (#1317)

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -14,6 +14,7 @@
 #include "config.h"
 #include "alerts/alerts.h"
 #include "decoder.h"
+#include "fim_sum_op.h"
 
 #ifdef SQLITE_ENABLED
 #include <sqlite3.h>
@@ -450,6 +451,27 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
         return (0);
     }
 
+    /* Placeholder-only hash transitions (xxx <-> real) are not integrity
+     * events; update the DB quietly so future scans stay clean (#1590/#1704). */
+    if (!fim_sum_has_real_change(saved_sum, c_sum)) {
+        if (fsetpos(fp, &sdb.init_pos)) {
+            merror("%s: Error handling integrity database (fsetpos).", ARGV0);
+            lf->data = NULL;
+            return (0);
+        }
+        fputc('#', fp);
+        fseek(fp, 0, SEEK_END);
+        fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name);
+        fflush(fp);
+        if (db_entry) {
+            snprintf(db_entry->prefix_sum, OS_MAXSTR, "+++%s", c_sum);
+            fseek(fp, 0, SEEK_END);
+            fgetpos(fp, &db_entry->pos);
+        }
+        lf->data = NULL;
+        return (0);
+    }
+
 
 
 
@@ -674,8 +696,9 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
             os_strdup(newgid, lf->gowner_after);
         }
 
-        /* MD5 message */
-        if (!newmd5 || !oldmd5 || strcmp(newmd5, oldmd5) == 0) {
+        /* MD5 message — ignore xxx placeholder transitions */
+        if (!newmd5 || !oldmd5 || strcmp(newmd5, oldmd5) == 0 ||
+                fim_hash_is_placeholder(oldmd5) || fim_hash_is_placeholder(newmd5)) {
             sdb.md5[0] = '\0';
         } else {
             snprintf(sdb.md5, OS_FLSIZE, "Old md5sum was: '%s'\n"
@@ -686,7 +709,8 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
         }
 
         /* SHA-1 message */
-        if (!newsha1 || !oldsha1 || strcmp(newsha1, oldsha1) == 0) {
+        if (!newsha1 || !oldsha1 || strcmp(newsha1, oldsha1) == 0 ||
+                fim_hash_is_placeholder(oldsha1) || fim_hash_is_placeholder(newsha1)) {
             sdb.sha1[0] = '\0';
         } else {
             snprintf(sdb.sha1, OS_FLSIZE, "Old sha1sum was: '%s'\n"
@@ -697,7 +721,8 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
         }
 
         /* SHA-256 message */
-        if (!newsha256 || !oldsha256 || strcmp(newsha256, oldsha256) == 0) {
+        if (!newsha256 || !oldsha256 || strcmp(newsha256, oldsha256) == 0 ||
+                fim_hash_is_placeholder(oldsha256) || fim_hash_is_placeholder(newsha256)) {
             sdb.sha256[0] = '\0';
         } else {
             snprintf(sdb.sha256, OS_FLSIZE, "Old sha256sum was: '%s'\n"

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -454,20 +454,42 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
     /* Placeholder-only hash transitions (xxx <-> real) are not integrity
      * events; update the DB quietly so future scans stay clean (#1590/#1704). */
     if (!fim_sum_has_real_change(saved_sum, c_sum)) {
-        if (fsetpos(fp, &sdb.init_pos)) {
+        char new_prefix[OS_MAXSTR + 1];
+        fpos_t new_pos;
+
+        if (fsetpos(fp, &sdb.init_pos) != 0) {
             merror("%s: Error handling integrity database (fsetpos).", ARGV0);
             lf->data = NULL;
             return (0);
         }
-        fputc('#', fp);
-        fseek(fp, 0, SEEK_END);
-        if (db_entry) {
-            /* Record the start of the new line before writing it. */
-            fgetpos(fp, &db_entry->pos);
-            snprintf(db_entry->prefix_sum, OS_MAXSTR, "+++%s", c_sum);
+        if (fputc('#', fp) == EOF) {
+            merror("%s: Error handling integrity database (fputc).", ARGV0);
+            lf->data = NULL;
+            return (0);
         }
-        fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name);
-        fflush(fp);
+        if (fseek(fp, 0, SEEK_END) != 0) {
+            merror("%s: Error handling integrity database (fseek).", ARGV0);
+            lf->data = NULL;
+            return (0);
+        }
+        if (fgetpos(fp, &new_pos) != 0) {
+            merror("%s: Error handling integrity database (fgetpos).", ARGV0);
+            lf->data = NULL;
+            return (0);
+        }
+        snprintf(new_prefix, sizeof(new_prefix), "+++%s", c_sum);
+        if (fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name) < 0 ||
+                fflush(fp) != 0) {
+            merror("%s: Error handling integrity database (write).", ARGV0);
+            lf->data = NULL;
+            return (0);
+        }
+        /* Publish index metadata only after a successful append. */
+        if (db_entry) {
+            db_entry->pos = new_pos;
+            memcpy(db_entry->prefix_sum, new_prefix, sizeof(db_entry->prefix_sum));
+            db_entry->prefix_sum[OS_MAXSTR] = '\0';
+        }
         lf->data = NULL;
         return (0);
     }
@@ -521,24 +543,43 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
     fputc('#', fp);
 
     /* Add the new entry at the end of the file */
-    fseek(fp, 0, SEEK_END);
-    if (db_entry) {
-        /* Record the start of the new line before writing it. */
-        fgetpos(fp, &db_entry->pos);
-        snprintf(db_entry->prefix_sum, OS_MAXSTR, "%c%c%c%s",
+    {
+        char new_prefix[OS_MAXSTR + 1];
+        fpos_t new_pos;
+
+        if (fseek(fp, 0, SEEK_END) != 0) {
+            merror("%s: Error handling integrity database (fseek).", ARGV0);
+            lf->data = NULL;
+            return (0);
+        }
+        if (fgetpos(fp, &new_pos) != 0) {
+            merror("%s: Error handling integrity database (fgetpos).", ARGV0);
+            lf->data = NULL;
+            return (0);
+        }
+        snprintf(new_prefix, sizeof(new_prefix), "%c%c%c%s",
                  '!',
                  p >= 1 ? '!' : '+',
                  p == 2 ? '!' : (p > 2) ? '?' : '+',
                  c_sum);
+        if (fprintf(fp, "%c%c%c%s !%ld %s\n",
+                    '!',
+                    p >= 1 ? '!' : '+',
+                    p == 2 ? '!' : (p > 2) ? '?' : '+',
+                    c_sum,
+                    (long int)lf->time,
+                    f_name) < 0 ||
+                fflush(fp) != 0) {
+            merror("%s: Error handling integrity database (write).", ARGV0);
+            lf->data = NULL;
+            return (0);
+        }
+        if (db_entry) {
+            db_entry->pos = new_pos;
+            memcpy(db_entry->prefix_sum, new_prefix, sizeof(db_entry->prefix_sum));
+            db_entry->prefix_sum[OS_MAXSTR] = '\0';
+        }
     }
-    fprintf(fp, "%c%c%c%s !%ld %s\n",
-            '!',
-            p >= 1 ? '!' : '+',
-            p == 2 ? '!' : (p > 2) ? '?' : '+',
-            c_sum,
-            (long int)lf->time,
-            f_name);
-    fflush(fp);
 
     /* File deleted */
     if (c_sum[0] == '-' && c_sum[1] == '1') {

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -461,13 +461,13 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
         }
         fputc('#', fp);
         fseek(fp, 0, SEEK_END);
+        if (db_entry) {
+            /* Record the start of the new line before writing it. */
+            fgetpos(fp, &db_entry->pos);
+            snprintf(db_entry->prefix_sum, OS_MAXSTR, "+++%s", c_sum);
+        }
         fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name);
         fflush(fp);
-        if (db_entry) {
-            snprintf(db_entry->prefix_sum, OS_MAXSTR, "+++%s", c_sum);
-            fseek(fp, 0, SEEK_END);
-            fgetpos(fp, &db_entry->pos);
-        }
         lf->data = NULL;
         return (0);
     }
@@ -522,6 +522,15 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
 
     /* Add the new entry at the end of the file */
     fseek(fp, 0, SEEK_END);
+    if (db_entry) {
+        /* Record the start of the new line before writing it. */
+        fgetpos(fp, &db_entry->pos);
+        snprintf(db_entry->prefix_sum, OS_MAXSTR, "%c%c%c%s",
+                 '!',
+                 p >= 1 ? '!' : '+',
+                 p == 2 ? '!' : (p > 2) ? '?' : '+',
+                 c_sum);
+    }
     fprintf(fp, "%c%c%c%s !%ld %s\n",
             '!',
             p >= 1 ? '!' : '+',
@@ -530,16 +539,6 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
             (long int)lf->time,
             f_name);
     fflush(fp);
-
-    if (db_entry) {
-        snprintf(db_entry->prefix_sum, OS_MAXSTR, "%c%c%c%s",
-                 '!',
-                 p >= 1 ? '!' : '+',
-                 p == 2 ? '!' : (p > 2) ? '?' : '+',
-                 c_sum);
-        fseek(fp, 0, SEEK_END);
-        fgetpos(fp, &db_entry->pos);
-    }
 
     /* File deleted */
     if (c_sum[0] == '-' && c_sum[1] == '1') {

--- a/src/headers/fim_sum_op.h
+++ b/src/headers/fim_sum_op.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef FIM_SUM_OP_H
+#define FIM_SUM_OP_H
+
+#include <stddef.h>
+
+/* "xxx" is the syscheck placeholder for a hash that was not computed. */
+int fim_hash_is_placeholder(const char *hash);
+
+/* Offset from the start of a local syscheck.fp hash entry to the sum data
+ * (size:perm:uid:gid:md5:sha1[:sha256]). Legacy entries have 6 flag chars;
+ * current entries have 7 (includes sha256 enable flag). */
+int fim_sum_data_offset(const char *hash_entry);
+
+/* Compare two sum strings (size:perm:uid:gid:md5:sha1[:sha256]).
+ * Returns 1 if they differ in a "real" way (size/perm/owner/group, or a hash
+ * where neither side is the xxx placeholder). Returns 0 if equal or the only
+ * hash differences involve placeholders (#1590/#1704). */
+int fim_sum_has_real_change(const char *old_sum, const char *new_sum);
+
+#endif

--- a/src/headers/shared.h
+++ b/src/headers/shared.h
@@ -203,6 +203,7 @@ extern const char *__local_name;
 #include "list_op.h"
 #include "dirtree_op.h"
 #include "hash_op.h"
+#include "fim_sum_op.h"
 #include "store_op.h"
 #include "rc.h"
 #include "ar.h"

--- a/src/shared/fim_sum_op.c
+++ b/src/shared/fim_sum_op.c
@@ -1,0 +1,120 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "fim_sum_op.h"
+
+int fim_hash_is_placeholder(const char *hash)
+{
+    if (!hash || !*hash) {
+        return (1);
+    }
+
+    /* Placeholder is exactly "xxx" (optionally ending the field at ':' or NUL). */
+    if (hash[0] == 'x' && hash[1] == 'x' && hash[2] == 'x' &&
+            (hash[3] == '\0' || hash[3] == ':')) {
+        return (1);
+    }
+
+    return (0);
+}
+
+int fim_sum_data_offset(const char *hash_entry)
+{
+    if (!hash_entry || strlen(hash_entry) < 7) {
+        return (6);
+    }
+
+    /* New format: flags[6] is '+' or '-' for sha256. Legacy: flags[6] starts size. */
+    if (hash_entry[6] == '+' || hash_entry[6] == '-') {
+        return (7);
+    }
+
+    return (6);
+}
+
+/* Split "a:b:c:..." into up to max_fields pointers into a mutable copy. */
+static int fim_split_sum(char *buf, char **fields, int max_fields)
+{
+    int n = 0;
+    char *p = buf;
+
+    if (!buf || !fields || max_fields <= 0) {
+        return (0);
+    }
+
+    fields[n++] = p;
+    while (*p && n < max_fields) {
+        if (*p == ':') {
+            *p = '\0';
+            p++;
+            fields[n++] = p;
+            continue;
+        }
+        p++;
+    }
+
+    return (n);
+}
+
+int fim_sum_has_real_change(const char *old_sum, const char *new_sum)
+{
+    char old_buf[512];
+    char new_buf[512];
+    char *of[8];
+    char *nf[8];
+    int oc, nc, i;
+    size_t olen, nlen;
+
+    if (!old_sum || !new_sum) {
+        return (1);
+    }
+
+    if (strcmp(old_sum, new_sum) == 0) {
+        return (0);
+    }
+
+    olen = strlen(old_sum);
+    nlen = strlen(new_sum);
+    if (olen >= sizeof(old_buf) || nlen >= sizeof(new_buf)) {
+        /* Oversized: fall back to strict compare already failed above */
+        return (1);
+    }
+
+    memcpy(old_buf, old_sum, olen + 1);
+    memcpy(new_buf, new_sum, nlen + 1);
+
+    oc = fim_split_sum(old_buf, of, 8);
+    nc = fim_split_sum(new_buf, nf, 8);
+    if (oc < 6 || nc < 6) {
+        return (1);
+    }
+
+    /* size, perm, uid, gid — always meaningful when they differ */
+    for (i = 0; i < 4; i++) {
+        if (strcmp(of[i], nf[i]) != 0) {
+            return (1);
+        }
+    }
+
+    /* md5, sha1, optional sha256 — ignore placeholder transitions */
+    for (i = 4; i < oc && i < nc && i < 7; i++) {
+        if (strcmp(of[i], nf[i]) == 0) {
+            continue;
+        }
+        if (fim_hash_is_placeholder(of[i]) || fim_hash_is_placeholder(nf[i])) {
+            continue;
+        }
+        return (1);
+    }
+
+    return (0);
+}

--- a/src/shared/fim_sum_op.c
+++ b/src/shared/fim_sum_op.c
@@ -14,13 +14,16 @@
 
 int fim_hash_is_placeholder(const char *hash)
 {
+    size_t len;
+
     if (!hash || !*hash) {
         return (1);
     }
 
-    /* Placeholder is exactly "xxx" (optionally ending the field at ':' or NUL). */
-    if (hash[0] == 'x' && hash[1] == 'x' && hash[2] == 'x' &&
-            (hash[3] == '\0' || hash[3] == ':')) {
+    /* Placeholder is exactly "xxx" (field may continue with ':' in a sum). */
+    len = strlen(hash);
+    if (len >= 3 && hash[0] == 'x' && hash[1] == 'x' && hash[2] == 'x' &&
+            (len == 3 || hash[3] == ':')) {
         return (1);
     }
 

--- a/src/shared/tests/Makefile
+++ b/src/shared/tests/Makefile
@@ -8,7 +8,7 @@ TOP = ../..
 CFLAGS_COMMON = -g -Wall -I$(TOP)/headers -I$(TOP) -I$(TOP)/analysisd
 
 # Headless tests run by `check`. Interactive helpers stay under `legacy_helpers`.
-AUTO_TEST_BINS = thread_pool_test queue_op_test string_test
+AUTO_TEST_BINS = thread_pool_test queue_op_test string_test fim_sum_test
 LEGACY_HELPER_BINS = prime_test hash_test merge_test ip_test
 
 .PHONY: maketest check clean legacy_helpers
@@ -25,6 +25,9 @@ queue_op_test: queue_op_test.c $(TOP)/shared.a
 
 string_test: string_test.c
 	$(CC) $(CFLAGS_COMMON) -DARGV0=\"string_test\" -o $@ string_test.c ../string_op.c
+
+fim_sum_test: fim_sum_test.c
+	$(CC) $(CFLAGS_COMMON) -DARGV0=\"fim_sum_test\" -o $@ fim_sum_test.c ../fim_sum_op.c
 
 # Interactive / argv-driven helpers (not part of automated check).
 legacy_helpers:

--- a/src/shared/tests/Makefile
+++ b/src/shared/tests/Makefile
@@ -26,7 +26,7 @@ queue_op_test: queue_op_test.c $(TOP)/shared.a
 string_test: string_test.c
 	$(CC) $(CFLAGS_COMMON) -DARGV0=\"string_test\" -o $@ string_test.c ../string_op.c
 
-fim_sum_test: fim_sum_test.c
+fim_sum_test: fim_sum_test.c ../fim_sum_op.c ../../headers/fim_sum_op.h
 	$(CC) $(CFLAGS_COMMON) -DARGV0=\"fim_sum_test\" -o $@ fim_sum_test.c ../fim_sum_op.c
 
 # Interactive / argv-driven helpers (not part of automated check).

--- a/src/shared/tests/fim_sum_test.c
+++ b/src/shared/tests/fim_sum_test.c
@@ -1,0 +1,53 @@
+/* Unit tests for FIM sum placeholder helpers (#1590/#1704). */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "fim_sum_op.h"
+
+static int failures = 0;
+
+static void expect_int(const char *name, int got, int want)
+{
+    if (got != want) {
+        printf("FAIL %s: got %d want %d\n", name, got, want);
+        failures++;
+    }
+}
+
+int main(void)
+{
+    expect_int("placeholder xxx", fim_hash_is_placeholder("xxx"), 1);
+    expect_int("placeholder xxx:", fim_hash_is_placeholder("xxx:rest"), 1);
+    expect_int("not placeholder", fim_hash_is_placeholder("abc"), 0);
+    expect_int("null is placeholder", fim_hash_is_placeholder(NULL), 1);
+
+    expect_int("offset new format",
+               fim_sum_data_offset("++++++-0:0:0:0:aaa:bbb:ccc"), 7);
+    expect_int("offset legacy format",
+               fim_sum_data_offset("++++++0:0:0:0:aaa:bbb"), 6);
+
+    expect_int("equal sums",
+               fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx",
+                                       "0:0:0:0:aaa:bbb:xxx"), 0);
+    expect_int("xxx to real sha1",
+               fim_sum_has_real_change("0:0:0:0:aaa:xxx:xxx",
+                                       "0:0:0:0:aaa:bbb:xxx"), 0);
+    expect_int("real to xxx sha1",
+               fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx",
+                                       "0:0:0:0:aaa:xxx:xxx"), 0);
+    expect_int("real sha1 change",
+               fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx",
+                                       "0:0:0:0:aaa:ccc:xxx"), 1);
+    expect_int("size change",
+               fim_sum_has_real_change("10:0:0:0:aaa:bbb:xxx",
+                                       "11:0:0:0:aaa:bbb:xxx"), 1);
+
+    if (failures) {
+        printf("FAILED: %d assertion(s)\n", failures);
+        return (1);
+    }
+
+    printf("PASS: fim_sum_test\n");
+    return (0);
+}

--- a/src/shared/tests/fim_sum_test.c
+++ b/src/shared/tests/fim_sum_test.c
@@ -19,6 +19,8 @@ int main(void)
 {
     expect_int("placeholder xxx", fim_hash_is_placeholder("xxx"), 1);
     expect_int("placeholder xxx:", fim_hash_is_placeholder("xxx:rest"), 1);
+    expect_int("short x not placeholder", fim_hash_is_placeholder("x"), 0);
+    expect_int("short xx not placeholder", fim_hash_is_placeholder("xx"), 0);
     expect_int("not placeholder", fim_hash_is_placeholder("abc"), 0);
     expect_int("null is placeholder", fim_hash_is_placeholder(NULL), 1);
 
@@ -36,6 +38,9 @@ int main(void)
     expect_int("real to xxx sha1",
                fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx",
                                        "0:0:0:0:aaa:xxx:xxx"), 0);
+    expect_int("malformed short hash field",
+               fim_sum_has_real_change("0:0:0:0:x:xx:xxx",
+                                       "0:0:0:0:x:yy:xxx"), 1);
     expect_int("real sha1 change",
                fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx",
                                        "0:0:0:0:aaa:ccc:xxx"), 1);

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -308,20 +308,6 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
 
                 if (strcmp(c_sum, buf + sum_off) != 0) {
                     int real_change = fim_sum_has_real_change(buf + sum_off, c_sum);
-                    char *updated;
-                    char *old_data = buf;
-
-                    /* Refresh local cache so we do not resend forever. */
-                    os_calloc((size_t)sum_off + strlen(c_sum) + 1, sizeof(char), updated);
-                    memcpy(updated, buf, (size_t)sum_off);
-                    updated[sum_off] = '\0';
-                    memcpy(updated + sum_off, c_sum, strlen(c_sum) + 1);
-                    if (OSHash_Update(syscheck.fp, file_name, updated) == 1) {
-                        free(old_data);
-                        buf = updated;
-                    } else {
-                        free(updated);
-                    }
 
                     /* Placeholder-only diffs still go to the manager so its DB
                      * can heal, but analysisd will not raise an alert. */
@@ -346,6 +332,20 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                     if (send_syscheck_msg(alert_msg) != 0) {
                         merror("%s: WARN: Failed to send syscheck update for '%s'. "
                               "Change will be retried on the next scan.", ARGV0, file_name);
+                    } else {
+                        /* Only refresh local cache after a successful send so a
+                         * failed delivery is retried on the next scan. */
+                        char *updated;
+                        char *old_data = buf;
+
+                        os_calloc((size_t)sum_off + strlen(c_sum) + 1, sizeof(char), updated);
+                        memcpy(updated, buf, (size_t)sum_off);
+                        memcpy(updated + sum_off, c_sum, strlen(c_sum) + 1);
+                        if (OSHash_Update(syscheck.fp, file_name, updated) == 1) {
+                            free(old_data);
+                        } else {
+                            free(updated);
+                        }
                     }
                 }
             }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -29,7 +29,7 @@ static int __counter = 0;
 static int read_file(const char *file_name, int opts, OSMatch *restriction)
 {
     char *buf;
-    char sha1s = '+';
+    char sha1s;
     struct stat statbuf;
 
     /* Check if the file should be ignored */
@@ -128,11 +128,15 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                 if (stat(file_name, &statbuf_lnk) == 0) {
                     if (S_ISREG(statbuf_lnk.st_mode)) {
                         if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
+                            merror("%s: WARN: Unable to read file '%s' for checksum: %s",
+                                   ARGV0, file_name, strerror(errno));
                             strncpy(mf_sum, "xxx", 4);
                             strncpy(sf_sum, "xxx", 4);
                         }
                         if (opts & CHECK_SHA256SUM) {
                             if (OS_SHA256_File(file_name, sha256_sum, OS_BINARY) < 0) {
+                                merror("%s: WARN: Unable to read file '%s' for sha256: %s",
+                                       ARGV0, file_name, strerror(errno));
                                 strncpy(sha256_sum, "xxx", 4);
                             }
                         }
@@ -140,11 +144,15 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                 }
             } else {
                  if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
+                    merror("%s: WARN: Unable to read file '%s' for checksum: %s",
+                           ARGV0, file_name, strerror(errno));
                     strncpy(mf_sum, "xxx", 4);
                     strncpy(sf_sum, "xxx", 4);
                  }
                  if (opts & CHECK_SHA256SUM) {
                     if (OS_SHA256_File(file_name, sha256_sum, OS_BINARY) < 0) {
+                        merror("%s: WARN: Unable to read file '%s' for sha256: %s",
+                               ARGV0, file_name, strerror(errno));
                         strncpy(sha256_sum, "xxx", 4);
                     }
                  }
@@ -152,18 +160,25 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
 #else
             if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0)
             {
+                merror("%s: WARN: Unable to read file '%s' for checksum: %s",
+                       ARGV0, file_name, strerror(errno));
                 strncpy(mf_sum, "xxx", 4);
                 strncpy(sf_sum, "xxx", 4);
             }
             if (opts & CHECK_SHA256SUM) {
                 if (OS_SHA256_File(file_name, sha256_sum, OS_BINARY) < 0) {
+                    merror("%s: WARN: Unable to read file '%s' for sha256: %s",
+                           ARGV0, file_name, strerror(errno));
                     strncpy(sha256_sum, "xxx", 4);
                 }
             }
 #endif
 
             if (opts & CHECK_SEECHANGES) {
-                sha1s = 's';
+                /* 's' = seechanges + sha1 on; 'n' = seechanges + sha1 off */
+                sha1s = (opts & CHECK_SHA1SUM) ? 's' : 'n';
+            } else {
+                sha1s = (opts & CHECK_SHA1SUM) ? '+' : '-';
             }
         } else {
             if (opts & CHECK_SEECHANGES) {
@@ -282,34 +297,56 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
             alert_msg[0] = '\0';
             alert_msg[OS_MAXSTR] = '\0';
 
-            /* If it returns < 0, we have already alerted */
+            /* If it returns < 0, we have already alerted (missing file) or
+             * skipped (checksum read failure). */
             if (c_read_file(file_name, buf, c_sum) < 0) {
                 return (0);
             }
 
-            if (strcmp(c_sum, buf + 6) != 0) {
-                /* Send the new checksum to the analysis server */
-                alert_msg[OS_MAXSTR] = '\0';
-                #ifdef WIN32
-                snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
-                #else
-                char *fullalert = NULL;
-                if (buf[5] == 's' || buf[5] == 'n') {
-                    fullalert = seechanges_addfile(file_name);
-                    if (fullalert) {
-                        snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s", c_sum, file_name, fullalert);
-                        free(fullalert);
-                        fullalert = NULL;
+            {
+                int sum_off = fim_sum_data_offset(buf);
+
+                if (strcmp(c_sum, buf + sum_off) != 0) {
+                    int real_change = fim_sum_has_real_change(buf + sum_off, c_sum);
+                    char *updated;
+                    char *old_data = buf;
+
+                    /* Refresh local cache so we do not resend forever. */
+                    os_calloc((size_t)sum_off + strlen(c_sum) + 1, sizeof(char), updated);
+                    memcpy(updated, buf, (size_t)sum_off);
+                    updated[sum_off] = '\0';
+                    memcpy(updated + sum_off, c_sum, strlen(c_sum) + 1);
+                    if (OSHash_Update(syscheck.fp, file_name, updated) == 1) {
+                        free(old_data);
+                        buf = updated;
+                    } else {
+                        free(updated);
+                    }
+
+                    /* Placeholder-only diffs still go to the manager so its DB
+                     * can heal, but analysisd will not raise an alert. */
+                    alert_msg[OS_MAXSTR] = '\0';
+                    #ifdef WIN32
+                    snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
+                    #else
+                    char *fullalert = NULL;
+                    if (real_change && (buf[5] == 's' || buf[5] == 'n')) {
+                        fullalert = seechanges_addfile(file_name);
+                        if (fullalert) {
+                            snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s", c_sum, file_name, fullalert);
+                            free(fullalert);
+                            fullalert = NULL;
+                        } else {
+                            snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
+                        }
                     } else {
                         snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
                     }
-                } else {
-                    snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
-                }
-                #endif
-                if (send_syscheck_msg(alert_msg) != 0) {
-                    merror("%s: WARN: Failed to send syscheck update for '%s'. "
-                          "Change will be retried on the next scan.", ARGV0, file_name);
+                    #endif
+                    if (send_syscheck_msg(alert_msg) != 0) {
+                        merror("%s: WARN: Failed to send syscheck update for '%s'. "
+                              "Change will be retried on the next scan.", ARGV0, file_name);
+                    }
                 }
             }
         }

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -127,11 +127,13 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                 struct stat statbuf_lnk;
                 if (stat(file_name, &statbuf_lnk) == 0) {
                     if (S_ISREG(statbuf_lnk.st_mode)) {
-                        if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
-                            merror("%s: WARN: Unable to read file '%s' for checksum: %s",
-                                   ARGV0, file_name, strerror(errno));
-                            strncpy(mf_sum, "xxx", 4);
-                            strncpy(sf_sum, "xxx", 4);
+                        if ((opts & CHECK_MD5SUM) || (opts & CHECK_SHA1SUM)) {
+                            if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
+                                merror("%s: WARN: Unable to read file '%s' for checksum: %s",
+                                       ARGV0, file_name, strerror(errno));
+                                strncpy(mf_sum, "xxx", 4);
+                                strncpy(sf_sum, "xxx", 4);
+                            }
                         }
                         if (opts & CHECK_SHA256SUM) {
                             if (OS_SHA256_File(file_name, sha256_sum, OS_BINARY) < 0) {
@@ -143,11 +145,13 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                     }
                 }
             } else {
-                 if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
-                    merror("%s: WARN: Unable to read file '%s' for checksum: %s",
-                           ARGV0, file_name, strerror(errno));
-                    strncpy(mf_sum, "xxx", 4);
-                    strncpy(sf_sum, "xxx", 4);
+                 if ((opts & CHECK_MD5SUM) || (opts & CHECK_SHA1SUM)) {
+                     if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
+                        merror("%s: WARN: Unable to read file '%s' for checksum: %s",
+                               ARGV0, file_name, strerror(errno));
+                        strncpy(mf_sum, "xxx", 4);
+                        strncpy(sf_sum, "xxx", 4);
+                     }
                  }
                  if (opts & CHECK_SHA256SUM) {
                     if (OS_SHA256_File(file_name, sha256_sum, OS_BINARY) < 0) {
@@ -158,12 +162,14 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                  }
             }
 #else
-            if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0)
-            {
-                merror("%s: WARN: Unable to read file '%s' for checksum: %s",
-                       ARGV0, file_name, strerror(errno));
-                strncpy(mf_sum, "xxx", 4);
-                strncpy(sf_sum, "xxx", 4);
+            if ((opts & CHECK_MD5SUM) || (opts & CHECK_SHA1SUM)) {
+                if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0)
+                {
+                    merror("%s: WARN: Unable to read file '%s' for checksum: %s",
+                           ARGV0, file_name, strerror(errno));
+                    strncpy(mf_sum, "xxx", 4);
+                    strncpy(sf_sum, "xxx", 4);
+                }
             }
             if (opts & CHECK_SHA256SUM) {
                 if (OS_SHA256_File(file_name, sha256_sum, OS_BINARY) < 0) {
@@ -309,32 +315,36 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                 if (strcmp(c_sum, buf + sum_off) != 0) {
                     int real_change = fim_sum_has_real_change(buf + sum_off, c_sum);
 
-                    /* Placeholder-only diffs still go to the manager so its DB
-                     * can heal, but analysisd will not raise an alert. */
-                    alert_msg[OS_MAXSTR] = '\0';
-                    #ifdef WIN32
-                    snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
-                    #else
-                    char *fullalert = NULL;
-                    if (real_change && (buf[5] == 's' || buf[5] == 'n')) {
-                        fullalert = seechanges_addfile(file_name);
-                        if (fullalert) {
-                            snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s", c_sum, file_name, fullalert);
-                            free(fullalert);
-                            fullalert = NULL;
+                    if (real_change) {
+                        /* Real integrity change: notify the manager first. */
+                        alert_msg[OS_MAXSTR] = '\0';
+                        #ifdef WIN32
+                        snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
+                        #else
+                        char *fullalert = NULL;
+                        if (buf[5] == 's' || buf[5] == 'n') {
+                            fullalert = seechanges_addfile(file_name);
+                            if (fullalert) {
+                                snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s", c_sum, file_name, fullalert);
+                                free(fullalert);
+                                fullalert = NULL;
+                            } else {
+                                snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
+                            }
                         } else {
                             snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
                         }
-                    } else {
-                        snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
+                        #endif
+                        if (send_syscheck_msg(alert_msg) != 0) {
+                            merror("%s: WARN: Failed to send syscheck update for '%s'. "
+                                  "Change will be retried on the next scan.", ARGV0, file_name);
+                            return (0);
+                        }
                     }
-                    #endif
-                    if (send_syscheck_msg(alert_msg) != 0) {
-                        merror("%s: WARN: Failed to send syscheck update for '%s'. "
-                              "Change will be retried on the next scan.", ARGV0, file_name);
-                    } else {
-                        /* Only refresh local cache after a successful send so a
-                         * failed delivery is retried on the next scan. */
+
+                    /* Heal/refresh local cache after a successful send, or for
+                     * placeholder-only transitions that need no manager alert. */
+                    {
                         char *updated;
                         char *old_data = buf;
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -339,11 +339,16 @@ void start_daemon()
     }
 }
 
-/* Read file information and return a pointer to the checksum */
+/* Read file information and return a pointer to the checksum.
+ * Returns 0 on success, -1 if the file is missing (delete alert already
+ * sent), -2 if checksumming failed (e.g. EMFILE) so the caller should skip
+ * without treating it as an integrity change (#1704).
+ */
 int c_read_file(const char *file_name, const char *oldsum, char *newsum)
 {
     int size = 0, perm = 0, owner = 0, group = 0, md5sum = 0, sha1sum = 0, sha256sum = 0;
     int return_error = 0;
+    int checksum_failed = 0;
     struct stat statbuf;
     os_md5 mf_sum;
     os_sha1 sf_sum;
@@ -398,12 +403,11 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
         md5sum = 1;
     }
 
-    /* sha1 sum */
-    if (oldsum[5] == '+') {
+    /* sha1 sum: '+' or 's' means enabled; '-' or 'n' means disabled.
+     * ('s'/'n' also encode report_changes / seechanges.) */
+    if (oldsum[5] == '+' || oldsum[5] == 's') {
         sha1sum = 1;
-    } else if (oldsum[5] == 's') {
-        sha1sum = 1;
-    } else if (oldsum[5] == 'n') {
+    } else {
         sha1sum = 0;
     }
 
@@ -422,12 +426,18 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
             /* Generate checksums of the file */
             if (sha1sum || md5sum) {
                 if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
+                    merror("%s: WARN: Unable to read file '%s' for checksum: %s",
+                           ARGV0, file_name, strerror(errno));
+                    checksum_failed = 1;
                     strncpy(sf_sum, "xxx", 4);
                     strncpy(mf_sum, "xxx", 4);
                 }
             }
             if (sha256sum) {
                 if (OS_SHA256_File(file_name, sha256_sum, OS_BINARY) < 0) {
+                    merror("%s: WARN: Unable to read file '%s' for sha256: %s",
+                           ARGV0, file_name, strerror(errno));
+                    checksum_failed = 1;
                     strncpy(sha256_sum, "xxx", 4);
                 }
             }
@@ -443,12 +453,18 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
                     /* Generate checksums of the file */
                     if (sha1sum || md5sum) {
                         if (OS_MD5_SHA1_File(file_name, syscheck.prefilter_cmd, mf_sum, sf_sum, OS_BINARY) < 0) {
+                            merror("%s: WARN: Unable to read file '%s' for checksum: %s",
+                                   ARGV0, file_name, strerror(errno));
+                            checksum_failed = 1;
                             strncpy(sf_sum, "xxx", 4);
                             strncpy(mf_sum, "xxx", 4);
                         }
                     }
                     if (sha256sum) {
                         if (OS_SHA256_File(file_name, sha256_sum, OS_BINARY) < 0) {
+                            merror("%s: WARN: Unable to read file '%s' for sha256: %s",
+                                   ARGV0, file_name, strerror(errno));
+                            checksum_failed = 1;
                             strncpy(sha256_sum, "xxx", 4);
                         }
                     }
@@ -457,6 +473,10 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
         }
     }
 #endif
+
+    if (checksum_failed) {
+        return (-2);
+    }
 
     newsum[0] = '\0';
     /* Caller is expected to provide a buffer of at least 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -341,8 +341,8 @@ void start_daemon()
 
 /* Read file information and return a pointer to the checksum.
  * Returns 0 on success, -1 if the file is missing (delete alert already
- * sent), -2 if checksumming failed (e.g. EMFILE) so the caller should skip
- * without treating it as an integrity change (#1704).
+ * sent), -2 if metadata/checksum read failed (e.g. EACCES, EMFILE) so
+ * the caller should skip without treating it as an integrity change.
  */
 int c_read_file(const char *file_name, const char *oldsum, char *newsum)
 {
@@ -367,13 +367,20 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
 #endif
     if (return_error)
     {
-        char alert_msg[PATH_MAX+4];
+        /* Only treat missing paths as deletions; other metadata errors
+         * (EACCES, etc.) must not look like "file deleted". */
+        if (errno == ENOENT || errno == ENOTDIR) {
+            char alert_msg[PATH_MAX+4];
 
-        alert_msg[PATH_MAX + 3] = '\0';
-        snprintf(alert_msg, PATH_MAX + 4, "-1 %s", file_name);
-        send_syscheck_msg(alert_msg);
+            alert_msg[PATH_MAX + 3] = '\0';
+            snprintf(alert_msg, PATH_MAX + 4, "-1 %s", file_name);
+            send_syscheck_msg(alert_msg);
+            return (-1);
+        }
 
-        return (-1);
+        merror("%s: WARN: Unable to stat file '%s': %s",
+               ARGV0, file_name, strerror(errno));
+        return (-2);
     }
 
     /* Get the old sum values */

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -23,13 +23,8 @@
 
 #ifdef INOTIFY_ENABLED
 #include <sys/inotify.h>
-#else
-/* shared.h already included above */
 #endif
 
-#include "fs_op.h"
-#include "hash_op.h"
-#include "debug_op.h"
 #include "syscheck.h"
 #include "error_messages/error_messages.h"
 
@@ -60,19 +55,6 @@ int realtime_checksumfile(const char *file_name)
             if (strcmp(c_sum, buf + sum_off) != 0) {
                 char alert_msg[OS_MAXSTR + 1];
                 int real_change = fim_sum_has_real_change(buf + sum_off, c_sum);
-                char *updated;
-                char *old_data = buf;
-
-                os_calloc((size_t)sum_off + strlen(c_sum) + 1, sizeof(char), updated);
-                memcpy(updated, buf, (size_t)sum_off);
-                updated[sum_off] = '\0';
-                memcpy(updated + sum_off, c_sum, strlen(c_sum) + 1);
-                if (OSHash_Update(syscheck.fp, file_name, updated) == 1) {
-                    free(old_data);
-                    buf = updated;
-                } else {
-                    free(updated);
-                }
 
                 alert_msg[OS_MAXSTR] = '\0';
 
@@ -94,7 +76,26 @@ int realtime_checksumfile(const char *file_name)
                     snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
                 }
                 #endif
-                send_syscheck_msg(alert_msg);
+                if (send_syscheck_msg(alert_msg) != 0) {
+                    merror("%s: WARN: Failed to send syscheck update for '%s'. "
+                          "Change will be retried on the next event/scan.", ARGV0, file_name);
+                    return (0);
+                }
+
+                /* Only refresh local cache after a successful send. */
+                {
+                    char *updated;
+                    char *old_data = buf;
+
+                    os_calloc((size_t)sum_off + strlen(c_sum) + 1, sizeof(char), updated);
+                    memcpy(updated, buf, (size_t)sum_off);
+                    memcpy(updated + sum_off, c_sum, strlen(c_sum) + 1);
+                    if (OSHash_Update(syscheck.fp, file_name, updated) == 1) {
+                        free(old_data);
+                    } else {
+                        free(updated);
+                    }
+                }
 
                 return (1);
             }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -19,12 +19,12 @@
 #define sleep(x) Sleep(x * 1000)
 #endif
 
+#include "shared.h"
+
 #ifdef INOTIFY_ENABLED
 #include <sys/inotify.h>
-#define OS_SIZE_6144    6144
-#define OS_MAXSTR       OS_SIZE_6144    /* Size for logs, sockets, etc */
 #else
-#include "shared.h"
+/* shared.h already included above */
 #endif
 
 #include "fs_op.h"
@@ -49,37 +49,55 @@ int realtime_checksumfile(const char *file_name)
         c_sum[0] = '\0';
         c_sum[OS_MAXSTR] = '\0';
 
-        /* If it returns < 0, we have already alerted */
+        /* If it returns < 0, missing file alerted or checksum read failed */
         if (c_read_file(file_name, buf, c_sum) < 0) {
             return (0);
         }
 
-        if (strcmp(c_sum, buf + 6) != 0) {
-            char alert_msg[OS_MAXSTR + 1];
+        {
+            int sum_off = fim_sum_data_offset(buf);
 
-            alert_msg[OS_MAXSTR] = '\0';
+            if (strcmp(c_sum, buf + sum_off) != 0) {
+                char alert_msg[OS_MAXSTR + 1];
+                int real_change = fim_sum_has_real_change(buf + sum_off, c_sum);
+                char *updated;
+                char *old_data = buf;
 
-            #ifdef WIN32
-            snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
-            #else
-            char *fullalert = NULL;
+                os_calloc((size_t)sum_off + strlen(c_sum) + 1, sizeof(char), updated);
+                memcpy(updated, buf, (size_t)sum_off);
+                updated[sum_off] = '\0';
+                memcpy(updated + sum_off, c_sum, strlen(c_sum) + 1);
+                if (OSHash_Update(syscheck.fp, file_name, updated) == 1) {
+                    free(old_data);
+                    buf = updated;
+                } else {
+                    free(updated);
+                }
 
-            if (buf[5] == 's' || buf[5] == 'n') {
-                fullalert = seechanges_addfile(file_name);
-                if (fullalert) {
-                    snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s", c_sum, file_name, fullalert);
-                    free(fullalert);
-                    fullalert = NULL;
+                alert_msg[OS_MAXSTR] = '\0';
+
+                #ifdef WIN32
+                snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
+                #else
+                char *fullalert = NULL;
+
+                if (real_change && (buf[5] == 's' || buf[5] == 'n')) {
+                    fullalert = seechanges_addfile(file_name);
+                    if (fullalert) {
+                        snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s", c_sum, file_name, fullalert);
+                        free(fullalert);
+                        fullalert = NULL;
+                    } else {
+                        snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
+                    }
                 } else {
                     snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
                 }
-            } else {
-                snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
-            }
-            #endif
-            send_syscheck_msg(alert_msg);
+                #endif
+                send_syscheck_msg(alert_msg);
 
-            return (1);
+                return (1);
+            }
         }
         return (0);
     } else {

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -56,33 +56,36 @@ int realtime_checksumfile(const char *file_name)
                 char alert_msg[OS_MAXSTR + 1];
                 int real_change = fim_sum_has_real_change(buf + sum_off, c_sum);
 
-                alert_msg[OS_MAXSTR] = '\0';
+                if (real_change) {
+                    alert_msg[OS_MAXSTR] = '\0';
 
-                #ifdef WIN32
-                snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
-                #else
-                char *fullalert = NULL;
+                    #ifdef WIN32
+                    snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
+                    #else
+                    char *fullalert = NULL;
 
-                if (real_change && (buf[5] == 's' || buf[5] == 'n')) {
-                    fullalert = seechanges_addfile(file_name);
-                    if (fullalert) {
-                        snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s", c_sum, file_name, fullalert);
-                        free(fullalert);
-                        fullalert = NULL;
+                    if (buf[5] == 's' || buf[5] == 'n') {
+                        fullalert = seechanges_addfile(file_name);
+                        if (fullalert) {
+                            snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s", c_sum, file_name, fullalert);
+                            free(fullalert);
+                            fullalert = NULL;
+                        } else {
+                            snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
+                        }
                     } else {
                         snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
                     }
-                } else {
-                    snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
-                }
-                #endif
-                if (send_syscheck_msg(alert_msg) != 0) {
-                    merror("%s: WARN: Failed to send syscheck update for '%s'. "
-                          "Change will be retried on the next event/scan.", ARGV0, file_name);
-                    return (0);
+                    #endif
+                    if (send_syscheck_msg(alert_msg) != 0) {
+                        merror("%s: WARN: Failed to send syscheck update for '%s'. "
+                              "Change will be retried on the next event/scan.", ARGV0, file_name);
+                        return (0);
+                    }
                 }
 
-                /* Only refresh local cache after a successful send. */
+                /* Heal/refresh local cache after a successful send, or for
+                 * placeholder-only transitions that need no manager alert. */
                 {
                     char *updated;
                     char *old_data = buf;
@@ -97,7 +100,7 @@ int realtime_checksumfile(const char *file_name)
                     }
                 }
 
-                return (1);
+                return (real_change ? 1 : 0);
             }
         }
         return (0);

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -55,7 +55,10 @@ int realtime_process(void);
 /* Process the content of the file changes */
 char *seechanges_addfile(const char *filename) __attribute__((nonnull));
 
-/* Get checksum changes */
+/* Get checksum changes.
+ * Returns 0 on success, -1 if missing (delete alerted), -2 if checksum
+ * read failed (caller should skip without alerting).
+ */
 int c_read_file(const char *file_name, const char *oldsum, char *newsum) __attribute__((nonnull));
 
 int send_syscheck_msg(const char *msg) __attribute__((nonnull));

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -56,8 +56,8 @@ int realtime_process(void);
 char *seechanges_addfile(const char *filename) __attribute__((nonnull));
 
 /* Get checksum changes.
- * Returns 0 on success, -1 if missing (delete alerted), -2 if checksum
- * read failed (caller should skip without alerting).
+ * Returns 0 on success, -1 if missing (delete alerted), -2 if metadata
+ * or checksum read failed (caller should skip without alerting).
  */
 int c_read_file(const char *file_name, const char *oldsum, char *newsum) __attribute__((nonnull));
 


### PR DESCRIPTION
Encode SHA1 enablement correctly when only MD5 is configured (#1590), skip alerts when checksum reads fail (e.g. EMFILE) and log a warning (#1704), ignore xxx placeholder transitions in analysisd, and compare sums with the correct flag-length offset after SHA-256 was added.