### PR TITLE
Fix active-response expect parsing for username placeholders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
+- @atomicturtle - Accept AR expect ``username`` (alias of ``user``), fall back to srcuser, and document fixed script argv (#2104)
 - @atomicturtle - Avoid FIM false positives from xxx hash placeholders and checksum read failures (#1590, #1704)
 - @atomicturtle - Match web-accesslog URLs that contain spaces; do not treat POST as a simple ignored request (#914, #922)
 - @atomicturtle - Require more attack-group context and same_location for rule 40501 (#1082)

--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -24,17 +24,7 @@ const char *OS_ARUsername(const Eventinfo *lf)
         return NULL;
     }
 
-    /* Decoder "user" / "dstuser" maps here */
-    if (lf->dstuser && lf->dstuser[0] && strcmp(lf->dstuser, "-") != 0) {
-        return lf->dstuser;
-    }
-
-    /* Many custom/web decoders only populate srcuser */
-    if (lf->srcuser && lf->srcuser[0] && strcmp(lf->srcuser, "-") != 0) {
-        return lf->srcuser;
-    }
-
-    return NULL;
+    return ar_pick_username(lf->dstuser, lf->srcuser);
 }
 
 void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)

--- a/src/analysisd/alerts/exec.c
+++ b/src/analysisd/alerts/exec.c
@@ -18,6 +18,25 @@
 #include "eventinfo.h"
 
 
+const char *OS_ARUsername(const Eventinfo *lf)
+{
+    if (!lf) {
+        return NULL;
+    }
+
+    /* Decoder "user" / "dstuser" maps here */
+    if (lf->dstuser && lf->dstuser[0] && strcmp(lf->dstuser, "-") != 0) {
+        return lf->dstuser;
+    }
+
+    /* Many custom/web decoders only populate srcuser */
+    if (lf->srcuser && lf->srcuser[0] && strcmp(lf->srcuser, "-") != 0) {
+        return lf->srcuser;
+    }
+
+    return NULL;
+}
+
 void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
 {
     char exec_msg[OS_SIZE_1024 + 1];
@@ -61,9 +80,12 @@ void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar)
         }
     }
 
