### PR TITLE
Add per-agent FIM maintenance mode via agent_control.

### DIFF
--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -813,9 +813,16 @@ int print_agents(int print_status, int active_only, int csv_output, cJSON *json_
                         }
 
                         if (csv_output) {
-                            printf("%s,%s,%s,%s,\n", line_read, name, ip, print_agent_status(agt_status));
+                            syscheck_maint_info mi;
+                            const char *mtag = "";
+                            if (syscheck_maint_get(name, ip, &mi)) {
+                                mtag = syscheck_maint_list_tag(&mi);
+                            }
+                            printf("%s,%s,%s,%s,%s\n", line_read, name, ip,
+                                   print_agent_status(agt_status), mtag);
                         } else if (json_output) {
                             cJSON *json_agent = cJSON_CreateObject();
+                            syscheck_maint_info mi;
                           
                             if (!json_agent)
                                 return 0;
@@ -824,9 +831,25 @@ int print_agents(int print_status, int active_only, int csv_output, cJSON *json_
                             cJSON_AddStringToObject(json_agent, "name", name);
                             cJSON_AddStringToObject(json_agent, "ip", ip);
                             cJSON_AddStringToObject(json_agent, "status", print_agent_status(agt_status));
+                            if (syscheck_maint_get(name, ip, &mi)) {
+                                cJSON_AddStringToObject(json_agent, "fimMaintenance",
+                                                        syscheck_maint_list_tag(&mi));
+                            }
                             cJSON_AddItemToArray(json_output, json_agent);
                         } else {
-                            printf(PRINT_AGENT_STATUS, line_read, name, ip, print_agent_status(agt_status));
+                            syscheck_maint_info mi;
+                            const char *mtag = "";
+                            if (syscheck_maint_get(name, ip, &mi)) {
+                                mtag = syscheck_maint_list_tag(&mi);
+                            }
+                            if (mtag[0]) {
+                                printf("   ID: %s, Name: %s, IP: %s, %s, %s\n",
+                                       line_read, name, ip,
+                                       print_agent_status(agt_status), mtag);
+                            } else {
+                                printf(PRINT_AGENT_STATUS, line_read, name, ip,
+                                       print_agent_status(agt_status));
+                            }
                         }
                     } else {
                         printf(PRINT_AGENT, line_read, name, ip);

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -15,6 +15,7 @@
 #include "alerts/alerts.h"
 #include "decoder.h"
 #include "fim_sum_op.h"
+#include "read-agents.h"
 
 #ifdef SQLITE_ENABLED
 #include <sqlite3.h>
@@ -62,6 +63,8 @@ static __thread _sdb sdb;
  * workers serialize FILE* / hash-index mutations for the same agent.
  */
 static char sk_agent_cp[MAX_AGENTS + 1][1];
+static char sk_agent_maint[MAX_AGENTS + 1][1];
+static time_t sk_agent_maint_checked[MAX_AGENTS + 1];
 static char *sk_agent_ips[MAX_AGENTS + 1];
 static FILE *sk_agent_fps[MAX_AGENTS + 1];
 static OSHash *sk_agent_index[MAX_AGENTS + 1];
@@ -144,6 +147,8 @@ void SyscheckInit()
             sk_agent_fps[i] = NULL;
             sk_agent_index[i] = NULL;
             sk_agent_cp[i][0] = '0';
+            sk_agent_maint[i][0] = '?';
+            sk_agent_maint_checked[i] = 0;
             os_mutex_init(&sk_agent_mutex[i], NULL);
         }
         sk_shared_ready = 1;
@@ -155,6 +160,8 @@ void SyscheckInit()
         sk_agent_fps[i] = NULL;
         sk_agent_index[i] = NULL;
         sk_agent_cp[i][0] = '0';
+        sk_agent_maint[i][0] = '?';
+        sk_agent_maint_checked[i] = 0;
     }
 #endif
 
@@ -165,6 +172,75 @@ void SyscheckInit()
 /* Check if the db is completed for that specific agent */
 #define DB_IsCompleted(x) (sk_agent_cp[x][0] == '1')?1:0
 
+/* FIM maintenance mode: re-check marker every few seconds, log transitions. */
+static int DB_IsMaintenance(int agent_id, const char *location)
+{
+    time_t now = time(NULL);
+    int on;
+
+    if (sk_agent_maint_checked[agent_id] != 0 &&
+            (now - sk_agent_maint_checked[agent_id]) < 2 &&
+            sk_agent_maint[agent_id][0] != '?') {
+        return (sk_agent_maint[agent_id][0] == '1') ? 1 : 0;
+    }
+
+    on = syscheck_maint_is_enabled_location(location);
+    if (sk_agent_maint[agent_id][0] == '?' ||
+            (on && sk_agent_maint[agent_id][0] != '1') ||
+            (!on && sk_agent_maint[agent_id][0] == '1')) {
+        if (on || sk_agent_maint[agent_id][0] == '1') {
+            merror("%s: INFO: Syscheck maintenance mode %s for '%s'.",
+                   ARGV0, on ? "enabled" : "disabled", location);
+        }
+    }
+
+    sk_agent_maint[agent_id][0] = on ? '1' : '0';
+    sk_agent_maint_checked[agent_id] = now;
+    return on;
+}
+
+/* Quietly comment the old DB line and append the new checksum (new baseline). */
+static int DB_QuietUpdate(const char *f_name, const char *c_sum, Eventinfo *lf,
+                          FILE *fp, sk_db_entry *db_entry)
+{
+    char new_prefix[OS_MAXSTR + 1];
+    fpos_t new_pos;
+
+    if (fsetpos(fp, &sdb.init_pos) != 0) {
+        merror("%s: Error handling integrity database (fsetpos).", ARGV0);
+        lf->data = NULL;
+        return (0);
+    }
+    if (fputc('#', fp) == EOF) {
+        merror("%s: Error handling integrity database (fputc).", ARGV0);
+        lf->data = NULL;
+        return (0);
+    }
+    if (fseek(fp, 0, SEEK_END) != 0) {
+        merror("%s: Error handling integrity database (fseek).", ARGV0);
+        lf->data = NULL;
+        return (0);
+    }
+    if (fgetpos(fp, &new_pos) != 0) {
+        merror("%s: Error handling integrity database (fgetpos).", ARGV0);
+        lf->data = NULL;
+        return (0);
+    }
+    snprintf(new_prefix, sizeof(new_prefix), "+++%s", c_sum);
+    if (fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name) < 0 ||
+            fflush(fp) != 0) {
+        merror("%s: Error handling integrity database (write).", ARGV0);
+        lf->data = NULL;
+        return (0);
+    }
+    if (db_entry) {
+        db_entry->pos = new_pos;
+        memcpy(db_entry->prefix_sum, new_prefix, sizeof(db_entry->prefix_sum));
+        db_entry->prefix_sum[OS_MAXSTR] = '\0';
+    }
+    lf->data = NULL;
+    return (0);
+}
 static void __setcompleted(const char *agent)
 {
     FILE *fp;
@@ -440,7 +516,7 @@ static sk_db_entry *DB_GetOrCreateIndexEntry(int agent_id, const char *f_name)
  * 1 if a change alert was generated. */
 static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
                                 Eventinfo *lf, FILE *fp,
-                                sk_db_entry *db_entry)
+                                sk_db_entry *db_entry, int maintenance)
 {
     int p = 0;
     char *saved_sum = sdb.buf + 3;
@@ -454,44 +530,12 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
     /* Placeholder-only hash transitions (xxx <-> real) are not integrity
      * events; update the DB quietly so future scans stay clean (#1590/#1704). */
     if (!fim_sum_has_real_change(saved_sum, c_sum)) {
-        char new_prefix[OS_MAXSTR + 1];
-        fpos_t new_pos;
+        return DB_QuietUpdate(f_name, c_sum, lf, fp, db_entry);
+    }
 
-        if (fsetpos(fp, &sdb.init_pos) != 0) {
-            merror("%s: Error handling integrity database (fsetpos).", ARGV0);
-            lf->data = NULL;
-            return (0);
-        }
-        if (fputc('#', fp) == EOF) {
-            merror("%s: Error handling integrity database (fputc).", ARGV0);
-            lf->data = NULL;
-            return (0);
-        }
-        if (fseek(fp, 0, SEEK_END) != 0) {
-            merror("%s: Error handling integrity database (fseek).", ARGV0);
-            lf->data = NULL;
-            return (0);
-        }
-        if (fgetpos(fp, &new_pos) != 0) {
-            merror("%s: Error handling integrity database (fgetpos).", ARGV0);
-            lf->data = NULL;
-            return (0);
-        }
-        snprintf(new_prefix, sizeof(new_prefix), "+++%s", c_sum);
-        if (fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name) < 0 ||
-                fflush(fp) != 0) {
-            merror("%s: Error handling integrity database (write).", ARGV0);
-            lf->data = NULL;
-            return (0);
-        }
-        /* Publish index metadata only after a successful append. */
-        if (db_entry) {
-            db_entry->pos = new_pos;
-            memcpy(db_entry->prefix_sum, new_prefix, sizeof(db_entry->prefix_sum));
-            db_entry->prefix_sum[OS_MAXSTR] = '\0';
-        }
-        lf->data = NULL;
-        return (0);
+    /* During FIM maintenance, accept the new checksum as baseline with no alert. */
+    if (maintenance) {
+        return DB_QuietUpdate(f_name, c_sum, lf, fp, db_entry);
     }
 
 
