### PR TITLE
Address Copilot review follow-ups for FIM maintenance mode.

### DIFF
--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -947,11 +947,10 @@ void syscheck_maint_log_accept(const char *location, const char *kind,
     FILE *fp;
     time_t now = time(NULL);
     char tbuf[64];
-    struct tm *tm_s;
+    struct tm tm_buf;
 
-    tm_s = localtime(&now);
-    if (tm_s) {
-        strftime(tbuf, sizeof(tbuf), "%F %T", tm_s);
+    if (localtime_r(&now, &tm_buf) != NULL) {
+        strftime(tbuf, sizeof(tbuf), "%F %T", &tm_buf);
     } else {
         snprintf(tbuf, sizeof(tbuf), "%ld", (long)now);
     }

--- a/src/shared/tests/Makefile
+++ b/src/shared/tests/Makefile
@@ -8,7 +8,7 @@ TOP = ../..
 CFLAGS_COMMON = -g -Wall -I$(TOP)/headers -I$(TOP) -I$(TOP)/analysisd
 
 # Headless tests run by `check`. Interactive helpers stay under `legacy_helpers`.
-AUTO_TEST_BINS = thread_pool_test queue_op_test string_test fim_sum_test ar_expect_test
+AUTO_TEST_BINS = thread_pool_test queue_op_test string_test fim_sum_test ar_expect_test fim_maint_test
 LEGACY_HELPER_BINS = prime_test hash_test merge_test ip_test
 
 .PHONY: maketest check clean legacy_helpers
@@ -32,6 +32,13 @@ fim_sum_test: fim_sum_test.c ../fim_sum_op.c ../../headers/fim_sum_op.h
 ar_expect_test: ar_expect_test.c ../ar_expect.c ../../headers/ar.h
 	$(CC) $(CFLAGS_COMMON) -DARGV0=\"ar_expect_test\" -o $@ \
 		ar_expect_test.c ../ar_expect.c
+
+fim_maint_test: fim_maint_test.c $(TOP)/shared.a
+	$(CC) -pthread $(CFLAGS_COMMON) -DARGV0=\"fim_maint_test\" -o $@ \
+		fim_maint_test.c \
+		-Wl,--start-group $(TOP)/shared.a $(TOP)/os_regex.a $(TOP)/os_net.a \
+		$(TOP)/os_xml.a $(TOP)/os_zlib.a $(TOP)/libcJSON.a -Wl,--end-group \
+		-lpcre2-8 -lm -lpthread -lz
 
 # Interactive / argv-driven helpers (not part of automated check).
 legacy_helpers:

--- a/src/shared/tests/fim_maint_test.c
+++ b/src/shared/tests/fim_maint_test.c
@@ -1,0 +1,117 @@
+/* Unit tests for FIM maintenance marker helpers (#2283 follow-up). */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+#include "shared.h"
+
+static int failures = 0;
+
+static void expect_int(const char *name, int got, int want)
+{
+    if (got != want) {
+        printf("FAIL %s: got %d want %d\n", name, got, want);
+        failures++;
+    }
+}
+
+static void expect_str(const char *name, const char *got, const char *want)
+{
+    if (strcmp(got, want) != 0) {
+        printf("FAIL %s: got '%s' want '%s'\n", name, got, want);
+        failures++;
+    }
+}
+
+static void expect_true(const char *name, int cond)
+{
+    if (!cond) {
+        printf("FAIL %s\n", name);
+        failures++;
+    }
+}
+
+int main(void)
+{
+    char path[OS_FLSIZE + 1];
+    char loc_path[OS_FLSIZE + 1];
+    char tmp[] = "/tmp/ossec-fim-maint-test.XXXXXX";
+    int fd;
+    syscheck_maint_info info;
+    syscheck_maint_info empty;
+
+    /* Path builders */
+    syscheck_maint_path(NULL, NULL, path, sizeof(path));
+    expect_str("local path", path, SYSCHECK_DIR "/.syscheck.maint");
+
+    syscheck_maint_path("web1", "10.0.0.5", path, sizeof(path));
+    expect_str("agent path", path, SYSCHECK_DIR "/.(web1) 10.0.0.5.maint");
+
+    syscheck_maint_path_from_location("syscheck", loc_path, sizeof(loc_path));
+    expect_str("loc syscheck", loc_path, SYSCHECK_DIR "/.syscheck.maint");
+
+    syscheck_maint_path_from_location("(web1) 10.0.0.5->syscheck",
+                                      loc_path, sizeof(loc_path));
+    expect_str("loc agent", loc_path,
+               SYSCHECK_DIR "/.(web1) 10.0.0.5.maint");
+
+    /* Round-trip marker I/O on a tempfile (DecodeSyscheck uses these helpers). */
+    fd = mkstemp(tmp);
+    expect_true("mkstemp", fd >= 0);
+    if (fd >= 0) {
+        close(fd);
+        unlink(tmp);
+    }
+
+    memset(&empty, 0, sizeof(empty));
+    expect_int("missing marker", syscheck_maint_read_path(tmp, &empty), 0);
+
+    memset(&info, 0, sizeof(info));
+    info.enabled = 1;
+    info.enabled_at = 1700000000;
+    info.pending_end = 0;
+    info.silent_updates = 3;
+    expect_int("write marker", syscheck_maint_write_path(tmp, &info), 1);
+
+    memset(&empty, 0, sizeof(empty));
+    expect_int("read marker", syscheck_maint_read_path(tmp, &empty), 1);
+    expect_int("enabled", empty.enabled, 1);
+    expect_true("enabled_at", empty.enabled_at == (time_t)1700000000);
+    expect_int("pending_end off", empty.pending_end, 0);
+    expect_true("silent_updates", empty.silent_updates == 3UL);
+
+    /* pending_end flip mirrors DecodeSyscheck HC_SK_DB_COMPLETED clear path */
+    empty.pending_end = 1;
+    expect_int("write pending_end", syscheck_maint_write_path(tmp, &empty), 1);
+    memset(&info, 0, sizeof(info));
+    expect_int("read pending_end", syscheck_maint_read_path(tmp, &info), 1);
+    expect_int("pending_end on", info.pending_end, 1);
+
+    expect_str("list tag pending", syscheck_maint_list_tag(&info),
+               "Maint(pending-end)");
+    info.pending_end = 0;
+    expect_str("list tag on", syscheck_maint_list_tag(&info), "Maint");
+    info.enabled = 0;
+    expect_str("list tag off", syscheck_maint_list_tag(&info), "");
+
+    /* Clear marker (same as clear_location / end-after-baseline) */
+    expect_true("unlink marker", unlink(tmp) == 0 || errno == ENOENT);
+    expect_int("gone after clear", syscheck_maint_read_path(tmp, &info), 0);
+
+    /* set_pending_end must fail without an existing marker */
+    expect_int("pending_end without marker",
+               syscheck_maint_set_pending_end("no-such-agent", "127.0.0.1", 1),
+               0);
+
+    if (failures) {
+        printf("FAILED: %d assertion(s)\n", failures);
+        return (1);
+    }
+
+    printf("PASS: fim_maint_test\n");
+    return (0);
+}

--- a/src/util/syscheck_control.c
+++ b/src/util/syscheck_control.c
@@ -286,9 +286,12 @@ int main(int argc, char **argv)
                 ErrorExit("%s: ERROR: Cannot delete %s: %s", ARGV0, final_dir, strerror(errno));
             }
 
-            /* Deleting FIM maintenance marker */
-            snprintf(final_dir, 1020, "/%s/.syscheck.maint", SYSCHECK_DIR);
-            unlink(final_dir);
+            /* Deleting FIM maintenance marker (may not exist) */
+            syscheck_maint_path(NULL, NULL, final_dir, sizeof(final_dir));
+            if ((unlink(final_dir)) != 0 && errno != ENOENT) {
+                ErrorExit("%s: ERROR: Cannot delete %s: %s", ARGV0, final_dir,
+                          strerror(errno));
+            }
 
             if (json_output) {
                 cJSON_AddNumberToObject(json_root, "error", 0);


### PR DESCRIPTION
Check maint marker unlink errors in syscheck_control, use localtime_r for audit timestamps, and add a unit test for marker helpers.