-    /* Get username */
-    if (lf->dstuser && (ar->ar_cmd->expect & USERNAME)) {
-        user = lf->dstuser;
+    /* Get username (dstuser preferred, srcuser fallback) */
+    if (ar->ar_cmd->expect & USERNAME) {
+        const char *uname = OS_ARUsername(lf);
+        if (uname) {
+            user = uname;
+        }
     }
 
     /* Get filename */

--- a/src/analysisd/alerts/exec.h
+++ b/src/analysisd/alerts/exec.h
@@ -15,5 +15,8 @@
 
 void OS_Exec(int execq, int arq, const Eventinfo *lf, const active_response *ar);
 
+/* Username for AR scripts: prefer dstuser, fall back to srcuser (#2104). */
+const char *OS_ARUsername(const Eventinfo *lf);
+
 #endif
 

--- a/src/analysisd/analysisd_stages.c
+++ b/src/analysisd/analysisd_stages.c
@@ -432,9 +432,10 @@ int analysisd_analyze_event(Eventinfo *lf)
                 int do_ar = 1;
 
                 if ((*rule_ar)->ar_cmd->expect & USERNAME) {
-                    if (!lf->dstuser || !OS_PRegex(lf->dstuser, "^[a-zA-Z._0-9@?-]*$")) {
-                        if (lf->dstuser) {
-                            merror(CRAFTED_USER, ARGV0, lf->dstuser);
+                    const char *uname = OS_ARUsername(lf);
+                    if (!uname || !OS_PRegex(uname, "^[a-zA-Z._0-9@?-]*$")) {
+                        if (uname) {
+                            merror(CRAFTED_USER, ARGV0, uname);
                         }
                         do_ar = 0;
                     }

--- a/src/config/active-response.c
+++ b/src/config/active-response.c
@@ -394,18 +394,8 @@ int ReadActiveCommands(XML_NODE node, void *d1, __attribute__((unused)) void *d2
         return (-1);
     }
 
-    /* Get the expect */
-    if (strlen(tmp_str) >= 4) {
-        if (OS_Regex("user", tmp_str)) {
-            tmp_command->expect |= USERNAME;
-        }
-        if (OS_Regex("srcip", tmp_str)) {
-            tmp_command->expect |= SRCIP;
-        }
-        if (OS_Regex("filename", tmp_str)) {
-            tmp_command->expect |= FILENAME;
-        }
-    }
+    /* Parse expect: comma-separated user|username, srcip, filename (#2104) */
+    tmp_command->expect = ar_parse_expect(tmp_str);
 
     free(tmp_str);
     tmp_str = NULL;

--- a/src/config/active-response.c
+++ b/src/config/active-response.c
@@ -394,7 +394,7 @@ int ReadActiveCommands(XML_NODE node, void *d1, __attribute__((unused)) void *d2
         return (-1);
     }
 
-    /* Parse expect: comma-separated user|username, srcip, filename (#2104) */
+    /* Parse expect: comma/whitespace-separated user|username, srcip, filename (#2104) */
     tmp_command->expect = ar_parse_expect(tmp_str);
 
     free(tmp_str);

--- a/src/headers/ar.h
+++ b/src/headers/ar.h
@@ -37,5 +37,12 @@
 #define DSTIP       0000002
 #define USERNAME    0000001
 
+/**
+ * Parse a comma-separated active-response <expect> string into a bitmask of
+ * USERNAME / SRCIP / FILENAME. Accepts "user" and "username" as aliases.
+ * Unknown tokens are ignored (with a warning). Empty / NULL → 0.
+ */
+int ar_parse_expect(const char *expect_str);
+
 #endif /* __AR_H */
 

--- a/src/headers/ar.h
+++ b/src/headers/ar.h
@@ -38,11 +38,18 @@
 #define USERNAME    0000001
 
 /**
- * Parse a comma-separated active-response <expect> string into a bitmask of
- * USERNAME / SRCIP / FILENAME. Accepts "user" and "username" as aliases.
- * Unknown tokens are ignored (with a warning). Empty / NULL → 0.
+ * Parse an active-response <expect> string into a bitmask of
+ * USERNAME / SRCIP / FILENAME. Tokens may be separated by commas and/or
+ * whitespace. Accepts "user" and "username" as aliases. Unknown tokens are
+ * ignored. Empty / NULL → 0.
  */
 int ar_parse_expect(const char *expect_str);
+
+/**
+ * Prefer dstuser, then srcuser; treat empty and "-" as absent.
+ * Returns a pointer into one of the inputs, or NULL.
+ */
+const char *ar_pick_username(const char *dstuser, const char *srcuser);
 
 #endif /* __AR_H */
 

--- a/src/shared/ar_expect.c
+++ b/src/shared/ar_expect.c
@@ -1,0 +1,102 @@
+/* Copyright (C) 2026 Atomicorp LLC
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ar.h"
+
+/* Trim leading/trailing whitespace in place; return start of token. */
+static char *ar_trim_token(char *tok)
+{
+    char *end;
+
+    if (!tok) {
+        return tok;
+    }
+
+    while (*tok && isspace((unsigned char)*tok)) {
+        tok++;
+    }
+
+    if (!*tok) {
+        return tok;
+    }
+
+    end = tok + strlen(tok);
+    while (end > tok && isspace((unsigned char)end[-1])) {
+        *--end = '\0';
+    }
+
+    return tok;
+}
+
+/* Case-insensitive compare without relying on strcasecmp (Windows). */
+static int ar_token_eq(const char *a, const char *b)
+{
+    while (*a && *b) {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b)) {
+            return 0;
+        }
+        a++;
+        b++;
+    }
+    return (*a == '\0' && *b == '\0');
+}
+
+int ar_parse_expect(const char *expect_str)
+{
+    int expect = 0;
+    char *copy;
+    char *cursor;
+    char *tok;
+    size_t len;
+
+    if (!expect_str || !*expect_str) {
+        return 0;
+    }
+
+    len = strlen(expect_str);
+    copy = (char *)malloc(len + 1);
+    if (!copy) {
+        return 0;
+    }
+    memcpy(copy, expect_str, len + 1);
+
+    cursor = copy;
+    while (cursor && *cursor) {
+        char *comma = strchr(cursor, ',');
+        if (comma) {
+            *comma = '\0';
+            tok = cursor;
+            cursor = comma + 1;
+        } else {
+            tok = cursor;
+            cursor = NULL;
+        }
+
+        tok = ar_trim_token(tok);
+        if (!*tok) {
+            continue;
+        }
+
+        if (ar_token_eq(tok, "user") || ar_token_eq(tok, "username")) {
+            expect |= USERNAME;
+        } else if (ar_token_eq(tok, "srcip")) {
+            expect |= SRCIP;
+        } else if (ar_token_eq(tok, "filename")) {
+            expect |= FILENAME;
+        }
+        /* Unknown tokens (e.g. legacy "hostname") are ignored. */
+    }
+
+    free(copy);
+    return expect;
+}

--- a/src/shared/ar_expect.c
+++ b/src/shared/ar_expect.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2026 Atomicorp LLC
+/* Copyright (C) 2026 Atomicorp, Inc.
  * All rights reserved.
  *
  * This program is a free software; you can redistribute it
@@ -13,31 +13,6 @@
 
 #include "ar.h"
 
-/* Trim leading/trailing whitespace in place; return start of token. */
-static char *ar_trim_token(char *tok)
-{
-    char *end;
-
-    if (!tok) {
-        return tok;
-    }
-
-    while (*tok && isspace((unsigned char)*tok)) {
-        tok++;
-    }
-
-    if (!*tok) {
-        return tok;
-    }
-
-    end = tok + strlen(tok);
-    while (end > tok && isspace((unsigned char)end[-1])) {
-        *--end = '\0';
-    }
-
-    return tok;
-}
-
 /* Case-insensitive compare without relying on strcasecmp (Windows). */
 static int ar_token_eq(const char *a, const char *b)
 {
@@ -49,6 +24,24 @@ static int ar_token_eq(const char *a, const char *b)
         b++;
     }
     return (*a == '\0' && *b == '\0');
+}
+
+static int ar_is_separator(char c)
+{
+    return (c == ',' || isspace((unsigned char)c));
+}
+
+const char *ar_pick_username(const char *dstuser, const char *srcuser)
+{
+    if (dstuser && dstuser[0] && strcmp(dstuser, "-") != 0) {
+        return dstuser;
+    }
+
+    if (srcuser && srcuser[0] && strcmp(srcuser, "-") != 0) {
+        return srcuser;
+    }
+
+    return NULL;
 }
 
 int ar_parse_expect(const char *expect_str)
@@ -70,21 +63,23 @@ int ar_parse_expect(const char *expect_str)
     }
     memcpy(copy, expect_str, len + 1);
 