@@ -827,7 +871,7 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
 
 /* Fall back to a linear scan when the hash index is unavailable or incomplete. */
 static int DB_SearchLinear(const char *f_name, const char *c_sum, Eventinfo *lf,
-                           FILE *fp, int agent_id)
+                           FILE *fp, int agent_id, int maintenance)
 {
     size_t sn_size;
     char *saved_name;
@@ -864,7 +908,8 @@ static int DB_SearchLinear(const char *f_name, const char *c_sum, Eventinfo *lf,
         }
 
         return DB_ProcessFoundEntry(f_name, c_sum, lf, fp,
-                                    DB_GetOrCreateIndexEntry(agent_id, f_name));
+                                    DB_GetOrCreateIndexEntry(agent_id, f_name),
+                                    maintenance);
     }
 
     return (-1);
@@ -875,6 +920,7 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
 {
     int agent_id;
     int result = 0;
+    int maintenance;
     FILE *fp;
 
     /* Expose filename variable for active response */
@@ -888,6 +934,8 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
         lf->data = NULL;
         return (0);
     }
+
+    maintenance = DB_IsMaintenance(agent_id, lf->location);
 
     DB_BuildIndex(agent_id, fp);
 
@@ -903,11 +951,13 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
             strncpy(sdb.buf, db_entry->prefix_sum, OS_MAXSTR);
             sdb.buf[OS_MAXSTR] = '\0';
             sdb.init_pos = db_entry->pos;
-            result = DB_ProcessFoundEntry(f_name, c_sum, lf, fp, db_entry);
+            result = DB_ProcessFoundEntry(f_name, c_sum, lf, fp, db_entry,
+                                          maintenance);
             goto out;
         }
 
-        linear_rc = DB_SearchLinear(f_name, c_sum, lf, fp, agent_id);
+        linear_rc = DB_SearchLinear(f_name, c_sum, lf, fp, agent_id,
+                                    maintenance);
         if (linear_rc >= 0) {
             result = linear_rc;
             goto out;
@@ -927,10 +977,10 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
     fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name);
     fflush(fp);
 
-    /* Alert if configured to notify on new files */
+    /* Alert if configured to notify on new files (skip during maintenance). */
     /* TODO: debugging this - Scott */
     /* if ((Config.syscheck_alert_new == 1) && (DB_IsCompleted(agent_id))) { */
-    if (Config.syscheck_alert_new == 1)  {
+    if ((Config.syscheck_alert_new == 1) && !maintenance)  {
         sdb.syscheck_dec->id = sdb.idn;
 
         char *newfilec_sum = NULL;

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -65,12 +65,14 @@ static __thread _sdb sdb;
 static char sk_agent_cp[MAX_AGENTS + 1][1];
 static char sk_agent_maint[MAX_AGENTS + 1][1];
 static time_t sk_agent_maint_checked[MAX_AGENTS + 1];
+static time_t sk_agent_maint_warn_last[MAX_AGENTS + 1];
 static char *sk_agent_ips[MAX_AGENTS + 1];
 static FILE *sk_agent_fps[MAX_AGENTS + 1];
 static OSHash *sk_agent_index[MAX_AGENTS + 1];
 #ifndef WIN32
 static pthread_mutex_t sk_table_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t sk_agent_mutex[MAX_AGENTS + 1];
+static pthread_mutex_t sk_maint_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int sk_shared_ready = 0;
 #endif
 
@@ -149,6 +151,7 @@ void SyscheckInit()
             sk_agent_cp[i][0] = '0';
             sk_agent_maint[i][0] = '?';
             sk_agent_maint_checked[i] = 0;
+            sk_agent_maint_warn_last[i] = 0;
             os_mutex_init(&sk_agent_mutex[i], NULL);
         }
         sk_shared_ready = 1;
@@ -162,6 +165,7 @@ void SyscheckInit()
         sk_agent_cp[i][0] = '0';
         sk_agent_maint[i][0] = '?';
         sk_agent_maint_checked[i] = 0;
+        sk_agent_maint_warn_last[i] = 0;
     }
 #endif
 
@@ -172,36 +176,64 @@ void SyscheckInit()
 /* Check if the db is completed for that specific agent */
 #define DB_IsCompleted(x) (sk_agent_cp[x][0] == '1')?1:0
 
-/* FIM maintenance mode: re-check marker every few seconds, log transitions. */
+/* FIM maintenance: cache "on" briefly; never trust cached "off" (enable edge). */
 static int DB_IsMaintenance(int agent_id, const char *location)
 {
     time_t now = time(NULL);
+    syscheck_maint_info info;
     int on;
+    char prev;
 
-    if (sk_agent_maint_checked[agent_id] != 0 &&
-            (now - sk_agent_maint_checked[agent_id]) < 2 &&
-            sk_agent_maint[agent_id][0] != '?') {
-        return (sk_agent_maint[agent_id][0] == '1') ? 1 : 0;
+#ifndef WIN32
+    os_mutex_lock(&sk_maint_mutex);
+#endif
+
+    prev = sk_agent_maint[agent_id][0];
+
+    /* Only skip disk I/O when we recently confirmed maintenance is ON. */
+    if (prev == '1' &&
+            sk_agent_maint_checked[agent_id] != 0 &&
+            (now - sk_agent_maint_checked[agent_id]) < 2) {
+#ifndef WIN32
+        os_mutex_unlock(&sk_maint_mutex);
+#endif
+        return 1;
     }
 
-    on = syscheck_maint_is_enabled_location(location);
-    if (sk_agent_maint[agent_id][0] == '?' ||
-            (on && sk_agent_maint[agent_id][0] != '1') ||
-            (!on && sk_agent_maint[agent_id][0] == '1')) {
-        if (on || sk_agent_maint[agent_id][0] == '1') {
+    on = syscheck_maint_get_location(location, &info) ? 1 : 0;
+
+    if (prev == '?' || (on && prev != '1') || (!on && prev == '1')) {
+        if (on || prev == '1') {
             merror("%s: INFO: Syscheck maintenance mode %s for '%s'.",
                    ARGV0, on ? "enabled" : "disabled", location);
         }
     }
 
+    if (on && info.enabled_at > 0 &&
+            (now - info.enabled_at) >= SYSCHECK_MAINT_WARN_AFTER) {
+        if (sk_agent_maint_warn_last[agent_id] == 0 ||
+                (now - sk_agent_maint_warn_last[agent_id]) >=
+                SYSCHECK_MAINT_WARN_INTERVAL) {
+            merror("%s: WARN: Syscheck maintenance mode still enabled for '%s' "
+                   "for %ld hours; FIM changes are silently accepted.",
+                   ARGV0, location,
+                   (long)((now - info.enabled_at) / 3600));
+            sk_agent_maint_warn_last[agent_id] = now;
+        }
+    }
+
     sk_agent_maint[agent_id][0] = on ? '1' : '0';
     sk_agent_maint_checked[agent_id] = now;
+
+#ifndef WIN32
+    os_mutex_unlock(&sk_maint_mutex);
+#endif
     return on;
 }
 
 /* Quietly comment the old DB line and append the new checksum (new baseline). */
 static int DB_QuietUpdate(const char *f_name, const char *c_sum, Eventinfo *lf,
-                          FILE *fp, sk_db_entry *db_entry)
+                          FILE *fp, sk_db_entry *db_entry, int log_maint)
 {
     char new_prefix[OS_MAXSTR + 1];
     fpos_t new_pos;
@@ -237,6 +269,12 @@ static int DB_QuietUpdate(const char *f_name, const char *c_sum, Eventinfo *lf,
         db_entry->pos = new_pos;
         memcpy(db_entry->prefix_sum, new_prefix, sizeof(db_entry->prefix_sum));
         db_entry->prefix_sum[OS_MAXSTR] = '\0';
+    }
+    if (log_maint && lf->location) {
+        syscheck_maint_log_accept(lf->location, "modify", f_name);
+        syscheck_maint_bump_silent_location(lf->location);
+        debug1("%s: Maintenance accept modify '%s' from '%s'.",
+               ARGV0, f_name, lf->location);
     }
     lf->data = NULL;
     return (0);
@@ -530,12 +568,12 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
     /* Placeholder-only hash transitions (xxx <-> real) are not integrity
      * events; update the DB quietly so future scans stay clean (#1590/#1704). */
     if (!fim_sum_has_real_change(saved_sum, c_sum)) {
-        return DB_QuietUpdate(f_name, c_sum, lf, fp, db_entry);
+        return DB_QuietUpdate(f_name, c_sum, lf, fp, db_entry, 0);
     }
 
     /* During FIM maintenance, accept the new checksum as baseline with no alert. */
     if (maintenance) {
-        return DB_QuietUpdate(f_name, c_sum, lf, fp, db_entry);
+        return DB_QuietUpdate(f_name, c_sum, lf, fp, db_entry, 1);
     }
 
 
@@ -977,10 +1015,20 @@ static int DB_Search(const char *f_name, const char *c_sum, Eventinfo *lf)
     fprintf(fp, "+++%s !%ld %s\n", c_sum, (long int)lf->time, f_name);
     fflush(fp);
 
+    if (maintenance) {
+        syscheck_maint_log_accept(lf->location, "new", f_name);
+        syscheck_maint_bump_silent_location(lf->location);
+        debug1("%s: Maintenance accept new '%s' from '%s'.",
+               ARGV0, f_name, lf->location);
+        lf->data = NULL;
+        result = 0;
+        goto out;
+    }
+
     /* Alert if configured to notify on new files (skip during maintenance). */
     /* TODO: debugging this - Scott */
     /* if ((Config.syscheck_alert_new == 1) && (DB_IsCompleted(agent_id))) { */
-    if ((Config.syscheck_alert_new == 1) && !maintenance)  {
+    if (Config.syscheck_alert_new == 1)  {
         sdb.syscheck_dec->id = sdb.idn;
 
         char *newfilec_sum = NULL;
@@ -1121,7 +1169,15 @@ int DecodeSyscheck(Eventinfo *lf)
          * a database completed message
          */
         if (strcmp(lf->log, HC_SK_DB_COMPLETED) == 0) {
+            syscheck_maint_info minfo;
+
             DB_SetCompleted(lf);
+            if (syscheck_maint_get_location(lf->location, &minfo) &&
+                    minfo.pending_end) {
+                syscheck_maint_clear_location(lf->location);
+                merror("%s: INFO: Syscheck maintenance mode ended for '%s' "
+                       "after baseline scan.", ARGV0, lf->location);
+            }
             return (0);
         }
 

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -267,8 +267,9 @@ static int DB_QuietUpdate(const char *f_name, const char *c_sum, Eventinfo *lf,
     }
     if (db_entry) {
         db_entry->pos = new_pos;
-        memcpy(db_entry->prefix_sum, new_prefix, sizeof(db_entry->prefix_sum));
-        db_entry->prefix_sum[OS_MAXSTR] = '\0';
+        strncpy(db_entry->prefix_sum, new_prefix,
+                sizeof(db_entry->prefix_sum) - 1);
+        db_entry->prefix_sum[sizeof(db_entry->prefix_sum) - 1] = '\0';
     }
     if (log_maint && lf->location) {
         syscheck_maint_log_accept(lf->location, "modify", f_name);

--- a/src/headers/defs.h
+++ b/src/headers/defs.h
@@ -190,6 +190,11 @@ http://www.ossec.net/main/license/\n"
 #define FWLOGS            "/logs/firewall"
 #define FWLOGS_DAILY      "/logs/firewall/firewall.log"
 #define EVENTSJSON_DAILY  "/logs/archives/archives.json"
+#define FIM_MAINT_LOG     "/logs/fim_maintenance.log"
+
+/* FIM maintenance: warn if left enabled this long (seconds) */
+#define SYSCHECK_MAINT_WARN_AFTER     86400
+#define SYSCHECK_MAINT_WARN_INTERVAL  3600
 
 /* Stats directories */
 #define STATWQUEUE  "/stats/weekly-average"

--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -10,6 +10,8 @@
 #ifndef __CRAGENT_H
 #define __CRAGENT_H
 
+#include <stddef.h>
+#include <time.h>
 #include <external/cJSON/cJSON.h>
 
 
@@ -40,16 +42,41 @@ int delete_syscheck(const char *sk_name, const char *sk_ip, int full_delete) __a
 /* FIM maintenance mode markers (manager-side, per agent).
  * While enabled, analysisd updates the syscheck DB without alerting.
  */
+typedef struct _syscheck_maint_info {
+    int enabled;
+    time_t enabled_at;
+    int pending_end;
+    unsigned long silent_updates;
+} syscheck_maint_info;
+
 void syscheck_maint_path(const char *sk_name, const char *sk_ip,
                          char *buf, size_t buflen) __attribute__((nonnull(3)));
 void syscheck_maint_path_from_location(const char *location,
                                        char *buf, size_t buflen)
     __attribute__((nonnull(1, 2)));
+int syscheck_maint_read_path(const char *path, syscheck_maint_info *info)
+    __attribute__((nonnull));
+int syscheck_maint_write_path(const char *path, const syscheck_maint_info *info)
+    __attribute__((nonnull));
+int syscheck_maint_get(const char *sk_name, const char *sk_ip,
+                       syscheck_maint_info *info) __attribute__((nonnull(3)));
+int syscheck_maint_get_location(const char *location, syscheck_maint_info *info)
+    __attribute__((nonnull));
 int syscheck_maint_is_enabled(const char *sk_name, const char *sk_ip);
 int syscheck_maint_is_enabled_location(const char *location)
     __attribute__((nonnull(1)));
 int syscheck_maint_enable(const char *sk_name, const char *sk_ip);
 int syscheck_maint_disable(const char *sk_name, const char *sk_ip);
+int syscheck_maint_set_pending_end(const char *sk_name, const char *sk_ip,
+                                   int pending);
+int syscheck_maint_clear_location(const char *location) __attribute__((nonnull));
+int syscheck_maint_bump_silent_location(const char *location)
+    __attribute__((nonnull));
+void syscheck_maint_log_accept(const char *location, const char *kind,
+                               const char *path) __attribute__((nonnull));
+/* Returns "" / "Maint" / "Maint(pending-end)" for list output. */
+const char *syscheck_maint_list_tag(const syscheck_maint_info *info)
+    __attribute__((nonnull));
 
 /* Delete rootcheck db */
 int delete_rootcheck(const char *sk_name, const char *sk_ip, int full_delete) __attribute__((nonnull));

--- a/src/headers/read-agents.h
+++ b/src/headers/read-agents.h
@@ -37,6 +37,20 @@ int print_rootcheck(const char *sk_name, const char *sk_ip, const char *fname, i
 /* Delete syscheck db */
 int delete_syscheck(const char *sk_name, const char *sk_ip, int full_delete) __attribute__((nonnull));
 
+/* FIM maintenance mode markers (manager-side, per agent).
+ * While enabled, analysisd updates the syscheck DB without alerting.
+ */
+void syscheck_maint_path(const char *sk_name, const char *sk_ip,
+                         char *buf, size_t buflen) __attribute__((nonnull(3)));
+void syscheck_maint_path_from_location(const char *location,
+                                       char *buf, size_t buflen)
+    __attribute__((nonnull(1, 2)));
+int syscheck_maint_is_enabled(const char *sk_name, const char *sk_ip);
+int syscheck_maint_is_enabled_location(const char *location)
+    __attribute__((nonnull(1)));
+int syscheck_maint_enable(const char *sk_name, const char *sk_ip);
+int syscheck_maint_disable(const char *sk_name, const char *sk_ip);
+
 /* Delete rootcheck db */
 int delete_rootcheck(const char *sk_name, const char *sk_ip, int full_delete) __attribute__((nonnull));
 

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -775,37 +775,115 @@ void syscheck_maint_path_from_location(const char *location,
     snprintf(buf, buflen, "%s/.%s.maint", SYSCHECK_DIR, base);
 }
 
-int syscheck_maint_is_enabled(const char *sk_name, const char *sk_ip)
+int syscheck_maint_read_path(const char *path, syscheck_maint_info *info)
+{
+    FILE *fp;
+    char line[256];
+
+    memset(info, 0, sizeof(*info));
+
+    if (access(path, F_OK) != 0) {
+        return (0);
+    }
+
+    info->enabled = 1;
+    info->enabled_at = time(NULL); /* legacy markers lack metadata */
+
+    fp = fopen(path, "r");
+    if (!fp) {
+        return (1);
+    }
+
+    while (fgets(line, sizeof(line), fp) != NULL) {
+        char *nl = strchr(line, '\n');
+        if (nl) {
+            *nl = '\0';
+        }
+        if (strncmp(line, "enabled_at=", 11) == 0) {
+            info->enabled_at = (time_t)strtoul(line + 11, NULL, 10);
+        } else if (strncmp(line, "pending_end=", 12) == 0) {
+            info->pending_end = atoi(line + 12) ? 1 : 0;
+        } else if (strncmp(line, "silent_updates=", 15) == 0) {
+            info->silent_updates = strtoul(line + 15, NULL, 10);
+        }
+    }
+
+    fclose(fp);
+    return (1);
+}
+
+int syscheck_maint_write_path(const char *path, const syscheck_maint_info *info)
+{
+    FILE *fp;
+
+    fp = fopen(path, "w");
+    if (!fp) {
+        merror("%s: ERROR: Cannot write %s: %s", __local_name, path,
+               strerror(errno));
+        return (0);
+    }
+
+    fprintf(fp, "#!maint\n");
+    fprintf(fp, "enabled_at=%ld\n", (long)info->enabled_at);
+    fprintf(fp, "pending_end=%d\n", info->pending_end ? 1 : 0);
+    fprintf(fp, "silent_updates=%lu\n", info->silent_updates);
+    fclose(fp);
+    return (1);
+}
+
+int syscheck_maint_get(const char *sk_name, const char *sk_ip,
+                       syscheck_maint_info *info)
 {
     char path[OS_FLSIZE + 1];
 
     syscheck_maint_path(sk_name, sk_ip, path, sizeof(path));
-    return (access(path, F_OK) == 0) ? 1 : 0;
+    return syscheck_maint_read_path(path, info);
 }
 
-int syscheck_maint_is_enabled_location(const char *location)
+int syscheck_maint_get_location(const char *location, syscheck_maint_info *info)
 {
     char path[OS_FLSIZE + 1];
 
     syscheck_maint_path_from_location(location, path, sizeof(path));
-    return (access(path, F_OK) == 0) ? 1 : 0;
+    return syscheck_maint_read_path(path, info);
+}
+
+int syscheck_maint_is_enabled(const char *sk_name, const char *sk_ip)
+{
+    syscheck_maint_info info;
+
+    return syscheck_maint_get(sk_name, sk_ip, &info) ? 1 : 0;
+}
+
+int syscheck_maint_is_enabled_location(const char *location)
+{
+    syscheck_maint_info info;
+
+    return syscheck_maint_get_location(location, &info) ? 1 : 0;
 }
 
 int syscheck_maint_enable(const char *sk_name, const char *sk_ip)
 {
-    FILE *fp;
     char path[OS_FLSIZE + 1];
+    syscheck_maint_info info;
 
     syscheck_maint_path(sk_name, sk_ip, path, sizeof(path));
-    fp = fopen(path, "w");
-    if (!fp) {
-        merror("%s: ERROR: Cannot create %s: %s", __local_name, path,
-               strerror(errno));
-        return (0);
+    memset(&info, 0, sizeof(info));
+    info.enabled = 1;
+    info.enabled_at = time(NULL);
+    info.pending_end = 0;
+    info.silent_updates = 0;
+    /* Preserve silent_updates if re-enabling an existing marker. */
+    {
+        syscheck_maint_info old;
+        if (syscheck_maint_read_path(path, &old)) {
+            info.silent_updates = old.silent_updates;
+            if (old.enabled_at > 0) {
+                info.enabled_at = old.enabled_at;
+            }
+        }
     }
-    fprintf(fp, "#!maint\n");
-    fclose(fp);
-    return (1);
+    return syscheck_maint_write_path(path, &info);
 }
 
 int syscheck_maint_disable(const char *sk_name, const char *sk_ip)
@@ -819,6 +897,84 @@ int syscheck_maint_disable(const char *sk_name, const char *sk_ip)
         return (0);
     }
     return (1);
+}
+
+int syscheck_maint_set_pending_end(const char *sk_name, const char *sk_ip,
+                                   int pending)
+{
+    char path[OS_FLSIZE + 1];
+    syscheck_maint_info info;
+
+    syscheck_maint_path(sk_name, sk_ip, path, sizeof(path));
+    if (!syscheck_maint_read_path(path, &info)) {
+        memset(&info, 0, sizeof(info));
+        info.enabled = 1;
+        info.enabled_at = time(NULL);
+    }
+    info.pending_end = pending ? 1 : 0;
+    return syscheck_maint_write_path(path, &info);
+}
+
+int syscheck_maint_clear_location(const char *location)
+{
+    char path[OS_FLSIZE + 1];
+
+    syscheck_maint_path_from_location(location, path, sizeof(path));
+    if (unlink(path) != 0 && errno != ENOENT) {
+        merror("%s: ERROR: Cannot delete %s: %s", __local_name, path,
+               strerror(errno));
+        return (0);
+    }
+    return (1);
+}
+
+int syscheck_maint_bump_silent_location(const char *location)
+{
+    char path[OS_FLSIZE + 1];
+    syscheck_maint_info info;
+
+    syscheck_maint_path_from_location(location, path, sizeof(path));
+    if (!syscheck_maint_read_path(path, &info)) {
+        return (0);
+    }
+    info.silent_updates++;
+    return syscheck_maint_write_path(path, &info);
+}
+
+void syscheck_maint_log_accept(const char *location, const char *kind,
+                               const char *fpath)
+{
+    FILE *fp;
+    time_t now = time(NULL);
+    char tbuf[64];
+    struct tm *tm_s;
+
+    tm_s = localtime(&now);
+    if (tm_s) {
+        strftime(tbuf, sizeof(tbuf), "%F %T", tm_s);
+    } else {
+        snprintf(tbuf, sizeof(tbuf), "%ld", (long)now);
+    }
+
+    fp = fopen(FIM_MAINT_LOG, "a");
+    if (!fp) {
+        debug1("%s: Unable to open %s: %s", __local_name, FIM_MAINT_LOG,
+               strerror(errno));
+        return;
+    }
+    fprintf(fp, "%s %s %s %s\n", tbuf, location, kind, fpath);
+    fclose(fp);
+}
+
+const char *syscheck_maint_list_tag(const syscheck_maint_info *info)
+{
+    if (!info->enabled) {
+        return "";
+    }
+    if (info->pending_end) {
+        return "Maint(pending-end)";
+    }
+    return "Maint";
 }
 
 /* Delete syscheck db */

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -736,6 +736,91 @@ int print_rootcheck(const char *sk_name, const char *sk_ip, const char *fname,
 
 #endif
 
+/* Build FIM maintenance marker path for local (sk_name NULL) or agent. */
+void syscheck_maint_path(const char *sk_name, const char *sk_ip,
+                         char *buf, size_t buflen)
+{
+    if (!sk_name) {
+        snprintf(buf, buflen, "%s/.syscheck.maint", SYSCHECK_DIR);
+    } else if (!sk_ip) {
+        snprintf(buf, buflen, "%s/.%s.maint", SYSCHECK_DIR, sk_name);
+    } else {
+        snprintf(buf, buflen, "%s/.(%s) %s.maint", SYSCHECK_DIR, sk_name, sk_ip);
+    }
+}
+
+/* Map analysisd lf->location ("syscheck", "(name) ip->syscheck", …) to marker. */
+void syscheck_maint_path_from_location(const char *location,
+                                       char *buf, size_t buflen)
+{
+    char base[OS_FLSIZE + 1];
+    char *arrow;
+
+    strncpy(base, location, OS_FLSIZE);
+    base[OS_FLSIZE] = '\0';
+
+    arrow = strstr(base, "->");
+    if (arrow) {
+        *arrow = '\0';
+        snprintf(buf, buflen, "%s/.%s.maint", SYSCHECK_DIR, base);
+        return;
+    }
+
+    if (strcmp(base, "syscheck") == 0 ||
+            strcmp(base, "syscheck-registry") == 0) {
+        snprintf(buf, buflen, "%s/.syscheck.maint", SYSCHECK_DIR);
+        return;
+    }
+
+    snprintf(buf, buflen, "%s/.%s.maint", SYSCHECK_DIR, base);
+}
+
+int syscheck_maint_is_enabled(const char *sk_name, const char *sk_ip)
+{
+    char path[OS_FLSIZE + 1];
+
+    syscheck_maint_path(sk_name, sk_ip, path, sizeof(path));
+    return (access(path, F_OK) == 0) ? 1 : 0;
+}
+
+int syscheck_maint_is_enabled_location(const char *location)
+{
+    char path[OS_FLSIZE + 1];
+
+    syscheck_maint_path_from_location(location, path, sizeof(path));
+    return (access(path, F_OK) == 0) ? 1 : 0;
+}
+
+int syscheck_maint_enable(const char *sk_name, const char *sk_ip)
+{
+    FILE *fp;
+    char path[OS_FLSIZE + 1];
+
+    syscheck_maint_path(sk_name, sk_ip, path, sizeof(path));
+    fp = fopen(path, "w");
+    if (!fp) {
+        merror("%s: ERROR: Cannot create %s: %s", __local_name, path,
+               strerror(errno));
+        return (0);
+    }
+    fprintf(fp, "#!maint\n");
+    fclose(fp);
+    return (1);
+}
+
+int syscheck_maint_disable(const char *sk_name, const char *sk_ip)
+{
+    char path[OS_FLSIZE + 1];
+
+    syscheck_maint_path(sk_name, sk_ip, path, sizeof(path));
+    if (unlink(path) != 0 && errno != ENOENT) {
+        merror("%s: ERROR: Cannot delete %s: %s", __local_name, path,
+               strerror(errno));
+        return (0);
+    }
+    return (1);
+}
+
 /* Delete syscheck db */
 int delete_syscheck(const char *sk_name, const char *sk_ip, int full_delete)
 {
@@ -773,6 +858,13 @@ int delete_syscheck(const char *sk_name, const char *sk_ip, int full_delete)
     }
     if ((unlink(tmp_file)) < 0) {
         merror("%s: ERROR: Cannot unlink %s: %s", __local_name, tmp_file, strerror(errno));
+    }
+
+    /* Delete FIM maintenance marker */
+    syscheck_maint_path(sk_name, sk_ip, tmp_file, sizeof(tmp_file));
+    if ((unlink(tmp_file)) < 0 && errno != ENOENT) {
+        merror("%s: ERROR: Cannot unlink %s: %s", __local_name, tmp_file,
+               strerror(errno));
     }
 
     /* Delete registry entries */

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -779,15 +779,17 @@ int syscheck_maint_read_path(const char *path, syscheck_maint_info *info)
 {
     FILE *fp;
     char line[256];
+    struct stat st;
 
     memset(info, 0, sizeof(*info));
 
-    if (access(path, F_OK) != 0) {
+    if (stat(path, &st) != 0) {
         return (0);
     }
 
     info->enabled = 1;
-    info->enabled_at = time(NULL); /* legacy markers lack metadata */
+    /* Legacy markers (#!maint only) have no enabled_at; use mtime. */
+    info->enabled_at = st.st_mtime;
 
     fp = fopen(path, "r");
     if (!fp) {
@@ -907,9 +909,7 @@ int syscheck_maint_set_pending_end(const char *sk_name, const char *sk_ip,
 
     syscheck_maint_path(sk_name, sk_ip, path, sizeof(path));
     if (!syscheck_maint_read_path(path, &info)) {
-        memset(&info, 0, sizeof(info));
-        info.enabled = 1;
-        info.enabled_at = time(NULL);
+        return (0);
     }
     info.pending_end = pending ? 1 : 0;
     return syscheck_maint_write_path(path, &info);

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -28,13 +28,14 @@ static void helpmsg(int status)
     printf("\t-R <id>     Restarts agent.\n");
     printf("\t-r -a       Runs the integrity/rootkit checking on all agents now.\n");
     printf("\t-r          Runs the integrity/rootkit checking on one agent now.\n\n");
+    printf("\t-M <action> FIM maintenance mode: enable|disable|status (use with -u).\n");
     printf("\t-b <ip>     Blocks the specified ip address.\n");
     printf("\t-f <ar>     Used with -b, specifies which response to run.\n");
     printf("\t-L          List available active responses.\n");
     printf("\t-m          Show the limit of agents that can be added.\n");
     printf("\t-s          Changes the output to CSV (comma delimited).\n");
     printf("\t-j          Changes the output to JSON .\n");
-    printf("\t-u <id>     Used with -r and -b Specifies the agent to use.\n");
+    printf("\t-u <id>     Used with -r, -b, and -M. Specifies the agent to use.\n");
     exit(status);
 }
 
@@ -65,6 +66,7 @@ int main(int argc, char **argv)
     int end_time = 0;
     int restart_agent = 0;
     int show_max_agents = 0;
+    const char *maint_action = NULL;
 
     char shost[512];
 
@@ -78,7 +80,7 @@ int main(int argc, char **argv)
         helpmsg(1);
     }
 
-    while ((c = getopt(argc, argv, "VehdlLcsjarmu:i:b:f:R:")) != -1) {
+    while ((c = getopt(argc, argv, "VehdlLcsjarmu:i:b:f:R:M:")) != -1) {
         switch (c) {
             case 'V':
                 print_version();
@@ -103,6 +105,13 @@ int main(int argc, char **argv)
                 break;
             case 'm':
                 show_max_agents++;
+                break;
+            case 'M':
+                if (!optarg) {
+                    merror("%s: -M needs enable|disable|status", ARGV0);
+                    helpmsg(1);
+                }
+                maint_action = optarg;
                 break;
             case 's':
                 csv_output = 1;
@@ -416,6 +425,16 @@ int main(int argc, char **argv)
                 printf("   Syscheck last started  at: %s\n", agt_info->syscheck_time);
                 printf("   Rootcheck last started at: %s\n", agt_info->rootcheck_time);
             }
+            if (agt_id != -1) {
+                printf("   FIM maintenance mode:  %s\n",
+                       syscheck_maint_is_enabled(keys.keyentries[agt_id]->name,
+                                                 keys.keyentries[agt_id]->ip->ip)
+                       ? "enabled" : "disabled");
+            } else {
+                printf("   FIM maintenance mode:  %s\n",
+                       syscheck_maint_is_enabled(NULL, NULL)
+                       ? "enabled" : "disabled");
+            }
         }else if(json_output){
                 cJSON_AddStringToObject(response, "os", agt_info->os);
                 cJSON_AddStringToObject(response, "version", agt_info->version);
@@ -425,6 +444,13 @@ int main(int argc, char **argv)
                 cJSON_AddStringToObject(response, "syscheckEndTime", end_time ? agt_info->syscheck_endtime : "");
                 cJSON_AddStringToObject(response, "rootcheckTime", agt_info->rootcheck_time);
                 cJSON_AddStringToObject(response, "rootcheckEndTime", end_time ? agt_info->rootcheck_endtime : "");
+                cJSON_AddStringToObject(response, "fimMaintenance",
+                    (agt_id != -1)
+                        ? (syscheck_maint_is_enabled(keys.keyentries[agt_id]->name,
+                                                     keys.keyentries[agt_id]->ip->ip)
+                           ? "enabled" : "disabled")
+                        : (syscheck_maint_is_enabled(NULL, NULL)
+                           ? "enabled" : "disabled"));
 
         } else {
             printf("%s,%s,%s,%s,%s,\n",
@@ -439,6 +465,87 @@ int main(int argc, char **argv)
             cJSON_AddItemToObject(root, "response", response);
             printf("%s",cJSON_PrintUnformatted(root));
             cJSON_Delete(root);
+        }
+        exit(0);
+    }
+
+    /* FIM maintenance mode */
+    if (maint_action) {
+        const char *sk_name = NULL;
+        const char *sk_ip = NULL;
+        int enabled;
+        int ok = 1;
+
+        if (!agent_id) {
+            if (json_output) {
+                cJSON_AddNumberToObject(root, "error", 44);
+                cJSON_AddStringToObject(root, "description",
+                                        "-M requires -u <agent_id>");
+                printf("%s", cJSON_PrintUnformatted(root));
+                cJSON_Delete(root);
+            } else {
+                printf("\n** -M requires -u <agent_id>.\n");
+            }
+            exit(1);
+        }
+
+        if (strcmp(agent_id, "000") != 0) {
+            sk_name = keys.keyentries[agt_id]->name;
+            sk_ip = keys.keyentries[agt_id]->ip->ip;
+        }
+
+        if (strcmp(maint_action, "enable") == 0) {
+            ok = syscheck_maint_enable(sk_name, sk_ip);
+            enabled = 1;
+        } else if (strcmp(maint_action, "disable") == 0) {
+            ok = syscheck_maint_disable(sk_name, sk_ip);
+            enabled = 0;
+        } else if (strcmp(maint_action, "status") == 0) {
+            enabled = syscheck_maint_is_enabled(sk_name, sk_ip);
+            ok = 1;
+        } else {
+            if (json_output) {
+                cJSON_AddNumberToObject(root, "error", 45);
+                cJSON_AddStringToObject(root, "description",
+                                        "Invalid -M action (enable|disable|status)");
+                printf("%s", cJSON_PrintUnformatted(root));
+                cJSON_Delete(root);
+            } else {
+                printf("\n** Invalid -M action '%s' (use enable|disable|status).\n",
+                       maint_action);
+            }
+            exit(1);
+        }
+
+        if (!ok) {
+            if (json_output) {
+                cJSON_AddNumberToObject(root, "error", 46);
+                cJSON_AddStringToObject(root, "description",
+                                        "Unable to update FIM maintenance mode");
+                printf("%s", cJSON_PrintUnformatted(root));
+                cJSON_Delete(root);
+            } else {
+                printf("\n** Unable to update FIM maintenance mode.\n");
+            }
+            exit(1);
+        }
+
+        if (json_output) {
+            cJSON *response = cJSON_CreateObject();
+            cJSON_AddNumberToObject(root, "error", 0);
+            cJSON_AddStringToObject(response, "agent", agent_id);
+            cJSON_AddStringToObject(response, "fimMaintenance",
+                                    enabled ? "enabled" : "disabled");
+            cJSON_AddStringToObject(response, "action", maint_action);
+            cJSON_AddItemToObject(root, "response", response);
+            printf("%s", cJSON_PrintUnformatted(root));
+            cJSON_Delete(root);
+        } else if (strcmp(maint_action, "status") == 0) {
+            printf("\nOSSEC HIDS %s: Agent %s FIM maintenance mode: %s\n",
+                   ARGV0, agent_id, enabled ? "enabled" : "disabled");
+        } else {
+            printf("\nOSSEC HIDS %s: FIM maintenance mode %s for agent %s.\n",
+                   ARGV0, enabled ? "enabled" : "disabled", agent_id);
         }
         exit(0);
     }

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
                 break;
             case 'M':
                 if (!optarg) {
-                    merror("%s: -M needs enable|disable|status", ARGV0);
+                    merror("%s: -M needs enable|disable|status|end", ARGV0);
                     helpmsg(1);
                 }
                 maint_action = optarg;
@@ -530,7 +530,11 @@ int main(int argc, char **argv)
         const char *sk_ip = NULL;
         int enabled = 0;
         int ok = 1;
+        int end_delivery_failed = 0;
+        int end_we_enabled = 0;
         syscheck_maint_info mi;
+
+        memset(&mi, 0, sizeof(mi));
 
         if (!agent_id) {
             if (json_output) {
@@ -552,7 +556,7 @@ int main(int argc, char **argv)
 
         if (strcmp(maint_action, "enable") == 0) {
             ok = syscheck_maint_enable(sk_name, sk_ip);
-            enabled = 1;
+            enabled = ok ? 1 : 0;
         } else if (strcmp(maint_action, "disable") == 0) {
             ok = syscheck_maint_disable(sk_name, sk_ip);
             enabled = 0;
@@ -567,24 +571,39 @@ int main(int argc, char **argv)
             /* Enable if needed, mark pending_end, force a scan. */
             if (!syscheck_maint_get(sk_name, sk_ip, &mi)) {
                 ok = syscheck_maint_enable(sk_name, sk_ip);
+                end_we_enabled = ok ? 1 : 0;
             }
             if (ok) {
                 ok = syscheck_maint_set_pending_end(sk_name, sk_ip, 1);
             }
             if (ok) {
                 if (strcmp(agent_id, "000") == 0) {
-                    os_set_restart_syscheck();
+                    if (!os_set_restart_syscheck()) {
+                        ok = 0;
+                        end_delivery_failed = 1;
+                    }
                 } else {
                     arq = connect_to_remoted();
                     if (arq < 0) {
                         ok = 0;
+                        end_delivery_failed = 1;
                     } else if (send_msg_to_agent(arq, HC_SK_RESTART,
                                                 agent_id, NULL) != 0) {
                         ok = 0;
+                        end_delivery_failed = 1;
                     }
                 }
             }
-            enabled = 1;
+            if (!ok) {
+                /* Roll back: clear pending_end; drop marker only if we created it. */
+                if (end_delivery_failed) {
+                    syscheck_maint_set_pending_end(sk_name, sk_ip, 0);
+                }
+                if (end_we_enabled) {
+                    syscheck_maint_disable(sk_name, sk_ip);
+                }
+            }
+            enabled = ok ? 1 : 0;
         } else {
             if (json_output) {
                 cJSON_AddNumberToObject(root, "error", 45);
@@ -602,18 +621,29 @@ int main(int argc, char **argv)
 
         if (!ok) {
             if (json_output) {
-                cJSON_AddNumberToObject(root, "error", 46);
+                cJSON_AddNumberToObject(root, "error",
+                                        end_delivery_failed ? 47 : 46);
                 cJSON_AddStringToObject(root, "description",
-                                        "Unable to update FIM maintenance mode");
+                                        end_delivery_failed
+                                        ? "Unable to deliver syscheck restart for -M end"
+                                        : "Unable to update FIM maintenance mode");
                 printf("%s", cJSON_PrintUnformatted(root));
                 cJSON_Delete(root);
+            } else if (end_delivery_failed) {
+                printf("\n** Unable to deliver syscheck restart for -M end "
+                       "(maintenance pending_end rolled back).\n");
             } else {
                 printf("\n** Unable to update FIM maintenance mode.\n");
             }
             exit(1);
         }
 
-        syscheck_maint_get(sk_name, sk_ip, &mi);
+        if (!syscheck_maint_get(sk_name, sk_ip, &mi)) {
+            enabled = 0;
+            memset(&mi, 0, sizeof(mi));
+        } else {
+            enabled = 1;
+        }
 
         if (json_output) {
             cJSON *response = cJSON_CreateObject();

--- a/src/util/agent_control.c
+++ b/src/util/agent_control.c
@@ -28,7 +28,8 @@ static void helpmsg(int status)
     printf("\t-R <id>     Restarts agent.\n");
     printf("\t-r -a       Runs the integrity/rootkit checking on all agents now.\n");
     printf("\t-r          Runs the integrity/rootkit checking on one agent now.\n\n");
-    printf("\t-M <action> FIM maintenance mode: enable|disable|status (use with -u).\n");
+    printf("\t-M <action> FIM maintenance: enable|disable|status|end (use with -u).\n");
+    printf("\t            Prefer 'end' after patching (scan then clear). 'disable' is immediate.\n");
     printf("\t-b <ip>     Blocks the specified ip address.\n");
     printf("\t-f <ar>     Used with -b, specifies which response to run.\n");
     printf("\t-L          List available active responses.\n");
@@ -259,13 +260,25 @@ int main(int argc, char **argv)
         cJSON *agents = NULL;
         
         if (!csv_output && !json_output) {
+            syscheck_maint_info mi000;
+            const char *mtag = "";
+
+            if (syscheck_maint_get(NULL, NULL, &mi000)) {
+                mtag = syscheck_maint_list_tag(&mi000);
+            }
             printf("\nOSSEC HIDS %s. List of available agents:",
                    ARGV0);
-            printf("\n   ID: 000, Name: %s (server), IP: 127.0.0.1, Active/Local\n",
-                   shost);
+            if (mtag[0]) {
+                printf("\n   ID: 000, Name: %s (server), IP: 127.0.0.1, Active/Local, %s\n",
+                       shost, mtag);
+            } else {
+                printf("\n   ID: 000, Name: %s (server), IP: 127.0.0.1, Active/Local\n",
+                       shost);
+            }
         } else if(json_output){
                 cJSON *first = cJSON_CreateObject();
                 agents = cJSON_CreateArray();
+                syscheck_maint_info mi000;
                 
                 if (!(first && root && agents))
                     exit(1);
@@ -277,9 +290,18 @@ int main(int argc, char **argv)
                 cJSON_AddStringToObject(first, "name", shost);
                 cJSON_AddStringToObject(first, "ip", "127.0.0.1");
                 cJSON_AddStringToObject(first, "status", "Active");
+                if (syscheck_maint_get(NULL, NULL, &mi000)) {
+                    cJSON_AddStringToObject(first, "fimMaintenance",
+                                            syscheck_maint_list_tag(&mi000));
+                }
                 cJSON_AddItemToArray(agents, first);
         } else {
-            printf("000,%s (server),127.0.0.1,Active/Local,\n", shost);
+            syscheck_maint_info mi000;
+            const char *mtag = "";
+            if (syscheck_maint_get(NULL, NULL, &mi000)) {
+                mtag = syscheck_maint_list_tag(&mi000);
+            }
+            printf("000,%s (server),127.0.0.1,Active/Local,%s\n", shost, mtag);
         }
         
         print_agents(1, active_only, csv_output, agents);
@@ -426,14 +448,34 @@ int main(int argc, char **argv)
                 printf("   Rootcheck last started at: %s\n", agt_info->rootcheck_time);
             }
             if (agt_id != -1) {
-                printf("   FIM maintenance mode:  %s\n",
-                       syscheck_maint_is_enabled(keys.keyentries[agt_id]->name,
-                                                 keys.keyentries[agt_id]->ip->ip)
-                       ? "enabled" : "disabled");
+                syscheck_maint_info mi;
+                if (syscheck_maint_get(keys.keyentries[agt_id]->name,
+                                       keys.keyentries[agt_id]->ip->ip, &mi)) {
+                    printf("   FIM maintenance mode:  %s",
+                           syscheck_maint_list_tag(&mi));
+                    if (mi.pending_end) {
+                        printf(" (pending end)");
+                    }
+                    printf("\n");
+                    printf("   Maint enabled since:   %ld (%ld hours ago)\n",
+                           (long)mi.enabled_at,
+                           (long)((time(NULL) - mi.enabled_at) / 3600));
+                    printf("   Silent FIM accepts:    %lu\n", mi.silent_updates);
+                } else {
+                    printf("   FIM maintenance mode:  disabled\n");
+                }
             } else {
-                printf("   FIM maintenance mode:  %s\n",
-                       syscheck_maint_is_enabled(NULL, NULL)
-                       ? "enabled" : "disabled");
+                syscheck_maint_info mi;
+                if (syscheck_maint_get(NULL, NULL, &mi)) {
+                    printf("   FIM maintenance mode:  %s\n",
+                           syscheck_maint_list_tag(&mi));
+                    printf("   Maint enabled since:   %ld (%ld hours ago)\n",
+                           (long)mi.enabled_at,
+                           (long)((time(NULL) - mi.enabled_at) / 3600));
+                    printf("   Silent FIM accepts:    %lu\n", mi.silent_updates);
+                } else {
+                    printf("   FIM maintenance mode:  disabled\n");
+                }
             }
         }else if(json_output){
                 cJSON_AddStringToObject(response, "os", agt_info->os);
@@ -444,13 +486,26 @@ int main(int argc, char **argv)
                 cJSON_AddStringToObject(response, "syscheckEndTime", end_time ? agt_info->syscheck_endtime : "");
                 cJSON_AddStringToObject(response, "rootcheckTime", agt_info->rootcheck_time);
                 cJSON_AddStringToObject(response, "rootcheckEndTime", end_time ? agt_info->rootcheck_endtime : "");
-                cJSON_AddStringToObject(response, "fimMaintenance",
-                    (agt_id != -1)
-                        ? (syscheck_maint_is_enabled(keys.keyentries[agt_id]->name,
-                                                     keys.keyentries[agt_id]->ip->ip)
-                           ? "enabled" : "disabled")
-                        : (syscheck_maint_is_enabled(NULL, NULL)
-                           ? "enabled" : "disabled"));
+                {
+                    syscheck_maint_info mi;
+                    int got = (agt_id != -1)
+                        ? syscheck_maint_get(keys.keyentries[agt_id]->name,
+                                             keys.keyentries[agt_id]->ip->ip, &mi)
+                        : syscheck_maint_get(NULL, NULL, &mi);
+                    if (got) {
+                        cJSON_AddStringToObject(response, "fimMaintenance",
+                                                syscheck_maint_list_tag(&mi));
+                        cJSON_AddNumberToObject(response, "fimMaintEnabledAt",
+                                                (double)mi.enabled_at);
+                        cJSON_AddNumberToObject(response, "fimMaintSilentUpdates",
+                                                (double)mi.silent_updates);
+                        cJSON_AddBoolToObject(response, "fimMaintPendingEnd",
+                                              mi.pending_end);
+                    } else {
+                        cJSON_AddStringToObject(response, "fimMaintenance",
+                                                "disabled");
+                    }
+                }
 
         } else {
             printf("%s,%s,%s,%s,%s,\n",
@@ -473,8 +528,9 @@ int main(int argc, char **argv)
     if (maint_action) {
         const char *sk_name = NULL;
         const char *sk_ip = NULL;
-        int enabled;
+        int enabled = 0;
         int ok = 1;
+        syscheck_maint_info mi;
 
         if (!agent_id) {
             if (json_output) {
@@ -500,18 +556,45 @@ int main(int argc, char **argv)
         } else if (strcmp(maint_action, "disable") == 0) {
             ok = syscheck_maint_disable(sk_name, sk_ip);
             enabled = 0;
+            if (ok && !json_output) {
+                printf("\n** Warning: immediate disable does not wait for a "
+                       "syscheck scan. Prefer '-M end' after patching.\n");
+            }
         } else if (strcmp(maint_action, "status") == 0) {
-            enabled = syscheck_maint_is_enabled(sk_name, sk_ip);
+            enabled = syscheck_maint_get(sk_name, sk_ip, &mi);
             ok = 1;
+        } else if (strcmp(maint_action, "end") == 0) {
+            /* Enable if needed, mark pending_end, force a scan. */
+            if (!syscheck_maint_get(sk_name, sk_ip, &mi)) {
+                ok = syscheck_maint_enable(sk_name, sk_ip);
+            }
+            if (ok) {
+                ok = syscheck_maint_set_pending_end(sk_name, sk_ip, 1);
+            }
+            if (ok) {
+                if (strcmp(agent_id, "000") == 0) {
+                    os_set_restart_syscheck();
+                } else {
+                    arq = connect_to_remoted();
+                    if (arq < 0) {
+                        ok = 0;
+                    } else if (send_msg_to_agent(arq, HC_SK_RESTART,
+                                                agent_id, NULL) != 0) {
+                        ok = 0;
+                    }
+                }
+            }
+            enabled = 1;
         } else {
             if (json_output) {
                 cJSON_AddNumberToObject(root, "error", 45);
                 cJSON_AddStringToObject(root, "description",
-                                        "Invalid -M action (enable|disable|status)");
+                                        "Invalid -M action (enable|disable|status|end)");
                 printf("%s", cJSON_PrintUnformatted(root));
                 cJSON_Delete(root);
             } else {
-                printf("\n** Invalid -M action '%s' (use enable|disable|status).\n",
+                printf("\n** Invalid -M action '%s' "
+                       "(use enable|disable|status|end).\n",
                        maint_action);
             }
             exit(1);
@@ -530,19 +613,44 @@ int main(int argc, char **argv)
             exit(1);
         }
 
+        syscheck_maint_get(sk_name, sk_ip, &mi);
+
         if (json_output) {
             cJSON *response = cJSON_CreateObject();
             cJSON_AddNumberToObject(root, "error", 0);
             cJSON_AddStringToObject(response, "agent", agent_id);
             cJSON_AddStringToObject(response, "fimMaintenance",
-                                    enabled ? "enabled" : "disabled");
+                                    enabled ? (mi.pending_end
+                                               ? "Maint(pending-end)"
+                                               : "enabled")
+                                            : "disabled");
             cJSON_AddStringToObject(response, "action", maint_action);
+            if (enabled) {
+                cJSON_AddNumberToObject(response, "fimMaintEnabledAt",
+                                        (double)mi.enabled_at);
+                cJSON_AddNumberToObject(response, "fimMaintSilentUpdates",
+                                        (double)mi.silent_updates);
+                cJSON_AddBoolToObject(response, "fimMaintPendingEnd",
+                                      mi.pending_end);
+            }
             cJSON_AddItemToObject(root, "response", response);
             printf("%s", cJSON_PrintUnformatted(root));
             cJSON_Delete(root);
         } else if (strcmp(maint_action, "status") == 0) {
-            printf("\nOSSEC HIDS %s: Agent %s FIM maintenance mode: %s\n",
-                   ARGV0, agent_id, enabled ? "enabled" : "disabled");
+            if (enabled) {
+                printf("\nOSSEC HIDS %s: Agent %s FIM maintenance: %s\n",
+                       ARGV0, agent_id, syscheck_maint_list_tag(&mi));
+                printf("   enabled_at=%ld  silent_updates=%lu  pending_end=%d\n",
+                       (long)mi.enabled_at, mi.silent_updates, mi.pending_end);
+            } else {
+                printf("\nOSSEC HIDS %s: Agent %s FIM maintenance mode: disabled\n",
+                       ARGV0, agent_id);
+            }
+        } else if (strcmp(maint_action, "end") == 0) {
+            printf("\nOSSEC HIDS %s: FIM maintenance end requested for agent %s.\n"
+                   "Syscheck/Rootcheck restart sent; maintenance clears when "
+                   "the baseline scan completes (syscheck-db-completed).\n",
+                   ARGV0, agent_id);
         } else {
             printf("\nOSSEC HIDS %s: FIM maintenance mode %s for agent %s.\n",
                    ARGV0, enabled ? "enabled" : "disabled", agent_id);

--- a/src/util/syscheck_control.c
+++ b/src/util/syscheck_control.c
@@ -286,6 +286,10 @@ int main(int argc, char **argv)
                 ErrorExit("%s: ERROR: Cannot delete %s: %s", ARGV0, final_dir, strerror(errno));
             }
 
+            /* Deleting FIM maintenance marker */
+            snprintf(final_dir, 1020, "/%s/.syscheck.maint", SYSCHECK_DIR);
+            unlink(final_dir);
+
             if (json_output) {
                 cJSON_AddNumberToObject(json_root, "error", 0);
                 cJSON_AddStringToObject(json_root, "response", "Integrity check database updated");


### PR DESCRIPTION
Allow operators to silently accept syscheck DB updates during OS patching without stopping the manager or wiping baselines (#677, #1289, #1681).