+    /* Split on commas and/or whitespace so both
+     * "srcip, username" and "srcip username" work. */
     cursor = copy;
-    while (cursor && *cursor) {
-        char *comma = strchr(cursor, ',');
-        if (comma) {
-            *comma = '\0';
-            tok = cursor;
-            cursor = comma + 1;
-        } else {
-            tok = cursor;
-            cursor = NULL;
+    while (*cursor) {
+        while (*cursor && ar_is_separator(*cursor)) {
+            cursor++;
+        }
+        if (!*cursor) {
+            break;
         }
 
-        tok = ar_trim_token(tok);
-        if (!*tok) {
-            continue;
+        tok = cursor;
+        while (*cursor && !ar_is_separator(*cursor)) {
+            cursor++;
+        }
+        if (*cursor) {
+            *cursor++ = '\0';
         }
 
         if (ar_token_eq(tok, "user") || ar_token_eq(tok, "username")) {

--- a/src/shared/tests/Makefile
+++ b/src/shared/tests/Makefile
@@ -8,7 +8,7 @@ TOP = ../..
 CFLAGS_COMMON = -g -Wall -I$(TOP)/headers -I$(TOP) -I$(TOP)/analysisd
 
 # Headless tests run by `check`. Interactive helpers stay under `legacy_helpers`.
-AUTO_TEST_BINS = thread_pool_test queue_op_test string_test fim_sum_test
+AUTO_TEST_BINS = thread_pool_test queue_op_test string_test fim_sum_test ar_expect_test
 LEGACY_HELPER_BINS = prime_test hash_test merge_test ip_test
 
 .PHONY: maketest check clean legacy_helpers
@@ -28,6 +28,10 @@ string_test: string_test.c
 
 fim_sum_test: fim_sum_test.c ../fim_sum_op.c ../../headers/fim_sum_op.h
 	$(CC) $(CFLAGS_COMMON) -DARGV0=\"fim_sum_test\" -o $@ fim_sum_test.c ../fim_sum_op.c
+
+ar_expect_test: ar_expect_test.c ../ar_expect.c ../../headers/ar.h
+	$(CC) $(CFLAGS_COMMON) -DARGV0=\"ar_expect_test\" -o $@ \
+		ar_expect_test.c ../ar_expect.c
 
 # Interactive / argv-driven helpers (not part of automated check).
 legacy_helpers:

--- a/src/shared/tests/ar_expect_test.c
+++ b/src/shared/tests/ar_expect_test.c
@@ -1,4 +1,4 @@
-/* Unit tests for ar_parse_expect (#2104). */
+/* Unit tests for ar_parse_expect / ar_pick_username (#2104). */
 
 #include <stdio.h>
 #include <string.h>
@@ -12,6 +12,19 @@ static void expect_eq(const char *label, int got, int want)
         fprintf(stderr, "FAIL: %s: got 0%o want 0%o\n", label, got, want);
         failures++;
     }
+}
+
+static void expect_str(const char *label, const char *got, const char *want)
+{
+    if (got == want) {
+        return;
+    }
+    if (got && want && strcmp(got, want) == 0) {
+        return;
+    }
+    fprintf(stderr, "FAIL: %s: got '%s' want '%s'\n",
+            label, got ? got : "(null)", want ? want : "(null)");
+    failures++;
 }
 
 int main(void)
@@ -38,6 +51,14 @@ int main(void)
               ar_parse_expect(" user , srcip , filename "),
               USERNAME | SRCIP | FILENAME);
 
+    /* Whitespace-separated (no commas) — compatible with older substring match */
+    expect_eq("srcip username",
+              ar_parse_expect("srcip username"),
+              SRCIP | USERNAME);
+    expect_eq("srcip\tusername filename",
+              ar_parse_expect("srcip\tusername filename"),
+              SRCIP | USERNAME | FILENAME);
+
     /* Unknown tokens ignored; known ones still applied */
     expect_eq("srcip, hostname",
               ar_parse_expect("srcip, hostname"),
@@ -47,6 +68,22 @@ int main(void)
     expect_eq("userextra alone unknown",
               ar_parse_expect("userextra"),
               0);
+
+    /* ar_pick_username */
+    expect_str("prefer dstuser",
+               ar_pick_username("alice", "bob"), "alice");
+    expect_str("fallback srcuser",
+               ar_pick_username(NULL, "bob"), "bob");
+    expect_str("skip empty dstuser",
+               ar_pick_username("", "bob"), "bob");
+    expect_str("skip dash dstuser",
+               ar_pick_username("-", "bob"), "bob");
+    expect_str("skip dash srcuser",
+               ar_pick_username(NULL, "-"), NULL);
+    expect_str("both absent",
+               ar_pick_username(NULL, NULL), NULL);
+    expect_str("both dash",
+               ar_pick_username("-", "-"), NULL);
 
     if (failures) {
         fprintf(stderr, "FAIL: ar_expect_test (%d)\n", failures);

--- a/src/shared/tests/ar_expect_test.c
+++ b/src/shared/tests/ar_expect_test.c
@@ -1,0 +1,58 @@
+/* Unit tests for ar_parse_expect (#2104). */
+
+#include <stdio.h>
+#include <string.h>
+#include "ar.h"
+
+static int failures;
+
+static void expect_eq(const char *label, int got, int want)
+{
+    if (got != want) {
+        fprintf(stderr, "FAIL: %s: got 0%o want 0%o\n", label, got, want);
+        failures++;
+    }
+}
+
+int main(void)
+{
+    failures = 0;
+
+    expect_eq("null", ar_parse_expect(NULL), 0);
+    expect_eq("empty", ar_parse_expect(""), 0);
+    expect_eq("spaces", ar_parse_expect("   "), 0);
+
+    expect_eq("user", ar_parse_expect("user"), USERNAME);
+    expect_eq("username", ar_parse_expect("username"), USERNAME);
+    expect_eq("USER", ar_parse_expect("USER"), USERNAME);
+    expect_eq("srcip", ar_parse_expect("srcip"), SRCIP);
+    expect_eq("filename", ar_parse_expect("filename"), FILENAME);
+
+    expect_eq("srcip, username",
+              ar_parse_expect("srcip, username"),
+              SRCIP | USERNAME);
+    expect_eq("username,srcip",
+              ar_parse_expect("username,srcip"),
+              SRCIP | USERNAME);
+    expect_eq(" user , srcip , filename ",
+              ar_parse_expect(" user , srcip , filename "),
+              USERNAME | SRCIP | FILENAME);
+
+    /* Unknown tokens ignored; known ones still applied */
+    expect_eq("srcip, hostname",
+              ar_parse_expect("srcip, hostname"),
+              SRCIP);
+
+    /* "user" must not be a substring match of unrelated tokens */
+    expect_eq("userextra alone unknown",
+              ar_parse_expect("userextra"),
+              0);
+
+    if (failures) {
+        fprintf(stderr, "FAIL: ar_expect_test (%d)\n", failures);
+        return 1;
+    }
+
+    printf("PASS: ar_expect_test\n");
+    return 0;
+}


### PR DESCRIPTION
Parse expect as comma-separated tokens so documented "username" works alongside "user", fill the AR user argument from dstuser or srcuser, and add unit coverage for the expect bitmask helper.