### PR TITLE
Add opt-in Windows FIM **`check_acl`** / `CHECK_ACL` so agents can detect NTFS DACL/ACE changes and raise integrity alerts with human-readable permission detail.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Work toward the next minor release after 4.2.0.
 
 - @atomicturtle - Use a dedicated OSSEC iptables chain for firewall-drop active response (#678)
 - @atomicturtle - Add opt-in Windows FIM ``check_attrs`` for Hidden/System/attribute change alerts (#1352)
+- @atomicturtle - Add opt-in Windows FIM ``check_acl`` for NTFS DACL/ACE matrix alerts
 - @hyn172 / @atomicturtle - [PR 504](https://github.com/ossec/ossec-hids/pull/504) - Add Windows interactive (logon type 2) success detail rule 18262
 - @awiddersheim / @atomicturtle - [PR 578](https://github.com/ossec/ossec-hids/pull/578) - Refactor Unix MQ start/send retry loops without changing wait budgets
 - @bchurchill / @atomicturtle - [PR 633](https://github.com/ossec/ossec-hids/pull/633) - Enable Linux compile/link hardening by default (PIE, FORTIFY, stack protector, full RELRO)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Work toward the next minor release after 4.2.0.
 **General**
 
 - @atomicturtle - Use a dedicated OSSEC iptables chain for firewall-drop active response (#678)
+- @atomicturtle - Add opt-in Windows FIM ``check_attrs`` for Hidden/System/attribute change alerts (#1352)
 - @hyn172 / @atomicturtle - [PR 504](https://github.com/ossec/ossec-hids/pull/504) - Add Windows interactive (logon type 2) success detail rule 18262
 - @awiddersheim / @atomicturtle - [PR 578](https://github.com/ossec/ossec-hids/pull/578) - Refactor Unix MQ start/send retry loops without changing wait budgets
 - @bchurchill / @atomicturtle - [PR 633](https://github.com/ossec/ossec-hids/pull/633) - Enable Linux compile/link hardening by default (PIE, FORTIFY, stack protector, full RELRO)

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -693,6 +693,7 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
         char *oldsha1 = NULL, *newsha1 = NULL;
         char *oldsha256 = NULL, *newsha256 = NULL;
         char *oldattrs = NULL, *newattrs = NULL;
+        char *oldacl = NULL, *newacl = NULL;
 
         oldsize = saved_sum;
         newsize = c_sum;
@@ -757,7 +758,7 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
                                 oldsha256++;
                                 newsha256++;
 
-                                /* Optional Windows attrs after sha256 */
+                                /* Optional Windows attrs[:acl] after sha256 */
                                 oldattrs = strchr(oldsha256, ':');
                                 newattrs = strchr(newsha256, ':');
                                 if (oldattrs && newattrs) {
@@ -765,6 +766,15 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
                                     *newattrs = '\0';
                                     oldattrs++;
                                     newattrs++;
+
+                                    oldacl = strchr(oldattrs, ':');
+                                    newacl = strchr(newattrs, ':');
+                                    if (oldacl && newacl) {
+                                        *oldacl = '\0';
+                                        *newacl = '\0';
+                                        oldacl++;
+                                        newacl++;
+                                    }
                                 }
                             }
                         }
@@ -884,6 +894,10 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
                      old_abuf, new_abuf);
         }
 
+        /* ACL digest change is detailed in lf->data (Permissions appendix). */
+        (void)oldacl;
+        (void)newacl;
+
         /* Provide information about the file */
         snprintf(sdb.comment, OS_MAXSTR, "Integrity checksum changed for: "
                  "'%.756s'\n"
@@ -905,7 +919,8 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
                  sdb.sha1,
                  sdb.sha256,
                  sdb.attrs,
-                 lf->data == NULL ? "" : "What changed:\n",
+                 lf->data == NULL ? "" :
+                    (strncmp(lf->data, "Permissions:", 12) == 0 ? "" : "What changed:\n"),
                  lf->data == NULL ? "" : lf->data
                 );
     }

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -37,6 +37,7 @@ typedef struct __sdb {
     char md5[OS_FLSIZE + 1];
     char sha1[OS_FLSIZE + 1];
     char sha256[OS_FLSIZE + 1];
+    char attrs[OS_FLSIZE + 1];
 
     int db_err;
 
@@ -126,6 +127,7 @@ void SyscheckInit()
     memset(sdb.md5, '\0', OS_FLSIZE + 1);
     memset(sdb.sha1, '\0', OS_FLSIZE + 1);
     memset(sdb.sha256, '\0', OS_FLSIZE + 1);
+    memset(sdb.attrs, '\0', OS_FLSIZE + 1);
 
     /* Create decoder (TLS — each worker owns its own) */
     os_calloc(1, sizeof(OSDecoderInfo), sdb.syscheck_dec);
@@ -690,6 +692,7 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
         char *oldmd5 = NULL, *newmd5 = NULL;
         char *oldsha1 = NULL, *newsha1 = NULL;
         char *oldsha256 = NULL, *newsha256 = NULL;
+        char *oldattrs = NULL, *newattrs = NULL;
 
         oldsize = saved_sum;
         newsize = c_sum;
@@ -753,6 +756,16 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
                                 *newsha256 = '\0';
                                 oldsha256++;
                                 newsha256++;
+
+                                /* Optional Windows attrs after sha256 */
+                                oldattrs = strchr(oldsha256, ':');
+                                newattrs = strchr(newsha256, ':');
+                                if (oldattrs && newattrs) {
+                                    *oldattrs = '\0';
+                                    *newattrs = '\0';
+                                    oldattrs++;
+                                    newattrs++;
+                                }
                             }
                         }
                     }
@@ -855,9 +868,26 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
             os_strdup(newsha256, lf->sha256_after);
         }
 
+        /* Windows file attributes message (#1352) */
+        if (!oldattrs || !newattrs || strcmp(oldattrs, newattrs) == 0) {
+            sdb.attrs[0] = '\0';
+        } else {
+            char old_abuf[128];
+            char new_abuf[128];
+            unsigned int oattrs = (unsigned int)strtoul(oldattrs, NULL, 10);
+            unsigned int nattrs = (unsigned int)strtoul(newattrs, NULL, 10);
+
+            fim_win_attrs_str(oattrs, old_abuf, sizeof(old_abuf));
+            fim_win_attrs_str(nattrs, new_abuf, sizeof(new_abuf));
+            snprintf(sdb.attrs, OS_FLSIZE,
+                     "Attributes changed from '%s' to '%s'\n",
+                     old_abuf, new_abuf);
+        }
+
         /* Provide information about the file */
         snprintf(sdb.comment, OS_MAXSTR, "Integrity checksum changed for: "
                  "'%.756s'\n"
+                 "%s"
                  "%s"
                  "%s"
                  "%s"
@@ -874,6 +904,7 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
                  sdb.md5,
                  sdb.sha1,
                  sdb.sha256,
+                 sdb.attrs,
                  lf->data == NULL ? "" : "What changed:\n",
                  lf->data == NULL ? "" : lf->data
                 );

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -902,9 +902,21 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
                      old_abuf, new_abuf);
         }
 
-        /* ACL digest change is detailed in lf->data (Permissions appendix). */
-        (void)oldacl;
-        (void)newacl;
+        /* ACL digest (detailed ACE matrix may also be in lf->data). */
+        if (oldacl && newacl && strcmp(oldacl, newacl) != 0) {
+            char acl_line[OS_FLSIZE];
+
+            snprintf(acl_line, sizeof(acl_line),
+                     "ACL digest changed from '%.32s' to '%.32s'\n",
+                     oldacl, newacl);
+            if (sdb.attrs[0] == '\0') {
+                snprintf(sdb.attrs, OS_FLSIZE, "%s", acl_line);
+            } else {
+                char combined[OS_FLSIZE];
+                snprintf(combined, sizeof(combined), "%s%s", sdb.attrs, acl_line);
+                snprintf(sdb.attrs, OS_FLSIZE, "%s", combined);
+            }
+        }
 
         /* Provide information about the file */
         snprintf(sdb.comment, OS_MAXSTR, "Integrity checksum changed for: "

--- a/src/analysisd/decoders/syscheck.c
+++ b/src/analysisd/decoders/syscheck.c
@@ -758,21 +758,29 @@ static int DB_ProcessFoundEntry(const char *f_name, const char *c_sum,
                                 oldsha256++;
                                 newsha256++;
 
-                                /* Optional Windows attrs[:acl] after sha256 */
+                                /* Optional Windows attrs[:acl] after sha256.
+                                 * Split each side independently so mixed
+                                 * formats (pre/post enabling CHECK_ATTRS/ACL
+                                 * or mixed agent versions) still leave a
+                                 * clean sha256 token.
+                                 */
                                 oldattrs = strchr(oldsha256, ':');
-                                newattrs = strchr(newsha256, ':');
-                                if (oldattrs && newattrs) {
+                                if (oldattrs) {
                                     *oldattrs = '\0';
-                                    *newattrs = '\0';
                                     oldattrs++;
-                                    newattrs++;
-
                                     oldacl = strchr(oldattrs, ':');
-                                    newacl = strchr(newattrs, ':');
-                                    if (oldacl && newacl) {
+                                    if (oldacl) {
                                         *oldacl = '\0';
-                                        *newacl = '\0';
                                         oldacl++;
+                                    }
+                                }
+                                newattrs = strchr(newsha256, ':');
+                                if (newattrs) {
+                                    *newattrs = '\0';
+                                    newattrs++;
+                                    newacl = strchr(newattrs, ':');
+                                    if (newacl) {
+                                        *newacl = '\0';
                                         newacl++;
                                     }
                                 }

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -165,6 +165,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
     const char *xml_check_owner = "check_owner";
     const char *xml_check_group = "check_group";
     const char *xml_check_perm = "check_perm";
+    const char *xml_check_attrs = "check_attrs";
     const char *xml_real_time = "realtime";
     const char *xml_report_changes = "report_changes";
     const char *xml_restrict = "restrict";
@@ -372,6 +373,18 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
             } else if (strcmp(*attrs, xml_no_recurse) == 0) {
                 if(strcmp(*values, "yes") == 0) {
                     opts |= CHECK_NORECURSE;
+                } else {
+                    merror(SK_INV_OPT, __local_name, *values, *attrs);
+                    ret = 0;
+                    goto out_free;
+                }
+            } else if (strcmp(*attrs, xml_check_attrs) == 0) {
+                /* Windows file attributes (Hidden/System/...). Ignored on
+                 * non-Windows agents; accepted so shared agent.conf is portable. */
+                if (strcmp(*values, "yes") == 0) {
+                    opts |= CHECK_ATTRS;
+                } else if (strcmp(*values, "no") == 0) {
+                    opts &= ~CHECK_ATTRS;
                 } else {
                     merror(SK_INV_OPT, __local_name, *values, *attrs);
                     ret = 0;
@@ -868,6 +881,7 @@ char *syscheck_opts2str(char *buf, int buflen, int opts) {
         CHECK_REALTIME,
         CHECK_SEECHANGES,
         CHECK_NORECURSE,
+        CHECK_ATTRS,
         0
         };
     char *check_strings[] = {
@@ -881,6 +895,7 @@ char *syscheck_opts2str(char *buf, int buflen, int opts) {
         "realtime",
         "report_changes",
         "no_recurse",
+        "attrs",
 	NULL
 	};
 

--- a/src/config/syscheck-config.c
+++ b/src/config/syscheck-config.c
@@ -166,6 +166,7 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
     const char *xml_check_group = "check_group";
     const char *xml_check_perm = "check_perm";
     const char *xml_check_attrs = "check_attrs";
+    const char *xml_check_acl = "check_acl";
     const char *xml_real_time = "realtime";
     const char *xml_report_changes = "report_changes";
     const char *xml_restrict = "restrict";
@@ -385,6 +386,17 @@ static int read_attr(syscheck_config *syscheck, const char *dirs, char **g_attrs
                     opts |= CHECK_ATTRS;
                 } else if (strcmp(*values, "no") == 0) {
                     opts &= ~CHECK_ATTRS;
+                } else {
+                    merror(SK_INV_OPT, __local_name, *values, *attrs);
+                    ret = 0;
+                    goto out_free;
+                }
+            } else if (strcmp(*attrs, xml_check_acl) == 0) {
+                /* Windows NTFS DACL/ACE matrix. Ignored on non-Windows. */
+                if (strcmp(*values, "yes") == 0) {
+                    opts |= CHECK_ACL;
+                } else if (strcmp(*values, "no") == 0) {
+                    opts &= ~CHECK_ACL;
                 } else {
                     merror(SK_INV_OPT, __local_name, *values, *attrs);
                     ret = 0;
@@ -882,6 +894,7 @@ char *syscheck_opts2str(char *buf, int buflen, int opts) {
         CHECK_SEECHANGES,
         CHECK_NORECURSE,
         CHECK_ATTRS,
+        CHECK_ACL,
         0
         };
     char *check_strings[] = {
@@ -896,6 +909,7 @@ char *syscheck_opts2str(char *buf, int buflen, int opts) {
         "report_changes",
         "no_recurse",
         "attrs",
+        "acl",
 	NULL
 	};
 

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -26,6 +26,7 @@
 #define CHECK_SHA256SUM     0000400
 #define CHECK_GENERIC       0001000
 #define CHECK_NORECURSE     0002000
+#define CHECK_ATTRS         0004000  /* Windows file attributes (Hidden, etc.) */
 
 
 #include <stdio.h>

--- a/src/config/syscheck-config.h
+++ b/src/config/syscheck-config.h
@@ -27,6 +27,7 @@
 #define CHECK_GENERIC       0001000
 #define CHECK_NORECURSE     0002000
 #define CHECK_ATTRS         0004000  /* Windows file attributes (Hidden, etc.) */
+#define CHECK_ACL           0010000  /* Windows NTFS DACL/ACE matrix */
 
 
 #include <stdio.h>

--- a/src/headers/fim_sum_op.h
+++ b/src/headers/fim_sum_op.h
@@ -16,14 +16,19 @@
 int fim_hash_is_placeholder(const char *hash);
 
 /* Offset from the start of a local syscheck.fp hash entry to the sum data
- * (size:perm:uid:gid:md5:sha1[:sha256]). Legacy entries have 6 flag chars;
- * current entries have 7 (includes sha256 enable flag). */
+ * (size:perm:uid:gid:md5:sha1[:sha256][:attrs]).
+ * Legacy: 6 flag chars. Current: 7 (sha256). With attrs: 8 flag chars. */
 int fim_sum_data_offset(const char *hash_entry);
 
-/* Compare two sum strings (size:perm:uid:gid:md5:sha1[:sha256]).
- * Returns 1 if they differ in a "real" way (size/perm/owner/group, or a hash
- * where neither side is the xxx placeholder). Returns 0 if equal or the only
- * hash differences involve placeholders (#1590/#1704). */
+/* Compare two sum strings (size:perm:uid:gid:md5:sha1[:sha256][:attrs]).
+ * Returns 1 if they differ in a "real" way (size/perm/owner/group/attrs, or a
+ * hash where neither side is the xxx placeholder). Returns 0 if equal or the
+ * only hash differences involve placeholders (#1590/#1704). */
 int fim_sum_has_real_change(const char *old_sum, const char *new_sum);
+
+/* Format Windows GetFileAttributes bits into a comma-separated name list
+ * (e.g. "ARCHIVE, HIDDEN"). Returns buf. Unknown bits are omitted; if none
+ * match, writes "NONE". */
+char *fim_win_attrs_str(unsigned int attrs, char *buf, size_t buflen);
 
 #endif

--- a/src/headers/fim_sum_op.h
+++ b/src/headers/fim_sum_op.h
@@ -16,19 +16,26 @@
 int fim_hash_is_placeholder(const char *hash);
 
 /* Offset from the start of a local syscheck.fp hash entry to the sum data
- * (size:perm:uid:gid:md5:sha1[:sha256][:attrs]).
- * Legacy: 6 flag chars. Current: 7 (sha256). With attrs: 8 flag chars. */
+ * (size:perm:uid:gid:md5:sha1[:sha256][:attrs][:acl]).
+ * Legacy: 6 flag chars. Current: 7 (sha256). Attrs: 8. ACL: 9. */
 int fim_sum_data_offset(const char *hash_entry);
 
-/* Compare two sum strings (size:perm:uid:gid:md5:sha1[:sha256][:attrs]).
- * Returns 1 if they differ in a "real" way (size/perm/owner/group/attrs, or a
- * hash where neither side is the xxx placeholder). Returns 0 if equal or the
- * only hash differences involve placeholders (#1590/#1704). */
+/* Compare sum strings including optional attrs (index 7) and acl digest (8).
+ * Ignores anything after the first newline (local ACL snapshot). */
 int fim_sum_has_real_change(const char *old_sum, const char *new_sum);
+
+/* 1 if sum portions (before newline) are identical. */
+int fim_sum_equal(const char *a, const char *b);
 
 /* Format Windows GetFileAttributes bits into a comma-separated name list
  * (e.g. "ARCHIVE, HIDDEN"). Returns buf. Unknown bits are omitted; if none
  * match, writes "NONE". */
 char *fim_win_attrs_str(unsigned int attrs, char *buf, size_t buflen);
+
+/* Length of sum data in a local cache entry (stops at newline ACL snapshot). */
+size_t fim_sum_data_len(const char *sum_and_maybe_snapshot);
+
+/* Copy 0-based sum field into buf (stops at newline). Returns 0 on success. */
+int fim_sum_get_field(const char *sum, int index, char *buf, size_t buflen);
 
 #endif

--- a/src/headers/win_acl_op.h
+++ b/src/headers/win_acl_op.h
@@ -1,0 +1,73 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef WIN_ACL_OP_H
+#define WIN_ACL_OP_H
+
+#include <stddef.h>
+
+/* Sentinel labels digested via OS_MD5_Str("NODACL") / OS_MD5_Str("NULLDACL"). */
+
+#define FIM_ACE_ALLOW 0
+#define FIM_ACE_DENY  1
+
+#define FIM_ACL_NORMAL    0
+#define FIM_ACL_NODACL    1
+#define FIM_ACL_NULLDACL  2
+
+/* Portable inheritance bits (match Windows ACE flags). */
+#define FIM_ACE_OI  0x01
+#define FIM_ACE_CI  0x02
+#define FIM_ACE_NP  0x04
+#define FIM_ACE_IO  0x08
+#define FIM_ACE_ID  0x10
+
+typedef struct fim_ace {
+    char sid[192];         /* enough for max canonical SID string + NUL */
+    int type;              /* FIM_ACE_ALLOW / FIM_ACE_DENY */
+    unsigned int flags;    /* inheritance bits */
+    unsigned int mask;
+    unsigned int ord;      /* original DACL order (included in digest) */
+} fim_ace_t;
+
+typedef struct fim_acl {
+    fim_ace_t *aces;
+    size_t count;
+    int special;           /* FIM_ACL_NORMAL / NODACL / NULLDACL */
+} fim_acl_t;
+
+void fim_acl_free(fim_acl_t *acl);
+void fim_acl_sort(fim_acl_t *acl);
+
+/* Read NTFS DACL for path. Returns 0 on success. Non-Windows: returns -1. */
+int fim_win_acl_read(const char *path, fim_acl_t *out);
+
+/* MD5 hex (33 bytes) of canonical ACE list / sentinel. Returns 0 on success. */
+int fim_win_acl_digest(const fim_acl_t *acl, char *md5_hex33);
+
+/* Format full matrix into buf. Returns bytes written (may truncate). */
+int fim_win_acl_format(const fim_acl_t *acl, char *buf, size_t buflen);
+
+/* ACE-level Added/Removed/Modified diff into buf. */
+int fim_win_acl_diff(const fim_acl_t *old_acl, const fim_acl_t *new_acl,
+                     char *buf, size_t buflen);
+
+/* Parse canonical snapshot text (from local cache) into acl. Returns 0 on success. */
+int fim_win_acl_parse_snapshot(const char *text, fim_acl_t *out);
+
+/* Write canonical snapshot (SID-stable, for cache + digest input). */
+int fim_win_acl_snapshot(const fim_acl_t *acl, char *buf, size_t buflen);
+
+/* Build human-readable ACL change text from local-cache / c_sum entries
+ * that may include a "\\n" + snapshot after the sum. Returns bytes written,
+ * 0 if nothing to report, or -1 on error. */
+int fim_win_acl_change_text(const char *old_sum_entry, const char *new_sum_entry,
+                            char *buf, size_t buflen);
+
+#endif

--- a/src/headers/win_acl_op.h
+++ b/src/headers/win_acl_op.h
@@ -16,6 +16,7 @@
 
 #define FIM_ACE_ALLOW 0
 #define FIM_ACE_DENY  1
+#define FIM_ACE_OTHER 2  /* callback/object/unknown ACE types (opaque in digest) */
 
 #define FIM_ACL_NORMAL    0
 #define FIM_ACL_NODACL    1
@@ -63,6 +64,9 @@ int fim_win_acl_parse_snapshot(const char *text, fim_acl_t *out);
 
 /* Write canonical snapshot (SID-stable, for cache + digest input). */
 int fim_win_acl_snapshot(const fim_acl_t *acl, char *buf, size_t buflen);
+
+/* Allocate a full (non-truncated) snapshot. Caller must free. NULL on error. */
+char *fim_win_acl_snapshot_dup(const fim_acl_t *acl);
 
 /* Build human-readable ACL change text from local-cache / c_sum entries
  * that may include a "\\n" + snapshot after the sum. Returns bytes written,

--- a/src/shared/fim_sum_op.c
+++ b/src/shared/fim_sum_op.c
@@ -188,22 +188,19 @@ int fim_sum_has_real_change(const char *old_sum, const char *new_sum)
         return (1);
     }
 
-    /* Optional attrs (index 7) */
+    /* Optional attrs (index 7). Format-only add/remove (enabling/disabling
+     * check_attrs) is not a content change. */
     if (oc >= 8 && nc >= 8) {
         if (strcmp(of[7], nf[7]) != 0) {
             return (1);
         }
-    } else if (oc >= 8 || nc >= 8) {
-        return (1);
     }
 
-    /* Optional ACL digest (index 8) */
+    /* Optional ACL digest (index 8). Format-only add/remove is quiet. */
     if (oc >= 9 && nc >= 9) {
         if (strcmp(of[8], nf[8]) != 0) {
             return (1);
         }
-    } else if (oc >= 9 || nc >= 9) {
-        return (1);
     }
 
     return (0);

--- a/src/shared/fim_sum_op.c
+++ b/src/shared/fim_sum_op.c
@@ -65,6 +65,11 @@ int fim_sum_data_offset(const char *hash_entry)
         return (6);
     }
 
+    /* With ACL: flags[8] is '+' or '-' before size. */
+    if (len >= 9 && (hash_entry[8] == '+' || hash_entry[8] == '-')) {
+        return (9);
+    }
+
     /* With attrs: flags[7] is '+' or '-' before size. */
     if (len >= 8 && (hash_entry[7] == '+' || hash_entry[7] == '-')) {
         return (8);
@@ -72,6 +77,35 @@ int fim_sum_data_offset(const char *hash_entry)
 
     /* Current: 7 flag chars (includes sha256 enable flag). */
     return (7);
+}
+
+size_t fim_sum_data_len(const char *sum_and_maybe_snapshot)
+{
+    const char *nl;
+
+    if (!sum_and_maybe_snapshot) {
+        return (0);
+    }
+    nl = strchr(sum_and_maybe_snapshot, '\n');
+    if (nl) {
+        return (size_t)(nl - sum_and_maybe_snapshot);
+    }
+    return (strlen(sum_and_maybe_snapshot));
+}
+
+int fim_sum_equal(const char *a, const char *b)
+{
+    size_t alen, blen;
+
+    if (!a || !b) {
+        return (0);
+    }
+    alen = fim_sum_data_len(a);
+    blen = fim_sum_data_len(b);
+    if (alen != blen) {
+        return (0);
+    }
+    return (strncmp(a, b, alen) == 0);
 }
 
 /* Split "a:b:c:..." into up to max_fields pointers into a mutable copy. */
@@ -100,10 +134,10 @@ static int fim_split_sum(char *buf, char **fields, int max_fields)
 
 int fim_sum_has_real_change(const char *old_sum, const char *new_sum)
 {
-    char old_buf[512];
-    char new_buf[512];
-    char *of[9];
-    char *nf[9];
+    char old_buf[1024];
+    char new_buf[1024];
+    char *of[10];
+    char *nf[10];
     int oc, nc, i;
     size_t olen, nlen;
 
@@ -115,23 +149,28 @@ int fim_sum_has_real_change(const char *old_sum, const char *new_sum)
         return (0);
     }
 
-    olen = strlen(old_sum);
-    nlen = strlen(new_sum);
+    olen = fim_sum_data_len(old_sum);
+    nlen = fim_sum_data_len(new_sum);
     if (olen >= sizeof(old_buf) || nlen >= sizeof(new_buf)) {
-        /* Oversized: fall back to strict compare already failed above */
         return (1);
     }
 
-    memcpy(old_buf, old_sum, olen + 1);
-    memcpy(new_buf, new_sum, nlen + 1);
+    memcpy(old_buf, old_sum, olen);
+    old_buf[olen] = '\0';
+    memcpy(new_buf, new_sum, nlen);
+    new_buf[nlen] = '\0';
 
-    oc = fim_split_sum(old_buf, of, 9);
-    nc = fim_split_sum(new_buf, nf, 9);
+    if (strcmp(old_buf, new_buf) == 0) {
+        return (0);
+    }
+
+    oc = fim_split_sum(old_buf, of, 10);
+    nc = fim_split_sum(new_buf, nf, 10);
     if (oc < 6 || nc < 6) {
         return (1);
     }
 
-    /* size, perm, uid, gid — always meaningful when they differ */
+    /* size, perm, uid, gid */
     for (i = 0; i < 4; i++) {
         if (strcmp(of[i], nf[i]) != 0) {
             return (1);
@@ -149,16 +188,54 @@ int fim_sum_has_real_change(const char *old_sum, const char *new_sum)
         return (1);
     }
 
-    /* Optional Windows attrs (8th field, index 7) */
+    /* Optional attrs (index 7) */
     if (oc >= 8 && nc >= 8) {
         if (strcmp(of[7], nf[7]) != 0) {
             return (1);
         }
     } else if (oc >= 8 || nc >= 8) {
-        /* One side gained/lost attrs tracking */
         return (1);
     }
 
+    /* Optional ACL digest (index 8) */
+    if (oc >= 9 && nc >= 9) {
+        if (strcmp(of[8], nf[8]) != 0) {
+            return (1);
+        }
+    } else if (oc >= 9 || nc >= 9) {
+        return (1);
+    }
+
+    return (0);
+}
+
+int fim_sum_get_field(const char *sum, int index, char *buf, size_t buflen)
+{
+    char tmp[1024];
+    char *fields[10];
+    size_t nlen;
+    int n;
+    int written;
+
+    if (!sum || !buf || buflen == 0 || index < 0) {
+        return (-1);
+    }
+    buf[0] = '\0';
+    nlen = fim_sum_data_len(sum);
+    if (nlen == 0 || nlen >= sizeof(tmp)) {
+        return (-1);
+    }
+    memcpy(tmp, sum, nlen);
+    tmp[nlen] = '\0';
+    n = fim_split_sum(tmp, fields, 10);
+    if (index >= n) {
+        return (-1);
+    }
+    written = snprintf(buf, buflen, "%s", fields[index]);
+    if (written < 0 || (size_t)written >= buflen) {
+        buf[0] = '\0';
+        return (-1);
+    }
     return (0);
 }
 

--- a/src/shared/fim_sum_op.c
+++ b/src/shared/fim_sum_op.c
@@ -7,10 +7,27 @@
  * Foundation.
  */
 
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 
 #include "fim_sum_op.h"
+
+/* Match Windows FILE_ATTRIBUTE_* values so this builds on non-Windows too. */
+#define FIM_ATTR_READONLY              0x00000001
+#define FIM_ATTR_HIDDEN                0x00000002
+#define FIM_ATTR_SYSTEM                0x00000004
+#define FIM_ATTR_DIRECTORY             0x00000010
+#define FIM_ATTR_ARCHIVE               0x00000020
+#define FIM_ATTR_DEVICE                0x00000040
+#define FIM_ATTR_NORMAL                0x00000080
+#define FIM_ATTR_TEMPORARY             0x00000100
+#define FIM_ATTR_SPARSE_FILE           0x00000200
+#define FIM_ATTR_REPARSE_POINT         0x00000400
+#define FIM_ATTR_COMPRESSED            0x00000800
+#define FIM_ATTR_OFFLINE               0x00001000
+#define FIM_ATTR_NOT_CONTENT_INDEXED   0x00002000
+#define FIM_ATTR_ENCRYPTED             0x00004000
 
 int fim_hash_is_placeholder(const char *hash)
 {
@@ -32,16 +49,29 @@ int fim_hash_is_placeholder(const char *hash)
 
 int fim_sum_data_offset(const char *hash_entry)
 {
-    if (!hash_entry || strlen(hash_entry) < 7) {
+    size_t len;
+
+    if (!hash_entry) {
         return (6);
     }
 
-    /* New format: flags[6] is '+' or '-' for sha256. Legacy: flags[6] starts size. */
-    if (hash_entry[6] == '+' || hash_entry[6] == '-') {
-        return (7);
+    len = strlen(hash_entry);
+    if (len < 7) {
+        return (6);
     }
 
-    return (6);
+    /* Legacy: flags[6] starts the size digits. */
+    if (hash_entry[6] != '+' && hash_entry[6] != '-') {
+        return (6);
+    }
+
+    /* With attrs: flags[7] is '+' or '-' before size. */
+    if (len >= 8 && (hash_entry[7] == '+' || hash_entry[7] == '-')) {
+        return (8);
+    }
+
+    /* Current: 7 flag chars (includes sha256 enable flag). */
+    return (7);
 }
 
 /* Split "a:b:c:..." into up to max_fields pointers into a mutable copy. */
@@ -72,8 +102,8 @@ int fim_sum_has_real_change(const char *old_sum, const char *new_sum)
 {
     char old_buf[512];
     char new_buf[512];
-    char *of[8];
-    char *nf[8];
+    char *of[9];
+    char *nf[9];
     int oc, nc, i;
     size_t olen, nlen;
 
@@ -95,8 +125,8 @@ int fim_sum_has_real_change(const char *old_sum, const char *new_sum)
     memcpy(old_buf, old_sum, olen + 1);
     memcpy(new_buf, new_sum, nlen + 1);
 
-    oc = fim_split_sum(old_buf, of, 8);
-    nc = fim_split_sum(new_buf, nf, 8);
+    oc = fim_split_sum(old_buf, of, 9);
+    nc = fim_split_sum(new_buf, nf, 9);
     if (oc < 6 || nc < 6) {
         return (1);
     }
@@ -119,5 +149,76 @@ int fim_sum_has_real_change(const char *old_sum, const char *new_sum)
         return (1);
     }
 
+    /* Optional Windows attrs (8th field, index 7) */
+    if (oc >= 8 && nc >= 8) {
+        if (strcmp(of[7], nf[7]) != 0) {
+            return (1);
+        }
+    } else if (oc >= 8 || nc >= 8) {
+        /* One side gained/lost attrs tracking */
+        return (1);
+    }
+
     return (0);
+}
+
+char *fim_win_attrs_str(unsigned int attrs, char *buf, size_t buflen)
+{
+    static const struct {
+        unsigned int bit;
+        const char *name;
+    } table[] = {
+        { FIM_ATTR_READONLY,            "READONLY" },
+        { FIM_ATTR_HIDDEN,              "HIDDEN" },
+        { FIM_ATTR_SYSTEM,              "SYSTEM" },
+        { FIM_ATTR_DIRECTORY,           "DIRECTORY" },
+        { FIM_ATTR_ARCHIVE,             "ARCHIVE" },
+        { FIM_ATTR_DEVICE,              "DEVICE" },
+        { FIM_ATTR_NORMAL,              "NORMAL" },
+        { FIM_ATTR_TEMPORARY,           "TEMPORARY" },
+        { FIM_ATTR_SPARSE_FILE,         "SPARSE" },
+        { FIM_ATTR_REPARSE_POINT,       "REPARSE_POINT" },
+        { FIM_ATTR_COMPRESSED,          "COMPRESSED" },
+        { FIM_ATTR_OFFLINE,             "OFFLINE" },
+        { FIM_ATTR_NOT_CONTENT_INDEXED, "NOT_CONTENT_INDEXED" },
+        { FIM_ATTR_ENCRYPTED,           "ENCRYPTED" },
+        { 0, NULL }
+    };
+    size_t used = 0;
+    int i;
+    int any = 0;
+
+    if (!buf || buflen == 0) {
+        return (buf);
+    }
+
+    buf[0] = '\0';
+    for (i = 0; table[i].name != NULL; i++) {
+        size_t nlen;
+
+        if ((attrs & table[i].bit) == 0) {
+            continue;
+        }
+        nlen = strlen(table[i].name);
+        if (any) {
+            if (used + 2 >= buflen) {
+                break;
+            }
+            buf[used++] = ',';
+            buf[used++] = ' ';
+            buf[used] = '\0';
+        }
+        if (used + nlen >= buflen) {
+            break;
+        }
+        memcpy(buf + used, table[i].name, nlen + 1);
+        used += nlen;
+        any = 1;
+    }
+
+    if (!any) {
+        snprintf(buf, buflen, "NONE");
+    }
+
+    return (buf);
 }

--- a/src/shared/tests/Makefile
+++ b/src/shared/tests/Makefile
@@ -8,7 +8,7 @@ TOP = ../..
 CFLAGS_COMMON = -g -Wall -I$(TOP)/headers -I$(TOP) -I$(TOP)/analysisd
 
 # Headless tests run by `check`. Interactive helpers stay under `legacy_helpers`.
-AUTO_TEST_BINS = thread_pool_test queue_op_test string_test fim_sum_test ar_expect_test fim_maint_test
+AUTO_TEST_BINS = thread_pool_test queue_op_test string_test fim_sum_test ar_expect_test fim_maint_test win_acl_test
 LEGACY_HELPER_BINS = prime_test hash_test merge_test ip_test
 
 .PHONY: maketest check clean legacy_helpers
@@ -28,6 +28,11 @@ string_test: string_test.c
 
 fim_sum_test: fim_sum_test.c ../fim_sum_op.c ../../headers/fim_sum_op.h
 	$(CC) $(CFLAGS_COMMON) -DARGV0=\"fim_sum_test\" -o $@ fim_sum_test.c ../fim_sum_op.c
+
+win_acl_test: win_acl_test.c ../../headers/win_acl_op.h $(TOP)/shared.a
+	$(CC) $(CFLAGS_COMMON) -DARGV0=\"win_acl_test\" -o $@ \
+		win_acl_test.c \
+		-Wl,--start-group $(TOP)/shared.a $(TOP)/os_crypto.a -Wl,--end-group
 
 ar_expect_test: ar_expect_test.c ../ar_expect.c ../../headers/ar.h
 	$(CC) $(CFLAGS_COMMON) -DARGV0=\"ar_expect_test\" -o $@ \

--- a/src/shared/tests/fim_sum_test.c
+++ b/src/shared/tests/fim_sum_test.c
@@ -59,6 +59,19 @@ int main(void)
                fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx",
                                        "0:0:0:0:aaa:bbb:xxx:32"), 1);
 
+    expect_int("offset acl format",
+               fim_sum_data_offset("++++++++-0:0:0:0:aaa:bbb:ccc:0:deadbeef"), 9);
+    expect_int("acl digest change",
+               fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx:0:aaa",
+                                       "0:0:0:0:aaa:bbb:xxx:0:bbb"), 1);
+    expect_int("acl equal ignores snapshot",
+               fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx:0:aaa\nold",
+                                       "0:0:0:0:aaa:bbb:xxx:0:aaa\nnew"), 0);
+    expect_int("fim_sum_equal true",
+               fim_sum_equal("0:0:0:0:a:b:c\nsnap", "0:0:0:0:a:b:c\nother"), 1);
+    expect_int("fim_sum_equal false",
+               fim_sum_equal("0:0:0:0:a:b:c", "0:0:0:0:a:b:d"), 0);
+
     {
         char abuf[128];
         fim_win_attrs_str(0x22, abuf, sizeof(abuf)); /* HIDDEN|ARCHIVE */

--- a/src/shared/tests/fim_sum_test.c
+++ b/src/shared/tests/fim_sum_test.c
@@ -55,9 +55,12 @@ int main(void)
     expect_int("attrs equal",
                fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx:32",
                                        "0:0:0:0:aaa:bbb:xxx:32"), 0);
-    expect_int("attrs added",
+    expect_int("attrs added format-only",
                fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx",
-                                       "0:0:0:0:aaa:bbb:xxx:32"), 1);
+                                       "0:0:0:0:aaa:bbb:xxx:32"), 0);
+    expect_int("acl added format-only",
+               fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx:0",
+                                       "0:0:0:0:aaa:bbb:xxx:0:deadbeef"), 0);
 
     expect_int("offset acl format",
                fim_sum_data_offset("++++++++-0:0:0:0:aaa:bbb:ccc:0:deadbeef"), 9);

--- a/src/shared/tests/fim_sum_test.c
+++ b/src/shared/tests/fim_sum_test.c
@@ -28,6 +28,8 @@ int main(void)
                fim_sum_data_offset("++++++-0:0:0:0:aaa:bbb:ccc"), 7);
     expect_int("offset legacy format",
                fim_sum_data_offset("++++++0:0:0:0:aaa:bbb"), 6);
+    expect_int("offset attrs format",
+               fim_sum_data_offset("++++++++0:0:0:0:aaa:bbb:ccc:32"), 8);
 
     expect_int("equal sums",
                fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx",
@@ -47,6 +49,29 @@ int main(void)
     expect_int("size change",
                fim_sum_has_real_change("10:0:0:0:aaa:bbb:xxx",
                                        "11:0:0:0:aaa:bbb:xxx"), 1);
+    expect_int("attrs change",
+               fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx:32",
+                                       "0:0:0:0:aaa:bbb:xxx:34"), 1);
+    expect_int("attrs equal",
+               fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx:32",
+                                       "0:0:0:0:aaa:bbb:xxx:32"), 0);
+    expect_int("attrs added",
+               fim_sum_has_real_change("0:0:0:0:aaa:bbb:xxx",
+                                       "0:0:0:0:aaa:bbb:xxx:32"), 1);
+
+    {
+        char abuf[128];
+        fim_win_attrs_str(0x22, abuf, sizeof(abuf)); /* HIDDEN|ARCHIVE */
+        if (strcmp(abuf, "HIDDEN, ARCHIVE") != 0) {
+            printf("FAIL attrs str: got '%s'\n", abuf);
+            failures++;
+        }
+        fim_win_attrs_str(0, abuf, sizeof(abuf));
+        if (strcmp(abuf, "NONE") != 0) {
+            printf("FAIL attrs none: got '%s'\n", abuf);
+            failures++;
+        }
+    }
 
     if (failures) {
         printf("FAILED: %d assertion(s)\n", failures);

--- a/src/shared/tests/win_acl_test.c
+++ b/src/shared/tests/win_acl_test.c
@@ -1,0 +1,183 @@
+/* Unit tests for Windows FIM ACL helpers (portable canonicalize/diff). */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "win_acl_op.h"
+#include "os_crypto/md5/md5_op.h"
+
+static int failures = 0;
+
+static void expect_int(const char *name, int got, int want)
+{
+    if (got != want) {
+        printf("FAIL %s: got %d want %d\n", name, got, want);
+        failures++;
+    }
+}
+
+static void expect_str(const char *name, const char *got, const char *want)
+{
+    if (!got || !want || strcmp(got, want) != 0) {
+        printf("FAIL %s: got '%s' want '%s'\n", name,
+               got ? got : "(null)", want ? want : "(null)");
+        failures++;
+    }
+}
+
+static void fill_ace(fim_ace_t *a, const char *sid, int type,
+                     unsigned int flags, unsigned int mask, unsigned int ord)
+{
+    memset(a, 0, sizeof(*a));
+    snprintf(a->sid, sizeof(a->sid), "%s", sid);
+    a->type = type;
+    a->flags = flags;
+    a->mask = mask;
+    a->ord = ord;
+}
+
+int main(void)
+{
+    fim_acl_t a, b;
+    char digest1[33], digest2[33];
+    char snap[1024];
+    char buf[2048];
+    os_md5 nodacl_md5;
+
+    memset(&a, 0, sizeof(a));
+    memset(&b, 0, sizeof(b));
+
+    /* Null / absent DACL sentinels */
+    a.special = FIM_ACL_NODACL;
+    expect_int("nodacl digest", fim_win_acl_digest(&a, digest1), 0);
+    OS_MD5_Str("NODACL", nodacl_md5);
+    expect_str("nodacl md5", digest1, nodacl_md5);
+
+    a.special = FIM_ACL_NULLDACL;
+    expect_int("nulldacl digest", fim_win_acl_digest(&a, digest2), 0);
+    OS_MD5_Str("NULLDACL", nodacl_md5);
+    expect_str("nulldacl md5", digest2, nodacl_md5);
+
+    /* Digest includes DACL order (ord); same ACEs with different ord differ. */
+    a.special = FIM_ACL_NORMAL;
+    a.aces = calloc(2, sizeof(fim_ace_t));
+    a.count = 2;
+    fill_ace(&a.aces[0], "S-1-5-32-545", FIM_ACE_ALLOW, FIM_ACE_OI | FIM_ACE_CI,
+             0x00120089, 0);
+    fill_ace(&a.aces[1], "S-1-5-18", FIM_ACE_ALLOW, 0, 0x001f01ff, 1);
+    fim_acl_sort(&a);
+    expect_int("digest a", fim_win_acl_digest(&a, digest1), 0);
+
+    b.special = FIM_ACL_NORMAL;
+    b.aces = calloc(2, sizeof(fim_ace_t));
+    b.count = 2;
+    fill_ace(&b.aces[0], "S-1-5-18", FIM_ACE_ALLOW, 0, 0x001f01ff, 0);
+    fill_ace(&b.aces[1], "S-1-5-32-545", FIM_ACE_ALLOW, FIM_ACE_OI | FIM_ACE_CI,
+             0x00120089, 1);
+    fim_acl_sort(&b);
+    expect_int("digest b", fim_win_acl_digest(&b, digest2), 0);
+    if (strcmp(digest1, digest2) == 0) {
+        printf("FAIL order-sensitive digest: digests unexpectedly equal\n");
+        failures++;
+    }
+
+    /* Same principals+ord → same digest regardless of array insert order */
+    fill_ace(&b.aces[0], "S-1-5-18", FIM_ACE_ALLOW, 0, 0x001f01ff, 1);
+    fill_ace(&b.aces[1], "S-1-5-32-545", FIM_ACE_ALLOW, FIM_ACE_OI | FIM_ACE_CI,
+             0x00120089, 0);
+    fim_acl_sort(&b);
+    expect_int("digest b2", fim_win_acl_digest(&b, digest2), 0);
+    expect_str("same ord digest", digest1, digest2);
+
+    /* Snapshot round-trip */
+    expect_int("snapshot", fim_win_acl_snapshot(&a, snap, sizeof(snap)), 0);
+    fim_acl_free(&b);
+    memset(&b, 0, sizeof(b));
+    expect_int("parse snap", fim_win_acl_parse_snapshot(snap, &b), 0);
+    expect_int("parse count", (int)b.count, 2);
+    expect_int("digest roundtrip", fim_win_acl_digest(&b, digest2), 0);
+    expect_str("roundtrip digest", digest1, digest2);
+
+    /* Diff: Added / Removed / Modified */
+    fill_ace(&b.aces[0], "S-1-5-32-545", FIM_ACE_ALLOW, FIM_ACE_OI | FIM_ACE_CI,
+             0x001201bf, 0);
+    fill_ace(&b.aces[1], "S-1-5-18", FIM_ACE_ALLOW, 0, 0x001f01ff, 1);
+    buf[0] = '\0';
+    expect_int("diff modified", fim_win_acl_diff(&a, &b, buf, sizeof(buf)) > 0, 1);
+    if (!strstr(buf, "Modified:")) {
+        printf("FAIL diff missing Modified: got '%s'\n", buf);
+        failures++;
+    }
+
+    /* Identical ACLs → diff returns 0 (no appendix spam). */
+    fill_ace(&b.aces[0], "S-1-5-32-545", FIM_ACE_ALLOW, FIM_ACE_OI | FIM_ACE_CI,
+             0x00120089, 0);
+    fill_ace(&b.aces[1], "S-1-5-18", FIM_ACE_ALLOW, 0, 0x001f01ff, 1);
+    fim_acl_sort(&b);
+    expect_int("diff identical", fim_win_acl_diff(&a, &b, buf, sizeof(buf)), 0);
+
+    /* change_text: unchanged digests → no appendix */
+    {
+        char old_e[2048], new_e[2048];
+        char snap2[1024];
+        fim_win_acl_snapshot(&a, snap2, sizeof(snap2));
+        snprintf(old_e, sizeof(old_e), "0:0:0:0:aaa:bbb:xxx:0:%s\n%s", digest1, snap2);
+        snprintf(new_e, sizeof(new_e), "0:0:0:0:aaa:bbb:xxx:0:%s\n%s", digest1, snap2);
+        expect_int("change_text same digest",
+                   fim_win_acl_change_text(old_e, new_e, buf, sizeof(buf)), 0);
+    }
+
+    /* Remove one ACE, add another */
+    {
+        fim_acl_t neu;
+        memset(&neu, 0, sizeof(neu));
+        neu.aces = calloc(2, sizeof(fim_ace_t));
+        neu.count = 2;
+        fill_ace(&neu.aces[0], "S-1-5-18", FIM_ACE_ALLOW, 0, 0x001f01ff, 0);
+        fill_ace(&neu.aces[1], "S-1-5-21-1-2-3-1001", FIM_ACE_DENY, FIM_ACE_ID,
+                 0x00110000, 1);
+        fim_acl_sort(&neu);
+        buf[0] = '\0';
+        fim_win_acl_diff(&a, &neu, buf, sizeof(buf));
+        if (!strstr(buf, "Removed:") || !strstr(buf, "Added:")) {
+            printf("FAIL diff add/remove: got '%s'\n", buf);
+            failures++;
+        }
+        fim_acl_free(&neu);
+    }
+
+    /* Format includes inheritance markers */
+    buf[0] = '\0';
+    fim_win_acl_format(&a, buf, sizeof(buf));
+    if (!strstr(buf, "Permissions:") || !strstr(buf, "ALLOWED")) {
+        printf("FAIL format: got '%s'\n", buf);
+        failures++;
+    }
+    if (!strstr(buf, "[OI,CI]") && !strstr(buf, "[OI")) {
+        /* At least one ACE should show inheritance */
+        if (!strstr(buf, "OI")) {
+            printf("FAIL format inheritance: got '%s'\n", buf);
+            failures++;
+        }
+    }
+
+    fim_acl_free(&a);
+    fim_acl_free(&b);
+
+    /* Non-Windows read stub */
+#ifndef WIN32
+    {
+        fim_acl_t stub;
+        expect_int("read stub", fim_win_acl_read("/tmp", &stub), -1);
+    }
+#endif
+
+    if (failures) {
+        printf("FAILED: %d assertion(s)\n", failures);
+        return (1);
+    }
+
+    printf("PASS: win_acl_test\n");
+    return (0);
+}

--- a/src/shared/win_acl_op.c
+++ b/src/shared/win_acl_op.c
@@ -338,7 +338,9 @@ int fim_win_acl_parse_snapshot(const char *text, fim_acl_t *out)
 
 int fim_win_acl_digest(const fim_acl_t *acl, char *md5_hex33)
 {
-    char snap[8192];
+    char *snap = NULL;
+    size_t cap = 8192;
+    const size_t max_cap = 256 * 1024;
     os_md5 md5;
 
     if (!acl || !md5_hex33) {
@@ -354,11 +356,34 @@ int fim_win_acl_digest(const fim_acl_t *acl, char *md5_hex33)
         memcpy(md5_hex33, md5, 33);
         return (0);
     }
-    if (fim_win_acl_snapshot(acl, snap, sizeof(snap)) != 0) {
-        return (-1);
+
+    /* Grow until the snapshot fits without the truncation marker so the
+     * digest covers the full DACL (display/format paths may still truncate).
+     */
+    for (;;) {
+        char *neu = realloc(snap, cap);
+        if (!neu) {
+            free(snap);
+            return (-1);
+        }
+        snap = neu;
+        if (fim_win_acl_snapshot(acl, snap, cap) != 0) {
+            free(snap);
+            return (-1);
+        }
+        if (strstr(snap, "... truncated") == NULL) {
+            break;
+        }
+        if (cap >= max_cap) {
+            free(snap);
+            return (-1);
+        }
+        cap *= 2;
     }
+
     OS_MD5_Str(snap, md5);
     memcpy(md5_hex33, md5, 33);
+    free(snap);
     return (0);
 }
 
@@ -670,7 +695,8 @@ int fim_win_acl_read(const char *path, fim_acl_t *out)
         }
         snprintf(ace.sid, sizeof(ace.sid), "%s", sid_str);
         LocalFree(sid_str);
-        ace.ord = (unsigned int)n;
+        /* Original DACL index (not filtered allow/deny-only index). */
+        ace.ord = (unsigned int)i;
 
         if (n >= cap) {
             fim_ace_t *neu;

--- a/src/shared/win_acl_op.c
+++ b/src/shared/win_acl_op.c
@@ -268,6 +268,38 @@ int fim_win_acl_snapshot(const fim_acl_t *acl, char *buf, size_t buflen)
     return (0);
 }
 
+char *fim_win_acl_snapshot_dup(const fim_acl_t *acl)
+{
+    char *snap = NULL;
+    size_t cap = 8192;
+    const size_t max_cap = 256 * 1024;
+
+    if (!acl) {
+        return (NULL);
+    }
+
+    for (;;) {
+        char *neu = realloc(snap, cap);
+        if (!neu) {
+            free(snap);
+            return (NULL);
+        }
+        snap = neu;
+        if (fim_win_acl_snapshot(acl, snap, cap) != 0) {
+            free(snap);
+            return (NULL);
+        }
+        if (strstr(snap, "... truncated") == NULL) {
+            return (snap);
+        }
+        if (cap >= max_cap) {
+            free(snap);
+            return (NULL);
+        }
+        cap *= 2;
+    }
+}
+
 int fim_win_acl_parse_snapshot(const char *text, fim_acl_t *out)
 {
     char *copy;
@@ -338,9 +370,7 @@ int fim_win_acl_parse_snapshot(const char *text, fim_acl_t *out)
 
 int fim_win_acl_digest(const fim_acl_t *acl, char *md5_hex33)
 {
-    char *snap = NULL;
-    size_t cap = 8192;
-    const size_t max_cap = 256 * 1024;
+    char *snap;
     os_md5 md5;
 
     if (!acl || !md5_hex33) {
@@ -357,30 +387,10 @@ int fim_win_acl_digest(const fim_acl_t *acl, char *md5_hex33)
         return (0);
     }
 
-    /* Grow until the snapshot fits without the truncation marker so the
-     * digest covers the full DACL (display/format paths may still truncate).
-     */
-    for (;;) {
-        char *neu = realloc(snap, cap);
-        if (!neu) {
-            free(snap);
-            return (-1);
-        }
-        snap = neu;
-        if (fim_win_acl_snapshot(acl, snap, cap) != 0) {
-            free(snap);
-            return (-1);
-        }
-        if (strstr(snap, "... truncated") == NULL) {
-            break;
-        }
-        if (cap >= max_cap) {
-            free(snap);
-            return (-1);
-        }
-        cap *= 2;
+    snap = fim_win_acl_snapshot_dup(acl);
+    if (!snap) {
+        return (-1);
     }
-
     OS_MD5_Str(snap, md5);
     memcpy(md5_hex33, md5, 33);
     free(snap);
@@ -392,8 +402,14 @@ static void format_one_ace(const fim_ace_t *a, char *line, size_t linelen, int w
     char inh[32];
     char rights[512];
     char who[256];
-    const char *kind = (a->type == FIM_ACE_DENY) ? "DENIED" : "ALLOWED";
+    const char *kind;
 
+    if (a->type == FIM_ACE_OTHER) {
+        snprintf(line, linelen, "OPAQUE %s (type/mask encoded)", a->sid);
+        return;
+    }
+
+    kind = (a->type == FIM_ACE_DENY) ? "DENIED" : "ALLOWED";
     format_inherit(a->flags, inh, sizeof(inh));
     format_mask(a->mask, rights, sizeof(rights));
     if (with_name) {
@@ -461,7 +477,10 @@ int fim_win_acl_diff(const fim_acl_t *old_acl, const fim_acl_t *new_acl,
     buf[0] = '\0';
 
     if (old_acl->special != new_acl->special) {
-        append_str(buf, buflen, &used, "Permissions changed (DACL state):\n");
+        /* Keep "Permissions:" prefix so analysisd does not label this as
+         * a content-diff "What changed:" appendix. */
+        append_str(buf, buflen, &used, "Permissions:\n");
+        append_str(buf, buflen, &used, "  DACL state changed\n");
         fim_win_acl_format(new_acl, buf + used,
                            buflen > used ? buflen - used : 0);
         return ((int)strlen(buf));
@@ -473,62 +492,81 @@ int fim_win_acl_diff(const fim_acl_t *old_acl, const fim_acl_t *new_acl,
 
     append_str(buf, buflen, &used, "Permissions:\n");
 
-    /* Removed / modified */
-    for (i = 0; i < old_acl->count; i++) {
-        const fim_ace_t *o = &old_acl->aces[i];
-        int found = 0;
-        for (j = 0; j < new_acl->count; j++) {
-            const fim_ace_t *n = &new_acl->aces[j];
-            if (!ace_same_principal(o, n)) {
-                continue;
+    /* Track which new ACEs have been paired so duplicate principals
+     * (same SID/type/flags, different masks) map 1:1. */
+    {
+        unsigned char *new_used = NULL;
+
+        if (new_acl->count > 0) {
+            new_used = calloc(new_acl->count, 1);
+            if (!new_used) {
+                return (-1);
             }
-            found = 1;
-            if (o->mask != n->mask) {
-                append_str(buf, buflen, &used, "  Modified: ");
+        }
+
+        /* Removed / modified */
+        for (i = 0; i < old_acl->count; i++) {
+            const fim_ace_t *o = &old_acl->aces[i];
+            int found = 0;
+
+            for (j = 0; j < new_acl->count; j++) {
+                const fim_ace_t *n = &new_acl->aces[j];
+
+                if (new_used && new_used[j]) {
+                    continue;
+                }
+                if (!ace_same_principal(o, n)) {
+                    continue;
+                }
+                found = 1;
+                if (new_used) {
+                    new_used[j] = 1;
+                }
+                if (o->mask != n->mask || o->ord != n->ord) {
+                    append_str(buf, buflen, &used, "  Modified: ");
+                    format_one_ace(o, line, sizeof(line), 1);
+                    append_str(buf, buflen, &used, line);
+                    append_str(buf, buflen, &used, " -> ");
+                    format_one_ace(n, line, sizeof(line), 1);
+                    append_str(buf, buflen, &used, line);
+                    append_str(buf, buflen, &used, "\n");
+                    any = 1;
+                }
+                break;
+            }
+            if (!found) {
+                append_str(buf, buflen, &used, "  Removed: ");
                 format_one_ace(o, line, sizeof(line), 1);
-                append_str(buf, buflen, &used, line);
-                append_str(buf, buflen, &used, " -> ");
-                format_one_ace(n, line, sizeof(line), 1);
                 append_str(buf, buflen, &used, line);
                 append_str(buf, buflen, &used, "\n");
                 any = 1;
             }
-            break;
-        }
-        if (!found) {
-            append_str(buf, buflen, &used, "  Removed: ");
-            format_one_ace(o, line, sizeof(line), 1);
-            append_str(buf, buflen, &used, line);
-            append_str(buf, buflen, &used, "\n");
-            any = 1;
-        }
-        if (used + 128 >= buflen) {
-            append_str(buf, buflen, &used, "  ... truncated ...\n");
-            return ((int)used);
-        }
-    }
-
-    /* Added */
-    for (j = 0; j < new_acl->count; j++) {
-        const fim_ace_t *n = &new_acl->aces[j];
-        int found = 0;
-        for (i = 0; i < old_acl->count; i++) {
-            if (ace_same_principal(&old_acl->aces[i], n)) {
-                found = 1;
-                break;
+            if (used + 128 >= buflen) {
+                append_str(buf, buflen, &used, "  ... truncated ...\n");
+                free(new_used);
+                return ((int)used);
             }
         }
-        if (!found) {
+
+        /* Added */
+        for (j = 0; j < new_acl->count; j++) {
+            const fim_ace_t *n = &new_acl->aces[j];
+
+            if (new_used && new_used[j]) {
+                continue;
+            }
             append_str(buf, buflen, &used, "  Added: ");
             format_one_ace(n, line, sizeof(line), 1);
             append_str(buf, buflen, &used, line);
             append_str(buf, buflen, &used, "\n");
             any = 1;
+            if (used + 128 >= buflen) {
+                append_str(buf, buflen, &used, "  ... truncated ...\n");
+                free(new_used);
+                return ((int)used);
+            }
         }
-        if (used + 128 >= buflen) {
-            append_str(buf, buflen, &used, "  ... truncated ...\n");
-            break;
-        }
+        free(new_used);
     }
 
     if (!any) {
@@ -667,36 +705,56 @@ int fim_win_acl_read(const char *path, fim_acl_t *out)
         if (!GetAce(pDacl, i, (LPVOID *)&hdr) || !hdr) {
             continue;
         }
-        if (hdr->AceType != ACCESS_ALLOWED_ACE_TYPE &&
-                hdr->AceType != ACCESS_DENIED_ACE_TYPE) {
-            continue;
-        }
 
         memset(&ace, 0, sizeof(ace));
-        ace.type = (hdr->AceType == ACCESS_DENIED_ACE_TYPE) ?
-                   FIM_ACE_DENY : FIM_ACE_ALLOW;
+        ace.ord = (unsigned int)i;
         ace.flags = hdr->AceFlags &
                     (OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE |
                      NO_PROPAGATE_INHERIT_ACE | INHERIT_ONLY_ACE |
                      INHERITED_ACE);
 
-        if (hdr->AceType == ACCESS_ALLOWED_ACE_TYPE) {
-            ACCESS_ALLOWED_ACE *a = (ACCESS_ALLOWED_ACE *)hdr;
-            ace.mask = a->Mask;
-            sid = (PSID)&a->SidStart;
-        } else {
-            ACCESS_DENIED_ACE *a = (ACCESS_DENIED_ACE *)hdr;
-            ace.mask = a->Mask;
-            sid = (PSID)&a->SidStart;
-        }
+        if (hdr->AceType == ACCESS_ALLOWED_ACE_TYPE ||
+                hdr->AceType == ACCESS_DENIED_ACE_TYPE) {
+            ace.type = (hdr->AceType == ACCESS_DENIED_ACE_TYPE) ?
+                       FIM_ACE_DENY : FIM_ACE_ALLOW;
 
-        if (!ConvertSidToStringSidA(sid, &sid_str) || !sid_str) {
-            continue;
+            if (hdr->AceType == ACCESS_ALLOWED_ACE_TYPE) {
+                ACCESS_ALLOWED_ACE *a = (ACCESS_ALLOWED_ACE *)hdr;
+                ace.mask = a->Mask;
+                sid = (PSID)&a->SidStart;
+            } else {
+                ACCESS_DENIED_ACE *a = (ACCESS_DENIED_ACE *)hdr;
+                ace.mask = a->Mask;
+                sid = (PSID)&a->SidStart;
+            }
+
+            if (!ConvertSidToStringSidA(sid, &sid_str) || !sid_str) {
+                LocalFree(pSD);
+                fim_acl_free(out);
+                return (-1);
+            }
+            snprintf(ace.sid, sizeof(ace.sid), "%s", sid_str);
+            LocalFree(sid_str);
+        } else {
+            /* Callback/object/unknown ACE: include an opaque digest so the
+             * integrity hash still changes when these entries change. */
+            os_md5 ace_md5;
+            const unsigned char *raw = (const unsigned char *)hdr;
+            size_t raw_len = hdr->AceSize;
+
+            ace.type = FIM_ACE_OTHER;
+            ace.mask = hdr->AceType;
+            if (raw_len == 0 || raw_len > 65535) {
+                raw_len = sizeof(ACE_HEADER);
+            }
+            if (OS_MD5_Bytes((const char *)raw, raw_len, ace_md5) != 0) {
+                LocalFree(pSD);
+                fim_acl_free(out);
+                return (-1);
+            }
+            snprintf(ace.sid, sizeof(ace.sid), "TYPE%u_%s",
+                     (unsigned int)hdr->AceType, ace_md5);
         }
-        snprintf(ace.sid, sizeof(ace.sid), "%s", sid_str);
-        LocalFree(sid_str);
-        /* Original DACL index (not filtered allow/deny-only index). */
-        ace.ord = (unsigned int)i;
 
         if (n >= cap) {
             fim_ace_t *neu;

--- a/src/shared/win_acl_op.c
+++ b/src/shared/win_acl_op.c
@@ -1,0 +1,703 @@
+/* Copyright (C) 2026 Atomicorp, Inc.
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "shared.h"
+#include "win_acl_op.h"
+#include "os_crypto/md5/md5_op.h"
+
+#ifdef WIN32
+#include <aclapi.h>
+#include <sddl.h>
+#endif
+
+/* Access mask bits (Windows values). */
+#define FIM_MASK_GENERIC_READ     0x80000000
+#define FIM_MASK_GENERIC_WRITE    0x40000000
+#define FIM_MASK_GENERIC_EXECUTE  0x20000000
+#define FIM_MASK_GENERIC_ALL      0x10000000
+#define FIM_MASK_DELETE           0x00010000
+#define FIM_MASK_READ_CONTROL     0x00020000
+#define FIM_MASK_WRITE_DAC        0x00040000
+#define FIM_MASK_WRITE_OWNER      0x00080000
+#define FIM_MASK_SYNCHRONIZE      0x00100000
+#define FIM_MASK_FILE_READ_DATA   0x00000001
+#define FIM_MASK_FILE_WRITE_DATA  0x00000002
+#define FIM_MASK_FILE_APPEND_DATA 0x00000004
+#define FIM_MASK_FILE_READ_EA     0x00000008
+#define FIM_MASK_FILE_WRITE_EA    0x00000010
+#define FIM_MASK_FILE_EXECUTE     0x00000020
+#define FIM_MASK_FILE_READ_ATTR   0x00000080
+#define FIM_MASK_FILE_WRITE_ATTR  0x00000100
+
+void fim_acl_free(fim_acl_t *acl)
+{
+    if (!acl) {
+        return;
+    }
+    free(acl->aces);
+    acl->aces = NULL;
+    acl->count = 0;
+    acl->special = FIM_ACL_NORMAL;
+}
+
+static int ace_cmp(const void *a, const void *b)
+{
+    const fim_ace_t *xa = a;
+    const fim_ace_t *xb = b;
+    int c;
+
+    /* Preserve evaluation order: primary key is original DACL index. */
+    if (xa->ord != xb->ord) {
+        return (xa->ord < xb->ord ? -1 : 1);
+    }
+    c = strcmp(xa->sid, xb->sid);
+    if (c != 0) {
+        return (c);
+    }
+    if (xa->type != xb->type) {
+        return (xa->type < xb->type ? -1 : 1);
+    }
+    if (xa->flags != xb->flags) {
+        return (xa->flags < xb->flags ? -1 : 1);
+    }
+    if (xa->mask != xb->mask) {
+        return (xa->mask < xb->mask ? -1 : 1);
+    }
+    return (0);
+}
+
+void fim_acl_sort(fim_acl_t *acl)
+{
+    if (!acl || !acl->aces || acl->count < 2) {
+        return;
+    }
+    qsort(acl->aces, acl->count, sizeof(fim_ace_t), ace_cmp);
+}
+
+static void append_str(char *buf, size_t buflen, size_t *used, const char *s)
+{
+    size_t n;
+
+    if (!buf || !used || !s || buflen == 0) {
+        return;
+    }
+    n = strlen(s);
+    if (*used >= buflen) {
+        return;
+    }
+    if (*used + n >= buflen) {
+        n = buflen - *used - 1;
+    }
+    memcpy(buf + *used, s, n);
+    *used += n;
+    buf[*used] = '\0';
+}
+
+static void format_inherit(unsigned int flags, char *out, size_t outlen)
+{
+    char tmp[32];
+    size_t u = 0;
+
+    tmp[0] = '\0';
+    if (flags & FIM_ACE_OI) {
+        append_str(tmp, sizeof(tmp), &u, "OI");
+    }
+    if (flags & FIM_ACE_CI) {
+        if (u) {
+            append_str(tmp, sizeof(tmp), &u, ",");
+        }
+        append_str(tmp, sizeof(tmp), &u, "CI");
+    }
+    if (flags & FIM_ACE_IO) {
+        if (u) {
+            append_str(tmp, sizeof(tmp), &u, ",");
+        }
+        append_str(tmp, sizeof(tmp), &u, "IO");
+    }
+    if (flags & FIM_ACE_NP) {
+        if (u) {
+            append_str(tmp, sizeof(tmp), &u, ",");
+        }
+        append_str(tmp, sizeof(tmp), &u, "NP");
+    }
+    if (flags & FIM_ACE_ID) {
+        if (u) {
+            append_str(tmp, sizeof(tmp), &u, ",");
+        }
+        append_str(tmp, sizeof(tmp), &u, "ID");
+    }
+    if (u == 0) {
+        snprintf(out, outlen, "-");
+    } else {
+        snprintf(out, outlen, "%s", tmp);
+    }
+}
+
+static void format_mask(unsigned int mask, char *out, size_t outlen)
+{
+    static const struct {
+        unsigned int bit;
+        const char *name;
+    } bits[] = {
+        { FIM_MASK_GENERIC_READ,     "GENERIC_READ" },
+        { FIM_MASK_GENERIC_WRITE,    "GENERIC_WRITE" },
+        { FIM_MASK_GENERIC_EXECUTE,  "GENERIC_EXECUTE" },
+        { FIM_MASK_GENERIC_ALL,      "GENERIC_ALL" },
+        { FIM_MASK_DELETE,           "DELETE" },
+        { FIM_MASK_READ_CONTROL,     "READ_CONTROL" },
+        { FIM_MASK_WRITE_DAC,        "WRITE_DAC" },
+        { FIM_MASK_WRITE_OWNER,      "WRITE_OWNER" },
+        { FIM_MASK_SYNCHRONIZE,      "SYNCHRONIZE" },
+        { FIM_MASK_FILE_READ_DATA,   "FILE_READ_DATA" },
+        { FIM_MASK_FILE_WRITE_DATA,  "FILE_WRITE_DATA" },
+        { FIM_MASK_FILE_APPEND_DATA, "FILE_APPEND_DATA" },
+        { FIM_MASK_FILE_READ_EA,     "FILE_READ_EA" },
+        { FIM_MASK_FILE_WRITE_EA,    "FILE_WRITE_EA" },
+        { FIM_MASK_FILE_EXECUTE,     "FILE_EXECUTE" },
+        { FIM_MASK_FILE_READ_ATTR,   "FILE_READ_ATTRIBUTES" },
+        { FIM_MASK_FILE_WRITE_ATTR,  "FILE_WRITE_ATTRIBUTES" },
+        { 0, NULL }
+    };
+    size_t used = 0;
+    int i;
+    int any = 0;
+    unsigned int residual = mask;
+
+    out[0] = '\0';
+    for (i = 0; bits[i].name; i++) {
+        if ((mask & bits[i].bit) == 0) {
+            continue;
+        }
+        if (any) {
+            append_str(out, outlen, &used, ", ");
+        }
+        append_str(out, outlen, &used, bits[i].name);
+        residual &= ~bits[i].bit;
+        any = 1;
+    }
+    if (any && residual) {
+        char extra[24];
+        snprintf(extra, sizeof(extra), "0x%08x", residual);
+        append_str(out, outlen, &used, ", ");
+        append_str(out, outlen, &used, extra);
+    }
+    if (!any) {
+        snprintf(out, outlen, "0x%08x", mask);
+    }
+}
+
+#ifdef WIN32
+static void sid_to_name(const char *sid_str, char *name, size_t namelen)
+{
+    PSID sid = NULL;
+    char account[256];
+    char domain[256];
+    DWORD acc_sz = sizeof(account);
+    DWORD dom_sz = sizeof(domain);
+    SID_NAME_USE use;
+
+    name[0] = '\0';
+    if (!ConvertStringSidToSidA(sid_str, &sid) || !sid) {
+        snprintf(name, namelen, "%s", sid_str);
+        return;
+    }
+    if (LookupAccountSidA(NULL, sid, account, &acc_sz, domain, &dom_sz, &use)) {
+        if (domain[0]) {
+            snprintf(name, namelen, "%s\\%s", domain, account);
+        } else {
+            snprintf(name, namelen, "%s", account);
+        }
+    } else {
+        snprintf(name, namelen, "%s", sid_str);
+    }
+    LocalFree(sid);
+}
+#else
+static void sid_to_name(const char *sid_str, char *name, size_t namelen)
+{
+    snprintf(name, namelen, "%s", sid_str);
+}
+#endif
+
+int fim_win_acl_snapshot(const fim_acl_t *acl, char *buf, size_t buflen)
+{
+    size_t used = 0;
+    size_t i;
+    char line[512];
+
+    if (!acl || !buf || buflen == 0) {
+        return (-1);
+    }
+    buf[0] = '\0';
+
+    if (acl->special == FIM_ACL_NODACL) {
+        append_str(buf, buflen, &used, "SPECIAL=NODACL\n");
+        return (0);
+    }
+    if (acl->special == FIM_ACL_NULLDACL) {
+        append_str(buf, buflen, &used, "SPECIAL=NULLDACL\n");
+        return (0);
+    }
+
+    for (i = 0; i < acl->count; i++) {
+        const fim_ace_t *a = &acl->aces[i];
+        int len;
+
+        len = snprintf(line, sizeof(line), "%u|%s|%d|%u|%u\n",
+                       a->ord, a->sid, a->type, a->flags, a->mask);
+        if (len < 0) {
+            continue;
+        }
+        if (used + (size_t)len + sizeof("... truncated ...\n") >= buflen) {
+            append_str(buf, buflen, &used, "... truncated ...\n");
+            break;
+        }
+        append_str(buf, buflen, &used, line);
+    }
+    return (0);
+}
+
+int fim_win_acl_parse_snapshot(const char *text, fim_acl_t *out)
+{
+    char *copy;
+    char *line;
+    char *save = NULL;
+    size_t cap = 16;
+    size_t n = 0;
+
+    if (!text || !out) {
+        return (-1);
+    }
+    memset(out, 0, sizeof(*out));
+    os_strdup(text, copy);
+    out->aces = calloc(cap, sizeof(fim_ace_t));
+    if (!out->aces) {
+        free(copy);
+        return (-1);
+    }
+
+    for (line = strtok_r(copy, "\n", &save); line; line = strtok_r(NULL, "\n", &save)) {
+        fim_ace_t ace;
+        char sid[192];
+        int type;
+        unsigned int flags, mask, ord;
+
+        if (strncmp(line, "SPECIAL=NODACL", 14) == 0) {
+            out->special = FIM_ACL_NODACL;
+            break;
+        }
+        if (strncmp(line, "SPECIAL=NULLDACL", 16) == 0) {
+            out->special = FIM_ACL_NULLDACL;
+            break;
+        }
+        if (strncmp(line, "... truncated", 13) == 0) {
+            continue;
+        }
+        if (sscanf(line, "%u|%191[^|]|%d|%u|%u", &ord, sid, &type, &flags, &mask) == 5) {
+            /* New format with original order. */
+        } else if (sscanf(line, "%191[^|]|%d|%u|%u", sid, &type, &flags, &mask) == 4) {
+            ord = (unsigned int)n;
+        } else {
+            continue;
+        }
+        memset(&ace, 0, sizeof(ace));
+        snprintf(ace.sid, sizeof(ace.sid), "%s", sid);
+        ace.type = type;
+        ace.flags = flags;
+        ace.mask = mask;
+        ace.ord = ord;
+        if (n >= cap) {
+            fim_ace_t *neu;
+            cap *= 2;
+            neu = realloc(out->aces, cap * sizeof(fim_ace_t));
+            if (!neu) {
+                free(copy);
+                fim_acl_free(out);
+                return (-1);
+            }
+            out->aces = neu;
+        }
+        out->aces[n++] = ace;
+    }
+    out->count = n;
+    free(copy);
+    fim_acl_sort(out);
+    return (0);
+}
+
+int fim_win_acl_digest(const fim_acl_t *acl, char *md5_hex33)
+{
+    char snap[8192];
+    os_md5 md5;
+
+    if (!acl || !md5_hex33) {
+        return (-1);
+    }
+    if (acl->special == FIM_ACL_NODACL) {
+        OS_MD5_Str("NODACL", md5);
+        memcpy(md5_hex33, md5, 33);
+        return (0);
+    }
+    if (acl->special == FIM_ACL_NULLDACL) {
+        OS_MD5_Str("NULLDACL", md5);
+        memcpy(md5_hex33, md5, 33);
+        return (0);
+    }
+    if (fim_win_acl_snapshot(acl, snap, sizeof(snap)) != 0) {
+        return (-1);
+    }
+    OS_MD5_Str(snap, md5);
+    memcpy(md5_hex33, md5, 33);
+    return (0);
+}
+
+static void format_one_ace(const fim_ace_t *a, char *line, size_t linelen, int with_name)
+{
+    char inh[32];
+    char rights[512];
+    char who[256];
+    const char *kind = (a->type == FIM_ACE_DENY) ? "DENIED" : "ALLOWED";
+
+    format_inherit(a->flags, inh, sizeof(inh));
+    format_mask(a->mask, rights, sizeof(rights));
+    if (with_name) {
+        sid_to_name(a->sid, who, sizeof(who));
+    } else {
+        snprintf(who, sizeof(who), "%s", a->sid);
+    }
+    snprintf(line, linelen, "%s (%s) [%s] - %s", who, kind, inh, rights);
+}
+
+int fim_win_acl_format(const fim_acl_t *acl, char *buf, size_t buflen)
+{
+    size_t used = 0;
+    size_t i;
+    char line[768];
+
+    if (!acl || !buf || buflen == 0) {
+        return (-1);
+    }
+    buf[0] = '\0';
+    append_str(buf, buflen, &used, "Permissions:\n");
+
+    if (acl->special == FIM_ACL_NODACL) {
+        append_str(buf, buflen, &used, "  (no DACL)\n");
+        return ((int)used);
+    }
+    if (acl->special == FIM_ACL_NULLDACL) {
+        append_str(buf, buflen, &used, "  (null DACL - unrestricted)\n");
+        return ((int)used);
+    }
+
+    for (i = 0; i < acl->count; i++) {
+        int len;
+
+        format_one_ace(&acl->aces[i], line, sizeof(line), 1);
+        len = (int)strlen(line);
+        if (used + 2 + (size_t)len + 1 + sizeof("  ... truncated ...\n") >= buflen) {
+            append_str(buf, buflen, &used, "  ... truncated ...\n");
+            break;
+        }
+        append_str(buf, buflen, &used, "  ");
+        append_str(buf, buflen, &used, line);
+        append_str(buf, buflen, &used, "\n");
+    }
+    return ((int)used);
+}
+
+static int ace_same_principal(const fim_ace_t *a, const fim_ace_t *b)
+{
+    return (strcmp(a->sid, b->sid) == 0 && a->type == b->type &&
+            a->flags == b->flags);
+}
+
+int fim_win_acl_diff(const fim_acl_t *old_acl, const fim_acl_t *new_acl,
+                     char *buf, size_t buflen)
+{
+    size_t used = 0;
+    size_t i, j;
+    char line[768];
+    int any = 0;
+
+    if (!old_acl || !new_acl || !buf || buflen == 0) {
+        return (-1);
+    }
+    buf[0] = '\0';
+
+    if (old_acl->special != new_acl->special) {
+        append_str(buf, buflen, &used, "Permissions changed (DACL state):\n");
+        fim_win_acl_format(new_acl, buf + used,
+                           buflen > used ? buflen - used : 0);
+        return ((int)strlen(buf));
+    }
+    if (old_acl->special != FIM_ACL_NORMAL) {
+        /* identical special states */
+        return (0);
+    }
+
+    append_str(buf, buflen, &used, "Permissions:\n");
+
+    /* Removed / modified */
+    for (i = 0; i < old_acl->count; i++) {
+        const fim_ace_t *o = &old_acl->aces[i];
+        int found = 0;
+        for (j = 0; j < new_acl->count; j++) {
+            const fim_ace_t *n = &new_acl->aces[j];
+            if (!ace_same_principal(o, n)) {
+                continue;
+            }
+            found = 1;
+            if (o->mask != n->mask) {
+                append_str(buf, buflen, &used, "  Modified: ");
+                format_one_ace(o, line, sizeof(line), 1);
+                append_str(buf, buflen, &used, line);
+                append_str(buf, buflen, &used, " -> ");
+                format_one_ace(n, line, sizeof(line), 1);
+                append_str(buf, buflen, &used, line);
+                append_str(buf, buflen, &used, "\n");
+                any = 1;
+            }
+            break;
+        }
+        if (!found) {
+            append_str(buf, buflen, &used, "  Removed: ");
+            format_one_ace(o, line, sizeof(line), 1);
+            append_str(buf, buflen, &used, line);
+            append_str(buf, buflen, &used, "\n");
+            any = 1;
+        }
+        if (used + 128 >= buflen) {
+            append_str(buf, buflen, &used, "  ... truncated ...\n");
+            return ((int)used);
+        }
+    }
+
+    /* Added */
+    for (j = 0; j < new_acl->count; j++) {
+        const fim_ace_t *n = &new_acl->aces[j];
+        int found = 0;
+        for (i = 0; i < old_acl->count; i++) {
+            if (ace_same_principal(&old_acl->aces[i], n)) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            append_str(buf, buflen, &used, "  Added: ");
+            format_one_ace(n, line, sizeof(line), 1);
+            append_str(buf, buflen, &used, line);
+            append_str(buf, buflen, &used, "\n");
+            any = 1;
+        }
+        if (used + 128 >= buflen) {
+            append_str(buf, buflen, &used, "  ... truncated ...\n");
+            break;
+        }
+    }
+
+    if (!any) {
+        /* No ACE-level differences (identical principals/masks). */
+        buf[0] = '\0';
+        return (0);
+    }
+    return ((int)used);
+}
+
+int fim_win_acl_change_text(const char *old_sum_entry, const char *new_sum_entry,
+                            char *buf, size_t buflen)
+{
+    const char *old_nl;
+    const char *new_nl;
+    fim_acl_t old_acl;
+    fim_acl_t new_acl;
+    char old_dig[40];
+    char new_dig[40];
+    int rc;
+    int have_old_dig;
+    int have_new_dig;
+
+    if (!old_sum_entry || !new_sum_entry || !buf || buflen == 0) {
+        return (-1);
+    }
+    buf[0] = '\0';
+
+    /* Only emit appendix text when the ACL digest field actually changed
+     * (or ACL tracking is newly present). Avoid attaching a full matrix on
+     * unrelated size/hash alerts. */
+    have_old_dig = (fim_sum_get_field(old_sum_entry, 8, old_dig, sizeof(old_dig)) == 0);
+    have_new_dig = (fim_sum_get_field(new_sum_entry, 8, new_dig, sizeof(new_dig)) == 0);
+    if (!have_new_dig) {
+        return (0);
+    }
+    if (have_old_dig && strcmp(old_dig, new_dig) == 0) {
+        return (0);
+    }
+
+    new_nl = strchr(new_sum_entry, '\n');
+    if (!new_nl || !new_nl[1]) {
+        return (0);
+    }
+    new_nl++;
+
+    old_nl = strchr(old_sum_entry, '\n');
+    memset(&old_acl, 0, sizeof(old_acl));
+    memset(&new_acl, 0, sizeof(new_acl));
+
+    if (fim_win_acl_parse_snapshot(new_nl, &new_acl) != 0) {
+        return (-1);
+    }
+
+    if (old_nl && old_nl[1]) {
+        if (fim_win_acl_parse_snapshot(old_nl + 1, &old_acl) != 0) {
+            fim_acl_free(&new_acl);
+            return (-1);
+        }
+        rc = fim_win_acl_diff(&old_acl, &new_acl, buf, buflen);
+        fim_acl_free(&old_acl);
+        if (rc <= 0) {
+            /* Digests differ but ACE walk found nothing (e.g. truncation) —
+             * fall back to the full new matrix. */
+            rc = fim_win_acl_format(&new_acl, buf, buflen);
+        }
+        fim_acl_free(&new_acl);
+        return (rc);
+    }
+
+    /* First ACL observation for this path: show the full matrix. */
+    rc = fim_win_acl_format(&new_acl, buf, buflen);
+    fim_acl_free(&new_acl);
+    return (rc);
+}
+
+#ifdef WIN32
+int fim_win_acl_read(const char *path, fim_acl_t *out)
+{
+    PSECURITY_DESCRIPTOR pSD = NULL;
+    PACL pDacl = NULL;
+    BOOL present = FALSE;
+    BOOL defaulted = FALSE;
+    ACL_SIZE_INFORMATION info;
+    DWORD i;
+    size_t cap = 16;
+    size_t n = 0;
+    LONG rc;
+
+    if (!path || !out) {
+        return (-1);
+    }
+    memset(out, 0, sizeof(*out));
+    out->aces = calloc(cap, sizeof(fim_ace_t));
+    if (!out->aces) {
+        return (-1);
+    }
+
+    rc = GetNamedSecurityInfoA((LPSTR)path, SE_FILE_OBJECT,
+                               DACL_SECURITY_INFORMATION,
+                               NULL, NULL, &pDacl, NULL, &pSD);
+    if (rc != ERROR_SUCCESS) {
+        fim_acl_free(out);
+        return (-1);
+    }
+
+    if (!GetSecurityDescriptorDacl(pSD, &present, &pDacl, &defaulted)) {
+        LocalFree(pSD);
+        fim_acl_free(out);
+        return (-1);
+    }
+
+    if (!present) {
+        out->special = FIM_ACL_NODACL;
+        LocalFree(pSD);
+        return (0);
+    }
+    if (pDacl == NULL) {
+        out->special = FIM_ACL_NULLDACL;
+        LocalFree(pSD);
+        return (0);
+    }
+
+    if (!GetAclInformation(pDacl, &info, sizeof(info), AclSizeInformation)) {
+        LocalFree(pSD);
+        fim_acl_free(out);
+        return (-1);
+    }
+
+    for (i = 0; i < info.AceCount; i++) {
+        ACE_HEADER *hdr = NULL;
+        fim_ace_t ace;
+        PSID sid = NULL;
+        LPSTR sid_str = NULL;
+
+        if (!GetAce(pDacl, i, (LPVOID *)&hdr) || !hdr) {
+            continue;
+        }
+        if (hdr->AceType != ACCESS_ALLOWED_ACE_TYPE &&
+                hdr->AceType != ACCESS_DENIED_ACE_TYPE) {
+            continue;
+        }
+
+        memset(&ace, 0, sizeof(ace));
+        ace.type = (hdr->AceType == ACCESS_DENIED_ACE_TYPE) ?
+                   FIM_ACE_DENY : FIM_ACE_ALLOW;
+        ace.flags = hdr->AceFlags &
+                    (OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE |
+                     NO_PROPAGATE_INHERIT_ACE | INHERIT_ONLY_ACE |
+                     INHERITED_ACE);
+
+        if (hdr->AceType == ACCESS_ALLOWED_ACE_TYPE) {
+            ACCESS_ALLOWED_ACE *a = (ACCESS_ALLOWED_ACE *)hdr;
+            ace.mask = a->Mask;
+            sid = (PSID)&a->SidStart;
+        } else {
+            ACCESS_DENIED_ACE *a = (ACCESS_DENIED_ACE *)hdr;
+            ace.mask = a->Mask;
+            sid = (PSID)&a->SidStart;
+        }
+
+        if (!ConvertSidToStringSidA(sid, &sid_str) || !sid_str) {
+            continue;
+        }
+        snprintf(ace.sid, sizeof(ace.sid), "%s", sid_str);
+        LocalFree(sid_str);
+        ace.ord = (unsigned int)n;
+
+        if (n >= cap) {
+            fim_ace_t *neu;
+            cap *= 2;
+            neu = realloc(out->aces, cap * sizeof(fim_ace_t));
+            if (!neu) {
+                LocalFree(pSD);
+                fim_acl_free(out);
+                return (-1);
+            }
+            out->aces = neu;
+        }
+        out->aces[n++] = ace;
+    }
+
+    out->count = n;
+    LocalFree(pSD);
+    fim_acl_sort(out);
+    return (0);
+}
+#else
+int fim_win_acl_read(const char *path, fim_acl_t *out)
+{
+    (void)path;
+    if (out) {
+        memset(out, 0, sizeof(*out));
+    }
+    return (-1);
+}
+#endif

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -10,6 +10,7 @@
 #include "shared.h"
 #include "syscheck.h"
 #include "fim_sum_op.h"
+#include "win_acl_op.h"
 #include "os_crypto/md5/md5_op.h"
 #include "os_crypto/sha1/sha1_op.h"
 #include "os_crypto/sha256/sha256_op.h"
@@ -199,8 +200,10 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
         if (!buf) {
             char alert_msg[916 + 1];    /* to accommodate a long */
             char hash_entry[916 + 1];
+            char *hash_full = NULL;     /* optional ACL snapshot entry */
             alert_msg[916] = '\0';
             hash_entry[916] = '\0';
+            hash_entry[0] = '\0';
 
 #ifndef WIN32
             if (opts & CHECK_SEECHANGES) {
@@ -215,6 +218,21 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
 #ifdef WIN32
             {
                 DWORD win_attrs = 0;
+                char acl_digest[33];
+                char acl_snap[8192];
+                fim_acl_t acl;
+                int have_acl = 0;
+                const char *uid_str;
+                HANDLE hFile;
+                PSID pSidOwner = NULL;
+                PSECURITY_DESCRIPTOR pSD = NULL;
+                DWORD dwRtnCode;
+                LPSTR szSID = NULL;
+                char *st_uid = NULL;
+
+                acl_digest[0] = '\0';
+                acl_snap[0] = '\0';
+                memset(&acl, 0, sizeof(acl));
 
                 if (opts & CHECK_ATTRS) {
                     win_attrs = GetFileAttributes(file_name);
@@ -223,6 +241,57 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                                ARGV0, file_name, (unsigned long)GetLastError());
                         return (0);
                     }
+                }
+
+                if (opts & CHECK_ACL) {
+                    if (fim_win_acl_read(file_name, &acl) != 0) {
+                        fim_acl_free(&acl);
+                        merror("%s: WARN: Unable to read ACL for '%s'",
+                               ARGV0, file_name);
+                        return (0);
+                    }
+                    if (fim_win_acl_digest(&acl, acl_digest) != 0 ||
+                            fim_win_acl_snapshot(&acl, acl_snap, sizeof(acl_snap)) != 0) {
+                        fim_acl_free(&acl);
+                        merror("%s: WARN: Unable to digest ACL for '%s'",
+                               ARGV0, file_name);
+                        return (0);
+                    }
+                    have_acl = 1;
+                    fim_acl_free(&acl);
+                }
+
+                if (have_acl) {
+                    /* 9-flag format: attrs slot always present (0 if unchecked). */
+                    snprintf(hash_entry, 916,
+                             "%c%c%c%c%c%c%c%c+%ld:%d:%d:%d:%s:%s:%s:%lu:%s",
+                             opts & CHECK_SIZE ? '+' : '-',
+                             opts & CHECK_PERM ? '+' : '-',
+                             opts & CHECK_OWNER ? '+' : '-',
+                             opts & CHECK_GROUP ? '+' : '-',
+                             opts & CHECK_MD5SUM ? '+' : '-',
+                             sha1s,
+                             opts & CHECK_SHA256SUM ? '+' : '-',
+                             opts & CHECK_ATTRS ? '+' : '-',
+                             opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
+                             opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
+                             opts & CHECK_OWNER ? (int)statbuf.st_uid : 0,
+                             opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
+                             opts & CHECK_MD5SUM ? mf_sum : "xxx",
+                             opts & CHECK_SHA1SUM ? sf_sum : "xxx",
+                             opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
+                             (opts & CHECK_ATTRS) ? (unsigned long)win_attrs : 0UL,
+                             acl_digest);
+                    {
+                        size_t he_len = strlen(hash_entry);
+                        size_t snap_len = strlen(acl_snap);
+
+                        os_calloc(he_len + 1 + snap_len + 1, sizeof(char), hash_full);
+                        memcpy(hash_full, hash_entry, he_len);
+                        hash_full[he_len] = '\n';
+                        memcpy(hash_full + he_len + 1, acl_snap, snap_len + 1);
+                    }
+                } else if (opts & CHECK_ATTRS) {
                     snprintf(hash_entry, 916,
                              "%c%c%c%c%c%c%c+%ld:%d:%d:%d:%s:%s:%s:%lu",
                              opts & CHECK_SIZE ? '+' : '-',
@@ -257,6 +326,88 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                              opts & CHECK_SHA1SUM ? sf_sum : "xxx",
                              opts & CHECK_SHA256SUM ? sha256_sum : "xxx");
                 }
+
+                /* Owner SID for the manager alert (reuse attrs/ACL above). */
+                alert_msg[916] = '\0';
+                hFile = CreateFile(file_name, GENERIC_READ,
+                                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                   NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                if (hFile == INVALID_HANDLE_VALUE) {
+                    DWORD dwErrorCode = GetLastError();
+                    char err_msg[PATH_MAX + 4];
+                    free(hash_full);
+                    err_msg[PATH_MAX + 3] = '\0';
+                    snprintf(err_msg, PATH_MAX + 4, "CreateFile=%ld %s",
+                             dwErrorCode, file_name);
+                    send_syscheck_msg(err_msg);
+                    return -1;
+                }
+
+                dwRtnCode = GetSecurityInfo(hFile, SE_FILE_OBJECT,
+                                            OWNER_SECURITY_INFORMATION,
+                                            &pSidOwner, NULL, NULL, NULL, &pSD);
+                if (dwRtnCode != ERROR_SUCCESS) {
+                    DWORD dwErrorCode = GetLastError();
+                    CloseHandle(hFile);
+                    free(hash_full);
+                    {
+                        char err_msg[PATH_MAX + 4];
+                        err_msg[PATH_MAX + 3] = '\0';
+                        snprintf(err_msg, PATH_MAX + 4, "GetSecurityInfo=%ld %s",
+                                 dwErrorCode, file_name);
+                        send_syscheck_msg(err_msg);
+                    }
+                    return -1;
+                }
+
+                ConvertSidToStringSid(pSidOwner, &szSID);
+                if (szSID) {
+                    st_uid = (char *)calloc(strlen(szSID) + 1, 1);
+                    memcpy(st_uid, szSID, strlen(szSID));
+                }
+                LocalFree(szSID);
+                if (pSD) {
+                    LocalFree(pSD);
+                }
+                CloseHandle(hFile);
+
+                uid_str = (opts & CHECK_OWNER) ? (st_uid ? st_uid : "0") : "0";
+
+                if (have_acl) {
+                    snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s:%lu:%s %s",
+                             opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
+                             opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
+                             uid_str,
+                             opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
+                             opts & CHECK_MD5SUM ? mf_sum : "xxx",
+                             opts & CHECK_SHA1SUM ? sf_sum : "xxx",
+                             opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
+                             (opts & CHECK_ATTRS) ? (unsigned long)win_attrs : 0UL,
+                             acl_digest,
+                             file_name);
+                } else if (opts & CHECK_ATTRS) {
+                    snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s:%lu %s",
+                             opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
+                             opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
+                             uid_str,
+                             opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
+                             opts & CHECK_MD5SUM ? mf_sum : "xxx",
+                             opts & CHECK_SHA1SUM ? sf_sum : "xxx",
+                             opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
+                             (unsigned long)win_attrs,
+                             file_name);
+                } else {
+                    snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s %s",
+                             opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
+                             opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
+                             uid_str,
+                             opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
+                             opts & CHECK_MD5SUM ? mf_sum : "xxx",
+                             opts & CHECK_SHA1SUM ? sf_sum : "xxx",
+                             opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
+                             file_name);
+                }
+                free(st_uid);
             }
 #else
             snprintf(hash_entry, 916, "%c%c%c%c%c%c%c%ld:%d:%d:%d:%s:%s:%s",
@@ -274,12 +425,8 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                      opts & CHECK_MD5SUM ? mf_sum : "xxx",
                      opts & CHECK_SHA1SUM ? sf_sum : "xxx",
                      opts & CHECK_SHA256SUM ? sha256_sum : "xxx");
-#endif
 
-            /* Send the new checksum to the analysis server */
             alert_msg[916] = '\0';
-
-#ifndef WIN32
             snprintf(alert_msg, 916, "%ld:%d:%d:%d:%s:%s:%s %s",
                      opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
                      opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
@@ -289,77 +436,16 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                      opts & CHECK_SHA1SUM ? sf_sum : "xxx",
                      opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
                      file_name);
-#else
-
-            HANDLE hFile = CreateFile(file_name, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-            if (hFile == INVALID_HANDLE_VALUE) {
-                DWORD dwErrorCode = GetLastError();
-                char alert_msg[PATH_MAX+4];
-                alert_msg[PATH_MAX + 3] = '\0';
-                snprintf(alert_msg, PATH_MAX + 4, "CreateFile=%ld %s", dwErrorCode, file_name);
-                send_syscheck_msg(alert_msg);
-                return -1;
-            }
-
-            PSID pSidOwner = NULL;
-            PSECURITY_DESCRIPTOR pSD = NULL;
-            DWORD dwRtnCode = GetSecurityInfo(hFile, SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, &pSidOwner, NULL, NULL, NULL, &pSD);
-            if (dwRtnCode != ERROR_SUCCESS) {
-                DWORD dwErrorCode = GetLastError();
-                CloseHandle(hFile);
-                char alert_msg[PATH_MAX+4];
-                alert_msg[PATH_MAX + 3] = '\0';
-                snprintf(alert_msg, PATH_MAX + 4, "GetSecurityInfo=%ld %s", dwErrorCode, file_name);
-                send_syscheck_msg(alert_msg);
-                return -1;
-            }
-
-            LPSTR szSID = NULL;
-            ConvertSidToStringSid(pSidOwner, &szSID);
-            char* st_uid = NULL;
-            if(szSID) {
-              st_uid = (char *) calloc(strlen(szSID) + 1, 1);
-              memcpy(st_uid, szSID, strlen(szSID));
-            }
-            LocalFree(szSID);
-            CloseHandle(hFile);
-
-            if (opts & CHECK_ATTRS) {
-                DWORD win_attrs = GetFileAttributes(file_name);
-                if (win_attrs == INVALID_FILE_ATTRIBUTES) {
-                    free(st_uid);
-                    merror("%s: WARN: Unable to get attributes for '%s' (%lu)",
-                           ARGV0, file_name, (unsigned long)GetLastError());
-                    return (0);
-                }
-                snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s:%lu %s",
-                         opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
-                         opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
-                         (opts & CHECK_OWNER) ? st_uid : "0",
-                         opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
-                         opts & CHECK_MD5SUM ? mf_sum : "xxx",
-                         opts & CHECK_SHA1SUM ? sf_sum : "xxx",
-                         opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
-                         (unsigned long)win_attrs,
-                         file_name);
-            } else {
-                snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s %s",
-                         opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
-                         opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
-                         (opts & CHECK_OWNER) ? st_uid : "0",
-                         opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
-                         opts & CHECK_MD5SUM ? mf_sum : "xxx",
-                         opts & CHECK_SHA1SUM ? sf_sum : "xxx",
-                         opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
-                         file_name);
-            }
-            free(st_uid);
 #endif
             if (send_syscheck_msg(alert_msg) == 0) {
-                if (OSHash_Add(syscheck.fp, file_name, strdup(hash_entry)) <= 0) {
+                char *to_store = hash_full ? hash_full : strdup(hash_entry);
+                hash_full = NULL;
+                if (!to_store || OSHash_Add(syscheck.fp, file_name, to_store) <= 0) {
+                    free(to_store);
                     merror("%s: ERROR: Unable to add file to db: %s", ARGV0, file_name);
                 }
             } else {
+                free(hash_full);
                 merror("%s: WARN: Failed to send syscheck baseline for '%s'. "
                       "File will be retried on the next scan.", ARGV0, file_name);
             }
@@ -373,20 +459,45 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
             alert_msg[OS_MAXSTR] = '\0';
 
 #ifdef WIN32
-            /* Upgrade local cache to 8-flag format when check_attrs was enabled. */
-            if ((opts & CHECK_ATTRS) && fim_sum_data_offset(buf) == 7) {
-                char *upgraded;
-                size_t blen = strlen(buf);
+            /* Upgrade local cache flag format when attrs/ACL were enabled. */
+            {
+                int cur_off = fim_sum_data_offset(buf);
 
-                os_calloc(blen + 2, sizeof(char), upgraded);
-                memcpy(upgraded, buf, 7);
-                upgraded[7] = '+';
-                memcpy(upgraded + 8, buf + 7, blen - 7 + 1);
-                if (OSHash_Update(syscheck.fp, file_name, upgraded) == 1) {
-                    free(buf);
-                    buf = upgraded;
-                } else {
-                    free(upgraded);
+                if ((opts & CHECK_ACL) && (cur_off == 7 || cur_off == 8)) {
+                    char *upgraded;
+                    size_t blen = strlen(buf);
+                    size_t insert = (size_t)(9 - cur_off);
+
+                    os_calloc(blen + insert + 1, sizeof(char), upgraded);
+                    memcpy(upgraded, buf, (size_t)cur_off);
+                    if (cur_off == 7) {
+                        upgraded[7] = (opts & CHECK_ATTRS) ? '+' : '-';
+                        upgraded[8] = '+';
+                        memcpy(upgraded + 9, buf + 7, blen - 7 + 1);
+                    } else {
+                        upgraded[8] = '+';
+                        memcpy(upgraded + 9, buf + 8, blen - 8 + 1);
+                    }
+                    if (OSHash_Update(syscheck.fp, file_name, upgraded) == 1) {
+                        free(buf);
+                        buf = upgraded;
+                    } else {
+                        free(upgraded);
+                    }
+                } else if ((opts & CHECK_ATTRS) && cur_off == 7) {
+                    char *upgraded;
+                    size_t blen = strlen(buf);
+
+                    os_calloc(blen + 2, sizeof(char), upgraded);
+                    memcpy(upgraded, buf, 7);
+                    upgraded[7] = '+';
+                    memcpy(upgraded + 8, buf + 7, blen - 7 + 1);
+                    if (OSHash_Update(syscheck.fp, file_name, upgraded) == 1) {
+                        free(buf);
+                        buf = upgraded;
+                    } else {
+                        free(upgraded);
+                    }
                 }
             }
 #endif
@@ -400,14 +511,37 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
             {
                 int sum_off = fim_sum_data_offset(buf);
 
-                if (strcmp(c_sum, buf + sum_off) != 0) {
+                if (!fim_sum_equal(c_sum, buf + sum_off)) {
                     int real_change = fim_sum_has_real_change(buf + sum_off, c_sum);
 
                     if (real_change) {
                         /* Real integrity change: notify the manager first. */
                         alert_msg[OS_MAXSTR] = '\0';
                         #ifdef WIN32
-                        snprintf(alert_msg, 916, "%s %s", c_sum, file_name);
+                        {
+                            char *sum_only = NULL;
+                            char *acl_txt = NULL;
+                            size_t slen = fim_sum_data_len(c_sum);
+
+                            os_calloc(OS_MAXSTR + 1, sizeof(char), sum_only);
+                            os_calloc(OS_MAXSTR + 1, sizeof(char), acl_txt);
+                            if (slen > (size_t)OS_MAXSTR) {
+                                slen = (size_t)OS_MAXSTR;
+                            }
+                            memcpy(sum_only, c_sum, slen);
+                            sum_only[slen] = '\0';
+
+                            if (sum_off >= 9 &&
+                                    fim_win_acl_change_text(buf + sum_off, c_sum,
+                                                            acl_txt, (size_t)OS_MAXSTR + 1) > 0) {
+                                snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s",
+                                         sum_only, file_name, acl_txt);
+                            } else {
+                                snprintf(alert_msg, OS_MAXSTR, "%s %s", sum_only, file_name);
+                            }
+                            free(sum_only);
+                            free(acl_txt);
+                        }
                         #else
                         char *fullalert = NULL;
                         if (buf[5] == 's' || buf[5] == 'n') {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -581,7 +581,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                     {
                         char *updated;
                         char *old_data = buf;
-                        int nflags = sum_off;
+                        int nflags;
                         int fields = 1;
                         size_t clen = fim_sum_data_len(c_sum);
                         size_t i;
@@ -602,8 +602,12 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                         os_calloc((size_t)nflags + strlen(c_sum) + 1, sizeof(char), updated);
                         memcpy(updated, buf, 7);
                         if (nflags >= 8) {
-                            updated[7] = (sum_off >= 8) ? buf[7] :
-                                         ((fields >= 8) ? '+' : '-');
+                            updated[7] = (fields >= 8) ? '+' : '-';
+                            /* When only ACL forced the attrs slot, keep the slot
+                             * disabled unless the old entry marked attrs enabled. */
+                            if (fields == 9 && (sum_off < 8 || buf[7] != '+')) {
+                                updated[7] = '-';
+                            }
                         }
                         if (nflags >= 9) {
                             updated[8] = '+';

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -492,7 +492,16 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                     size_t data_len = (blen > (size_t)cur_off) ? (blen - (size_t)cur_off) : 0;
 
                     os_calloc((size_t)need + data_len + 1, sizeof(char), upgraded);
-                    memcpy(upgraded, buf, 7);
+                    /* Copy only the old flag prefix — never pull size digits
+                     * from legacy 6-flag entries into the flag slots. */
+                    {
+                        size_t flag_copy = (cur_off < 7) ? (size_t)cur_off : 7;
+
+                        memcpy(upgraded, buf, flag_copy);
+                        if (cur_off < 7) {
+                            upgraded[6] = (opts & CHECK_SHA256SUM) ? '+' : '-';
+                        }
+                    }
                     if (need >= 8) {
                         upgraded[7] = want_attrs ? '+' : '-';
                     }
@@ -543,9 +552,11 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                             memcpy(sum_only, c_sum, slen);
                             sum_only[slen] = '\0';
 
-                            if (sum_off >= 9 &&
-                                    fim_win_acl_change_text(buf + sum_off, c_sum,
-                                                            acl_txt, (size_t)OS_MAXSTR + 1) > 0) {
+                            /* fim_win_acl_change_text() already no-ops unless the
+                             * new sum carries an ACL digest/snapshot that changed,
+                             * so do not gate on sum_off (legacy 7/8-flag cache). */
+                            if (fim_win_acl_change_text(buf + sum_off, c_sum,
+                                                        acl_txt, (size_t)OS_MAXSTR + 1) > 0) {
                                 snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s",
                                          sum_only, file_name, acl_txt);
                             } else {
@@ -600,7 +611,17 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                         }
 
                         os_calloc((size_t)nflags + strlen(c_sum) + 1, sizeof(char), updated);
-                        memcpy(updated, buf, 7);
+                        /* Copy only the old flag prefix — never pull size digits
+                         * from legacy 6-flag entries into the flag slots. */
+                        {
+                            size_t flag_copy = (sum_off < 7) ? (size_t)sum_off : 7;
+
+                            memcpy(updated, buf, flag_copy);
+                            if (sum_off < 7) {
+                                /* Legacy cache had no sha256 enable flag. */
+                                updated[6] = '-';
+                            }
+                        }
                         if (nflags >= 8) {
                             updated[7] = (fields >= 8) ? '+' : '-';
                             /* When only ACL forced the attrs slot, keep the slot

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -9,6 +9,7 @@
 
 #include "shared.h"
 #include "syscheck.h"
+#include "fim_sum_op.h"
 #include "os_crypto/md5/md5_op.h"
 #include "os_crypto/sha1/sha1_op.h"
 #include "os_crypto/sha256/sha256_op.h"
@@ -211,6 +212,53 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
             }
 #endif
 
+#ifdef WIN32
+            {
+                DWORD win_attrs = 0;
+
+                if (opts & CHECK_ATTRS) {
+                    win_attrs = GetFileAttributes(file_name);
+                    if (win_attrs == INVALID_FILE_ATTRIBUTES) {
+                        merror("%s: WARN: Unable to get attributes for '%s' (%lu)",
+                               ARGV0, file_name, (unsigned long)GetLastError());
+                        return (0);
+                    }
+                    snprintf(hash_entry, 916,
+                             "%c%c%c%c%c%c%c+%ld:%d:%d:%d:%s:%s:%s:%lu",
+                             opts & CHECK_SIZE ? '+' : '-',
+                             opts & CHECK_PERM ? '+' : '-',
+                             opts & CHECK_OWNER ? '+' : '-',
+                             opts & CHECK_GROUP ? '+' : '-',
+                             opts & CHECK_MD5SUM ? '+' : '-',
+                             sha1s,
+                             opts & CHECK_SHA256SUM ? '+' : '-',
+                             opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
+                             opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
+                             opts & CHECK_OWNER ? (int)statbuf.st_uid : 0,
+                             opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
+                             opts & CHECK_MD5SUM ? mf_sum : "xxx",
+                             opts & CHECK_SHA1SUM ? sf_sum : "xxx",
+                             opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
+                             (unsigned long)win_attrs);
+                } else {
+                    snprintf(hash_entry, 916, "%c%c%c%c%c%c%c%ld:%d:%d:%d:%s:%s:%s",
+                             opts & CHECK_SIZE ? '+' : '-',
+                             opts & CHECK_PERM ? '+' : '-',
+                             opts & CHECK_OWNER ? '+' : '-',
+                             opts & CHECK_GROUP ? '+' : '-',
+                             opts & CHECK_MD5SUM ? '+' : '-',
+                             sha1s,
+                             opts & CHECK_SHA256SUM ? '+' : '-',
+                             opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
+                             opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
+                             opts & CHECK_OWNER ? (int)statbuf.st_uid : 0,
+                             opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
+                             opts & CHECK_MD5SUM ? mf_sum : "xxx",
+                             opts & CHECK_SHA1SUM ? sf_sum : "xxx",
+                             opts & CHECK_SHA256SUM ? sha256_sum : "xxx");
+                }
+            }
+#else
             snprintf(hash_entry, 916, "%c%c%c%c%c%c%c%ld:%d:%d:%d:%s:%s:%s",
                      opts & CHECK_SIZE ? '+' : '-',
                      opts & CHECK_PERM ? '+' : '-',
@@ -226,6 +274,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                      opts & CHECK_MD5SUM ? mf_sum : "xxx",
                      opts & CHECK_SHA1SUM ? sf_sum : "xxx",
                      opts & CHECK_SHA256SUM ? sha256_sum : "xxx");
+#endif
 
             /* Send the new checksum to the analysis server */
             alert_msg[916] = '\0';
@@ -274,16 +323,36 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
             }
             LocalFree(szSID);
             CloseHandle(hFile);
-    
-            snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s %s",
-                     opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
-                     opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
-                     (opts & CHECK_OWNER) ? st_uid : "0",
-                     opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
-                     opts & CHECK_MD5SUM ? mf_sum : "xxx",
-                     opts & CHECK_SHA1SUM ? sf_sum : "xxx",
-                     opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
-                     file_name);
+
+            if (opts & CHECK_ATTRS) {
+                DWORD win_attrs = GetFileAttributes(file_name);
+                if (win_attrs == INVALID_FILE_ATTRIBUTES) {
+                    free(st_uid);
+                    merror("%s: WARN: Unable to get attributes for '%s' (%lu)",
+                           ARGV0, file_name, (unsigned long)GetLastError());
+                    return (0);
+                }
+                snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s:%lu %s",
+                         opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
+                         opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
+                         (opts & CHECK_OWNER) ? st_uid : "0",
+                         opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
+                         opts & CHECK_MD5SUM ? mf_sum : "xxx",
+                         opts & CHECK_SHA1SUM ? sf_sum : "xxx",
+                         opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
+                         (unsigned long)win_attrs,
+                         file_name);
+            } else {
+                snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s %s",
+                         opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
+                         opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
+                         (opts & CHECK_OWNER) ? st_uid : "0",
+                         opts & CHECK_GROUP ? (int)statbuf.st_gid : 0,
+                         opts & CHECK_MD5SUM ? mf_sum : "xxx",
+                         opts & CHECK_SHA1SUM ? sf_sum : "xxx",
+                         opts & CHECK_SHA256SUM ? sha256_sum : "xxx",
+                         file_name);
+            }
             free(st_uid);
 #endif
             if (send_syscheck_msg(alert_msg) == 0) {
@@ -302,6 +371,25 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
             c_sum[OS_MAXSTR] = '\0';
             alert_msg[0] = '\0';
             alert_msg[OS_MAXSTR] = '\0';
+
+#ifdef WIN32
+            /* Upgrade local cache to 8-flag format when check_attrs was enabled. */
+            if ((opts & CHECK_ATTRS) && fim_sum_data_offset(buf) == 7) {
+                char *upgraded;
+                size_t blen = strlen(buf);
+
+                os_calloc(blen + 2, sizeof(char), upgraded);
+                memcpy(upgraded, buf, 7);
+                upgraded[7] = '+';
+                memcpy(upgraded + 8, buf + 7, blen - 7 + 1);
+                if (OSHash_Update(syscheck.fp, file_name, upgraded) == 1) {
+                    free(buf);
+                    buf = upgraded;
+                } else {
+                    free(upgraded);
+                }
+            }
+#endif
 
             /* If it returns < 0, we have already alerted (missing file) or
              * skipped (checksum read failure). */

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -198,12 +198,13 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
 
         buf = (char *) OSHash_Get(syscheck.fp, file_name);
         if (!buf) {
-            char alert_msg[916 + 1];    /* to accommodate a long */
+            char alert_msg[OS_MAXSTR + 1];
             char hash_entry[916 + 1];
             char *hash_full = NULL;     /* optional ACL snapshot entry */
-            alert_msg[916] = '\0';
+            alert_msg[OS_MAXSTR] = '\0';
             hash_entry[916] = '\0';
             hash_entry[0] = '\0';
+            alert_msg[0] = '\0';
 
 #ifndef WIN32
             if (opts & CHECK_SEECHANGES) {
@@ -219,7 +220,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
             {
                 DWORD win_attrs = 0;
                 char acl_digest[33];
-                char acl_snap[8192];
+                char *acl_snap = NULL;
                 fim_acl_t acl;
                 int have_acl = 0;
                 const char *uid_str;
@@ -231,34 +232,37 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                 char *st_uid = NULL;
 
                 acl_digest[0] = '\0';
-                acl_snap[0] = '\0';
                 memset(&acl, 0, sizeof(acl));
 
                 if (opts & CHECK_ATTRS) {
                     win_attrs = GetFileAttributes(file_name);
                     if (win_attrs == INVALID_FILE_ATTRIBUTES) {
-                        merror("%s: WARN: Unable to get attributes for '%s' (%lu)",
+                        merror("%s: WARN: Unable to get attributes for '%s' (%lu); "
+                               "continuing without attribute baseline",
                                ARGV0, file_name, (unsigned long)GetLastError());
-                        return (0);
+                        win_attrs = 0;
                     }
                 }
 
                 if (opts & CHECK_ACL) {
                     if (fim_win_acl_read(file_name, &acl) != 0) {
                         fim_acl_free(&acl);
-                        merror("%s: WARN: Unable to read ACL for '%s'",
+                        merror("%s: WARN: Unable to read ACL for '%s'; "
+                               "continuing without ACL baseline",
                                ARGV0, file_name);
-                        return (0);
-                    }
-                    if (fim_win_acl_digest(&acl, acl_digest) != 0 ||
-                            fim_win_acl_snapshot(&acl, acl_snap, sizeof(acl_snap)) != 0) {
+                    } else if (fim_win_acl_digest(&acl, acl_digest) != 0 ||
+                               (acl_snap = fim_win_acl_snapshot_dup(&acl)) == NULL) {
                         fim_acl_free(&acl);
-                        merror("%s: WARN: Unable to digest ACL for '%s'",
+                        free(acl_snap);
+                        acl_snap = NULL;
+                        merror("%s: WARN: Unable to digest ACL for '%s'; "
+                               "continuing without ACL baseline",
                                ARGV0, file_name);
-                        return (0);
+                        acl_digest[0] = '\0';
+                    } else {
+                        have_acl = 1;
+                        fim_acl_free(&acl);
                     }
-                    have_acl = 1;
-                    fim_acl_free(&acl);
                 }
 
                 if (have_acl) {
@@ -284,12 +288,16 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                              acl_digest);
                     {
                         size_t he_len = strlen(hash_entry);
-                        size_t snap_len = strlen(acl_snap);
+                        size_t snap_len = acl_snap ? strlen(acl_snap) : 0;
 
                         os_calloc(he_len + 1 + snap_len + 1, sizeof(char), hash_full);
                         memcpy(hash_full, hash_entry, he_len);
                         hash_full[he_len] = '\n';
-                        memcpy(hash_full + he_len + 1, acl_snap, snap_len + 1);
+                        if (acl_snap) {
+                            memcpy(hash_full + he_len + 1, acl_snap, snap_len + 1);
+                        } else {
+                            hash_full[he_len + 1] = '\0';
+                        }
                     }
                 } else if (opts & CHECK_ATTRS) {
                     snprintf(hash_entry, 916,
@@ -328,7 +336,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                 }
 
                 /* Owner SID for the manager alert (reuse attrs/ACL above). */
-                alert_msg[916] = '\0';
+                alert_msg[OS_MAXSTR] = '\0';
                 hFile = CreateFile(file_name, GENERIC_READ,
                                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                                    NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
@@ -336,6 +344,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                     DWORD dwErrorCode = GetLastError();
                     char err_msg[PATH_MAX + 4];
                     free(hash_full);
+                    free(acl_snap);
                     err_msg[PATH_MAX + 3] = '\0';
                     snprintf(err_msg, PATH_MAX + 4, "CreateFile=%ld %s",
                              dwErrorCode, file_name);
@@ -350,6 +359,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                     DWORD dwErrorCode = GetLastError();
                     CloseHandle(hFile);
                     free(hash_full);
+                    free(acl_snap);
                     {
                         char err_msg[PATH_MAX + 4];
                         err_msg[PATH_MAX + 3] = '\0';
@@ -374,7 +384,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                 uid_str = (opts & CHECK_OWNER) ? (st_uid ? st_uid : "0") : "0";
 
                 if (have_acl) {
-                    snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s:%lu:%s %s",
+                    snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%s:%d:%s:%s:%s:%lu:%s %s",
                              opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
                              opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
                              uid_str,
@@ -386,7 +396,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                              acl_digest,
                              file_name);
                 } else if (opts & CHECK_ATTRS) {
-                    snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s:%lu %s",
+                    snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%s:%d:%s:%s:%s:%lu %s",
                              opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
                              opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
                              uid_str,
@@ -397,7 +407,7 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                              (unsigned long)win_attrs,
                              file_name);
                 } else {
-                    snprintf(alert_msg, 916, "%ld:%d:%s:%d:%s:%s:%s %s",
+                    snprintf(alert_msg, OS_MAXSTR, "%ld:%d:%s:%d:%s:%s:%s %s",
                              opts & CHECK_SIZE ? (long)statbuf.st_size : 0,
                              opts & CHECK_PERM ? (int)statbuf.st_mode : 0,
                              uid_str,
@@ -408,6 +418,8 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                              file_name);
                 }
                 free(st_uid);
+                free(acl_snap);
+                acl_snap = NULL;
             }
 #else
             snprintf(hash_entry, 916, "%c%c%c%c%c%c%c%ld:%d:%d:%d:%s:%s:%s",
@@ -459,39 +471,39 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
             alert_msg[OS_MAXSTR] = '\0';
 
 #ifdef WIN32
-            /* Upgrade local cache flag format when attrs/ACL were enabled. */
+            /* Keep local cache flag format aligned with current directory opts. */
             {
                 int cur_off = fim_sum_data_offset(buf);
+                int want_attrs = (opts & CHECK_ATTRS) ? 1 : 0;
+                int want_acl = (opts & CHECK_ACL) ? 1 : 0;
+                int need = 7;
 
-                if ((opts & CHECK_ACL) && (cur_off == 7 || cur_off == 8)) {
+                if (want_acl) {
+                    need = 9;
+                } else if (want_attrs) {
+                    need = 8;
+                }
+
+                if (cur_off != need ||
+                        (need >= 8 && ((buf[7] == '+') != want_attrs)) ||
+                        (need >= 9 && ((buf[8] == '+') != want_acl))) {
                     char *upgraded;
                     size_t blen = strlen(buf);
-                    size_t insert = (size_t)(9 - cur_off);
+                    size_t data_len = (blen > (size_t)cur_off) ? (blen - (size_t)cur_off) : 0;
 
-                    os_calloc(blen + insert + 1, sizeof(char), upgraded);
-                    memcpy(upgraded, buf, (size_t)cur_off);
-                    if (cur_off == 7) {
-                        upgraded[7] = (opts & CHECK_ATTRS) ? '+' : '-';
-                        upgraded[8] = '+';
-                        memcpy(upgraded + 9, buf + 7, blen - 7 + 1);
-                    } else {
-                        upgraded[8] = '+';
-                        memcpy(upgraded + 9, buf + 8, blen - 8 + 1);
-                    }
-                    if (OSHash_Update(syscheck.fp, file_name, upgraded) == 1) {
-                        free(buf);
-                        buf = upgraded;
-                    } else {
-                        free(upgraded);
-                    }
-                } else if ((opts & CHECK_ATTRS) && cur_off == 7) {
-                    char *upgraded;
-                    size_t blen = strlen(buf);
-
-                    os_calloc(blen + 2, sizeof(char), upgraded);
+                    os_calloc((size_t)need + data_len + 1, sizeof(char), upgraded);
                     memcpy(upgraded, buf, 7);
-                    upgraded[7] = '+';
-                    memcpy(upgraded + 8, buf + 7, blen - 7 + 1);
+                    if (need >= 8) {
+                        upgraded[7] = want_attrs ? '+' : '-';
+                    }
+                    if (need >= 9) {
+                        upgraded[8] = want_acl ? '+' : '-';
+                    }
+                    if (data_len > 0) {
+                        memcpy(upgraded + need, buf + cur_off, data_len + 1);
+                    } else {
+                        upgraded[need] = '\0';
+                    }
                     if (OSHash_Update(syscheck.fp, file_name, upgraded) == 1) {
                         free(buf);
                         buf = upgraded;
@@ -569,10 +581,34 @@ static int read_file(const char *file_name, int opts, OSMatch *restriction)
                     {
                         char *updated;
                         char *old_data = buf;
+                        int nflags = sum_off;
+                        int fields = 1;
+                        size_t clen = fim_sum_data_len(c_sum);
+                        size_t i;
 
-                        os_calloc((size_t)sum_off + strlen(c_sum) + 1, sizeof(char), updated);
-                        memcpy(updated, buf, (size_t)sum_off);
-                        memcpy(updated + sum_off, c_sum, strlen(c_sum) + 1);
+                        for (i = 0; i < clen; i++) {
+                            if (c_sum[i] == ':') {
+                                fields++;
+                            }
+                        }
+                        if (fields >= 9) {
+                            nflags = 9;
+                        } else if (fields >= 8) {
+                            nflags = 8;
+                        } else {
+                            nflags = 7;
+                        }
+
+                        os_calloc((size_t)nflags + strlen(c_sum) + 1, sizeof(char), updated);
+                        memcpy(updated, buf, 7);
+                        if (nflags >= 8) {
+                            updated[7] = (sum_off >= 8) ? buf[7] :
+                                         ((fields >= 8) ? '+' : '-');
+                        }
+                        if (nflags >= 9) {
+                            updated[8] = '+';
+                        }
+                        memcpy(updated + nflags, c_sum, strlen(c_sum) + 1);
                         if (OSHash_Update(syscheck.fp, file_name, updated) == 1) {
                             free(old_data);
                         } else {

--- a/src/syscheckd/create_db.c
+++ b/src/syscheckd/create_db.c
@@ -674,7 +674,7 @@ int read_dir(const char *dir_name, int opts, OSMatch *restriction)
     /* Check for real time flag */
     if (opts & CHECK_REALTIME) {
 #if defined(INOTIFY_ENABLED) || defined(WIN32)
-        realtime_adddir(dir_name);
+        realtime_adddir(dir_name, opts);
 #else
         merror("%s: WARN: realtime monitoring request on unsupported system for '%s'",
                 ARGV0,

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -20,6 +20,7 @@
 
 #include "shared.h"
 #include "syscheck.h"
+#include "fim_sum_op.h"
 #include "os_crypto/md5/md5_op.h"
 #include "os_crypto/sha1/sha1_op.h"
 #include "os_crypto/sha256/sha256_op.h"
@@ -347,12 +348,17 @@ void start_daemon()
 int c_read_file(const char *file_name, const char *oldsum, char *newsum)
 {
     int size = 0, perm = 0, owner = 0, group = 0, md5sum = 0, sha1sum = 0, sha256sum = 0;
+    int attrs = 0;
     int return_error = 0;
     int checksum_failed = 0;
+    int sum_off;
     struct stat statbuf;
     os_md5 mf_sum;
     os_sha1 sf_sum;
     os_sha256 sha256_sum;
+#ifdef WIN32
+    DWORD win_attrs = 0;
+#endif
 
     /* Clean sums */
     strncpy(mf_sum, "xxx", 4);
@@ -384,6 +390,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     }
 
     /* Get the old sum values */
+    sum_off = fim_sum_data_offset(oldsum);
 
     /* size */
     if (oldsum[0] == '+') {
@@ -425,6 +432,22 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
         sha256sum = 0;
     }
     /* If it's a digit (size), then it's the old format, no sha256 */
+
+#ifdef WIN32
+    /* attrs flag is only present in the 8-char flag format */
+    if (sum_off >= 8 && oldsum[7] == '+') {
+        attrs = 1;
+        win_attrs = GetFileAttributes(file_name);
+        if (win_attrs == INVALID_FILE_ATTRIBUTES) {
+            merror("%s: WARN: Unable to get attributes for '%s' (%lu)",
+                   ARGV0, file_name, (unsigned long)GetLastError());
+            return (-2);
+        }
+    }
+#else
+    (void)attrs;
+    (void)sum_off;
+#endif
 
     /* Generate new checksum */
     if (S_ISREG(statbuf.st_mode))
@@ -539,14 +562,26 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     LocalFree(szSID);
     CloseHandle(hFile);
 
-    snprintf(newsum, OS_MAXSTR, "%ld:%d:%s:%d:%s:%s:%s",
-             size == 0 ? 0 : (long)statbuf.st_size,
-             perm == 0 ? 0 : (int)statbuf.st_mode,
-             owner == 0 ? "0" : st_uid,
-             group == 0 ? 0 : (int)statbuf.st_gid,
-             md5sum   == 0 ? "xxx" : mf_sum,
-             sha1sum  == 0 ? "xxx" : sf_sum,
-             sha256sum == 0 ? "xxx" : sha256_sum);
+    if (attrs) {
+        snprintf(newsum, OS_MAXSTR, "%ld:%d:%s:%d:%s:%s:%s:%lu",
+                 size == 0 ? 0 : (long)statbuf.st_size,
+                 perm == 0 ? 0 : (int)statbuf.st_mode,
+                 owner == 0 ? "0" : st_uid,
+                 group == 0 ? 0 : (int)statbuf.st_gid,
+                 md5sum   == 0 ? "xxx" : mf_sum,
+                 sha1sum  == 0 ? "xxx" : sf_sum,
+                 sha256sum == 0 ? "xxx" : sha256_sum,
+                 (unsigned long)win_attrs);
+    } else {
+        snprintf(newsum, OS_MAXSTR, "%ld:%d:%s:%d:%s:%s:%s",
+                 size == 0 ? 0 : (long)statbuf.st_size,
+                 perm == 0 ? 0 : (int)statbuf.st_mode,
+                 owner == 0 ? "0" : st_uid,
+                 group == 0 ? 0 : (int)statbuf.st_gid,
+                 md5sum   == 0 ? "xxx" : mf_sum,
+                 sha1sum  == 0 ? "xxx" : sf_sum,
+                 sha256sum == 0 ? "xxx" : sha256_sum);
+    }
 
     free(st_uid);
 #endif

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -341,13 +341,19 @@ void start_daemon()
     }
 }
 
-/* Resolve syscheck opts for a path (longest matching configured directory). */
-static int syscheck_opts_for_path(const char *path)
+/* Resolve syscheck opts for a path (longest matching configured directory).
+ * Sets *matched to 1 when a directory matched, 0 otherwise (so callers can
+ * distinguish "matched with opts==0" from "no match").
+ */
+static int syscheck_opts_for_path(const char *path, int *matched)
 {
     int i;
     int best = -1;
     size_t best_len = 0;
 
+    if (matched) {
+        *matched = 0;
+    }
     if (!path || !syscheck.dir) {
         return (0);
     }
@@ -376,7 +382,13 @@ static int syscheck_opts_for_path(const char *path)
         best = i;
     }
 
-    return (best >= 0) ? syscheck.opts[best] : 0;
+    if (best < 0) {
+        return (0);
+    }
+    if (matched) {
+        *matched = 1;
+    }
+    return (syscheck.opts[best]);
 }
 
 /* Read file information and return a pointer to the checksum.
@@ -393,6 +405,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     int checksum_failed = 0;
     int sum_off;
     int path_opts;
+    int path_matched = 0;
     struct stat statbuf;
     os_md5 mf_sum;
     os_sha1 sf_sum;
@@ -413,7 +426,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     memset(&facl, 0, sizeof(facl));
 #endif
 
-    path_opts = syscheck_opts_for_path(file_name);
+    path_opts = syscheck_opts_for_path(file_name, &path_matched);
 
     /* Stat the file */
 #ifdef WIN32
@@ -494,7 +507,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
                    ARGV0, file_name, (unsigned long)GetLastError());
             return (-2);
         }
-    } else if (path_opts == 0 && sum_off >= 8 && oldsum[7] == '+') {
+    } else if (!path_matched && sum_off >= 8 && oldsum[7] == '+') {
         /* Path not matched to a configured directory; honor cache flags. */
         attrs = 1;
         win_attrs = GetFileAttributes(file_name);
@@ -514,7 +527,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
             return (-2);
         }
         have_facl = 1;
-    } else if (path_opts == 0 && sum_off >= 9 && oldsum[8] == '+') {
+    } else if (!path_matched && sum_off >= 9 && oldsum[8] == '+') {
         acl = 1;
         if (fim_win_acl_read(file_name, &facl) != 0 ||
                 fim_win_acl_digest(&facl, acl_digest) != 0) {
@@ -529,6 +542,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     (void)acl;
     (void)sum_off;
     (void)path_opts;
+    (void)path_matched;
 #endif
 
     /* Generate new checksum */

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -21,6 +21,7 @@
 #include "shared.h"
 #include "syscheck.h"
 #include "fim_sum_op.h"
+#include "win_acl_op.h"
 #include "os_crypto/md5/md5_op.h"
 #include "os_crypto/sha1/sha1_op.h"
 #include "os_crypto/sha256/sha256_op.h"
@@ -349,6 +350,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
 {
     int size = 0, perm = 0, owner = 0, group = 0, md5sum = 0, sha1sum = 0, sha256sum = 0;
     int attrs = 0;
+    int acl = 0;
     int return_error = 0;
     int checksum_failed = 0;
     int sum_off;
@@ -358,12 +360,19 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     os_sha256 sha256_sum;
 #ifdef WIN32
     DWORD win_attrs = 0;
+    char acl_digest[33];
+    fim_acl_t facl;
+    int have_facl = 0;
 #endif
 
     /* Clean sums */
     strncpy(mf_sum, "xxx", 4);
     strncpy(sf_sum, "xxx", 4);
     strncpy(sha256_sum, "xxx", 4);
+#ifdef WIN32
+    acl_digest[0] = '\0';
+    memset(&facl, 0, sizeof(facl));
+#endif
 
     /* Stat the file */
 #ifdef WIN32
@@ -434,7 +443,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     /* If it's a digit (size), then it's the old format, no sha256 */
 
 #ifdef WIN32
-    /* attrs flag is only present in the 8-char flag format */
+    /* attrs: present in 8+ flag formats; value used when flag[7] is '+'. */
     if (sum_off >= 8 && oldsum[7] == '+') {
         attrs = 1;
         win_attrs = GetFileAttributes(file_name);
@@ -444,8 +453,21 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
             return (-2);
         }
     }
+
+    /* ACL: 9-flag format with flag[8] == '+' */
+    if (sum_off >= 9 && oldsum[8] == '+') {
+        acl = 1;
+        if (fim_win_acl_read(file_name, &facl) != 0 ||
+                fim_win_acl_digest(&facl, acl_digest) != 0) {
+            fim_acl_free(&facl);
+            merror("%s: WARN: Unable to read ACL for '%s'", ARGV0, file_name);
+            return (-2);
+        }
+        have_facl = 1;
+    }
 #else
     (void)attrs;
+    (void)acl;
     (void)sum_off;
 #endif
 
@@ -505,18 +527,17 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
 #endif
 
     if (checksum_failed) {
+#ifdef WIN32
+        if (have_facl) {
+            fim_acl_free(&facl);
+        }
+#endif
         return (-2);
     }
 
     newsum[0] = '\0';
-    /* Caller is expected to provide a buffer of at least 
-     * 256 + 2 bytes for `newsum` 
-     * (see create_db.c: char c_sum[OS_MAXSTR + 1];). The
-     * snprintf() below is limited to
-     * OS_MAXSTR bytes, which is safely within that size even 
-     * when including all checksum
-     * fields (size, perm, uid, gid, md5, sha1, 
-     * sha256).
+    /* Caller is expected to provide a buffer of at least
+     * OS_MAXSTR + 1 bytes for `newsum`.
      */
 
 #ifndef WIN32
@@ -529,10 +550,15 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
              sha1sum  == 0 ? "xxx" : sf_sum,
              sha256sum == 0 ? "xxx" : sha256_sum);
 #else
-    HANDLE hFile = CreateFile(file_name, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    HANDLE hFile = CreateFile(file_name, GENERIC_READ,
+                              FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                              NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE) {
         DWORD dwErrorCode = GetLastError();
         char alert_msg[PATH_MAX+4];
+        if (have_facl) {
+            fim_acl_free(&facl);
+        }
         alert_msg[PATH_MAX + 3] = '\0';
         snprintf(alert_msg, PATH_MAX + 4, "CreateFile=%ld %s", dwErrorCode, file_name);
         send_syscheck_msg(alert_msg);
@@ -545,10 +571,15 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     if (dwRtnCode != ERROR_SUCCESS) {
         DWORD dwErrorCode = GetLastError();
         CloseHandle(hFile);
-        char alert_msg[PATH_MAX+4];
-        alert_msg[PATH_MAX + 3] = '\0';
-        snprintf(alert_msg, PATH_MAX + 4, "GetSecurityInfo=%ld %s", dwErrorCode, file_name);
-        send_syscheck_msg(alert_msg);
+        if (have_facl) {
+            fim_acl_free(&facl);
+        }
+        {
+            char alert_msg[PATH_MAX+4];
+            alert_msg[PATH_MAX + 3] = '\0';
+            snprintf(alert_msg, PATH_MAX + 4, "GetSecurityInfo=%ld %s", dwErrorCode, file_name);
+            send_syscheck_msg(alert_msg);
+        }
         return -1;
     }
 
@@ -560,13 +591,42 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
       memcpy( st_uid, szSID, strlen(szSID) );
     }
     LocalFree(szSID);
+    if (pSD) {
+        LocalFree(pSD);
+    }
     CloseHandle(hFile);
 
-    if (attrs) {
+    if (acl) {
+        /* attrs slot always present when ACL is enabled (0 if unchecked). */
+        snprintf(newsum, OS_MAXSTR, "%ld:%d:%s:%d:%s:%s:%s:%lu:%s",
+                 size == 0 ? 0 : (long)statbuf.st_size,
+                 perm == 0 ? 0 : (int)statbuf.st_mode,
+                 owner == 0 ? "0" : (st_uid ? st_uid : "0"),
+                 group == 0 ? 0 : (int)statbuf.st_gid,
+                 md5sum   == 0 ? "xxx" : mf_sum,
+                 sha1sum  == 0 ? "xxx" : sf_sum,
+                 sha256sum == 0 ? "xxx" : sha256_sum,
+                 attrs ? (unsigned long)win_attrs : 0UL,
+                 acl_digest);
+        /* Append SID-stable snapshot for local cache / ACE diffs. */
+        if (have_facl) {
+            size_t used = strlen(newsum);
+            if (used + 2 < (size_t)OS_MAXSTR) {
+                newsum[used] = '\n';
+                newsum[used + 1] = '\0';
+                if (fim_win_acl_snapshot(&facl, newsum + used + 1,
+                                         (size_t)OS_MAXSTR - used - 1) != 0) {
+                    newsum[used] = '\0';
+                }
+            }
+            fim_acl_free(&facl);
+            have_facl = 0;
+        }
+    } else if (attrs) {
         snprintf(newsum, OS_MAXSTR, "%ld:%d:%s:%d:%s:%s:%s:%lu",
                  size == 0 ? 0 : (long)statbuf.st_size,
                  perm == 0 ? 0 : (int)statbuf.st_mode,
-                 owner == 0 ? "0" : st_uid,
+                 owner == 0 ? "0" : (st_uid ? st_uid : "0"),
                  group == 0 ? 0 : (int)statbuf.st_gid,
                  md5sum   == 0 ? "xxx" : mf_sum,
                  sha1sum  == 0 ? "xxx" : sf_sum,
@@ -576,13 +636,16 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
         snprintf(newsum, OS_MAXSTR, "%ld:%d:%s:%d:%s:%s:%s",
                  size == 0 ? 0 : (long)statbuf.st_size,
                  perm == 0 ? 0 : (int)statbuf.st_mode,
-                 owner == 0 ? "0" : st_uid,
+                 owner == 0 ? "0" : (st_uid ? st_uid : "0"),
                  group == 0 ? 0 : (int)statbuf.st_gid,
                  md5sum   == 0 ? "xxx" : mf_sum,
                  sha1sum  == 0 ? "xxx" : sf_sum,
                  sha256sum == 0 ? "xxx" : sha256_sum);
     }
 
+    if (have_facl) {
+        fim_acl_free(&facl);
+    }
     free(st_uid);
 #endif
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -362,7 +362,16 @@ static int syscheck_opts_for_path(const char *path, int *matched)
         size_t len = strlen(syscheck.dir[i]);
         char next;
 
-        if (len == 0 || len < best_len) {
+        if (len == 0) {
+            continue;
+        }
+        /* Normalize trailing separators so "/var/log/" matches "/var/log/foo".
+         * Keep a lone "/" (or "\") so the root directory still matches. */
+        while (len > 1 && (syscheck.dir[i][len - 1] == '/' ||
+                           syscheck.dir[i][len - 1] == '\\')) {
+            len--;
+        }
+        if (len < best_len) {
             continue;
         }
 #ifdef WIN32

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -341,6 +341,44 @@ void start_daemon()
     }
 }
 
+/* Resolve syscheck opts for a path (longest matching configured directory). */
+static int syscheck_opts_for_path(const char *path)
+{
+    int i;
+    int best = -1;
+    size_t best_len = 0;
+
+    if (!path || !syscheck.dir) {
+        return (0);
+    }
+
+    for (i = 0; syscheck.dir[i]; i++) {
+        size_t len = strlen(syscheck.dir[i]);
+        char next;
+
+        if (len == 0 || len < best_len) {
+            continue;
+        }
+#ifdef WIN32
+        if (strncasecmp(path, syscheck.dir[i], len) != 0) {
+            continue;
+        }
+#else
+        if (strncmp(path, syscheck.dir[i], len) != 0) {
+            continue;
+        }
+#endif
+        next = path[len];
+        if (next != '\0' && next != '/' && next != '\\') {
+            continue;
+        }
+        best_len = len;
+        best = i;
+    }
+
+    return (best >= 0) ? syscheck.opts[best] : 0;
+}
+
 /* Read file information and return a pointer to the checksum.
  * Returns 0 on success, -1 if the file is missing (delete alert already
  * sent), -2 if metadata/checksum read failed (e.g. EACCES, EMFILE) so
@@ -354,6 +392,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     int return_error = 0;
     int checksum_failed = 0;
     int sum_off;
+    int path_opts;
     struct stat statbuf;
     os_md5 mf_sum;
     os_sha1 sf_sum;
@@ -373,6 +412,8 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     acl_digest[0] = '\0';
     memset(&facl, 0, sizeof(facl));
 #endif
+
+    path_opts = syscheck_opts_for_path(file_name);
 
     /* Stat the file */
 #ifdef WIN32
@@ -443,8 +484,18 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     /* If it's a digit (size), then it's the old format, no sha256 */
 
 #ifdef WIN32
-    /* attrs: present in 8+ flag formats; value used when flag[7] is '+'. */
-    if (sum_off >= 8 && oldsum[7] == '+') {
+    /* Prefer current directory opts over sticky cache flags so enabling or
+     * disabling check_attrs / check_acl takes effect without a DB wipe. */
+    if (path_opts & CHECK_ATTRS) {
+        attrs = 1;
+        win_attrs = GetFileAttributes(file_name);
+        if (win_attrs == INVALID_FILE_ATTRIBUTES) {
+            merror("%s: WARN: Unable to get attributes for '%s' (%lu)",
+                   ARGV0, file_name, (unsigned long)GetLastError());
+            return (-2);
+        }
+    } else if (path_opts == 0 && sum_off >= 8 && oldsum[7] == '+') {
+        /* Path not matched to a configured directory; honor cache flags. */
         attrs = 1;
         win_attrs = GetFileAttributes(file_name);
         if (win_attrs == INVALID_FILE_ATTRIBUTES) {
@@ -454,8 +505,16 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
         }
     }
 
-    /* ACL: 9-flag format with flag[8] == '+' */
-    if (sum_off >= 9 && oldsum[8] == '+') {
+    if (path_opts & CHECK_ACL) {
+        acl = 1;
+        if (fim_win_acl_read(file_name, &facl) != 0 ||
+                fim_win_acl_digest(&facl, acl_digest) != 0) {
+            fim_acl_free(&facl);
+            merror("%s: WARN: Unable to read ACL for '%s'", ARGV0, file_name);
+            return (-2);
+        }
+        have_facl = 1;
+    } else if (path_opts == 0 && sum_off >= 9 && oldsum[8] == '+') {
         acl = 1;
         if (fim_win_acl_read(file_name, &facl) != 0 ||
                 fim_win_acl_digest(&facl, acl_digest) != 0) {
@@ -469,6 +528,7 @@ int c_read_file(const char *file_name, const char *oldsum, char *newsum)
     (void)attrs;
     (void)acl;
     (void)sum_off;
+    (void)path_opts;
 #endif
 
     /* Generate new checksum */

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -189,7 +189,7 @@ int realtime_start()
 }
 
 /* Add a directory to real time checking */
-int realtime_adddir(const char *dir)
+int realtime_adddir(const char *dir, __attribute__((unused)) int opts)
 {
     if (!syscheck.realtime) {
         realtime_start();
@@ -293,6 +293,7 @@ typedef struct _win32rtfim {
     OVERLAPPED overlap;
 
     char *dir;
+    int opts;
     TCHAR buffer[1228800];
 } win32rtfim;
 
@@ -374,12 +375,23 @@ int realtime_start()
 int realtime_win32read(win32rtfim *rtlocald)
 {
     int rc;
+    DWORD notify_filter;
+
+    notify_filter = FILE_NOTIFY_CHANGE_FILE_NAME |
+                    FILE_NOTIFY_CHANGE_DIR_NAME |
+                    FILE_NOTIFY_CHANGE_SIZE |
+                    FILE_NOTIFY_CHANGE_LAST_WRITE |
+                    FILE_NOTIFY_CHANGE_SECURITY;
+    /* Attribute notifications only when check_attrs is enabled for this dir. */
+    if (rtlocald->opts & CHECK_ATTRS) {
+        notify_filter |= FILE_NOTIFY_CHANGE_ATTRIBUTES;
+    }
 
     rc = ReadDirectoryChangesW(rtlocald->h,
                                rtlocald->buffer,
                                sizeof(rtlocald->buffer) / sizeof(TCHAR),
                                TRUE,
-                               FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_SIZE | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_SECURITY | FILE_NOTIFY_CHANGE_ATTRIBUTES,
+                               notify_filter,
                                0,
                                &rtlocald->overlap,
                                RTCallBack);
@@ -392,7 +404,7 @@ int realtime_win32read(win32rtfim *rtlocald)
     return (0);
 }
 
-int realtime_adddir(const char *dir)
+int realtime_adddir(const char *dir, int opts)
 {
     char wdchar[32 + 1];
     win32rtfim *rtlocald;
@@ -429,6 +441,7 @@ int realtime_adddir(const char *dir)
     }
 
     rtlocald->overlap.Offset = ++syscheck.realtime->fd;
+    rtlocald->opts = opts;
 
     /* Set key for hash */
     wdchar[32] = '\0';
@@ -462,7 +475,8 @@ int realtime_start()
     return (0);
 }
 
-int realtime_adddir(__attribute__((unused)) const char *dir)
+int realtime_adddir(__attribute__((unused)) const char *dir,
+                    __attribute__((unused)) int opts)
 {
     return (0);
 }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -113,10 +113,38 @@ int realtime_checksumfile(const char *file_name)
                 {
                     char *updated;
                     char *old_data = buf;
+                    int nflags = sum_off;
+                    int fields = 1;
+                    size_t clen = fim_sum_data_len(c_sum);
+                    size_t i;
 
-                    os_calloc((size_t)sum_off + strlen(c_sum) + 1, sizeof(char), updated);
-                    memcpy(updated, buf, (size_t)sum_off);
-                    memcpy(updated + sum_off, c_sum, strlen(c_sum) + 1);
+                    for (i = 0; i < clen; i++) {
+                        if (c_sum[i] == ':') {
+                            fields++;
+                        }
+                    }
+                    if (fields >= 9) {
+                        nflags = 9;
+                    } else if (fields >= 8) {
+                        nflags = 8;
+                    } else {
+                        nflags = 7;
+                    }
+
+                    os_calloc((size_t)nflags + strlen(c_sum) + 1, sizeof(char), updated);
+                    memcpy(updated, buf, 7);
+                    if (nflags >= 8) {
+                        updated[7] = (fields >= 8) ? '+' : '-';
+                        /* Prefer attrs enablement from field presence; keep
+                         * disabled marker when only ACL forced a slot. */
+                        if (fields == 9 && buf[7] == '-') {
+                            updated[7] = '-';
+                        }
+                    }
+                    if (nflags >= 9) {
+                        updated[8] = '+';
+                    }
+                    memcpy(updated + nflags, c_sum, strlen(c_sum) + 1);
                     if (OSHash_Update(syscheck.fp, file_name, updated) == 1) {
                         free(old_data);
                     } else {

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -355,7 +355,7 @@ int realtime_win32read(win32rtfim *rtlocald)
                                rtlocald->buffer,
                                sizeof(rtlocald->buffer) / sizeof(TCHAR),
                                TRUE,
-                               FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_SIZE | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_SECURITY,
+                               FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_SIZE | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_SECURITY | FILE_NOTIFY_CHANGE_ATTRIBUTES,
                                0,
                                &rtlocald->overlap,
                                RTCallBack);

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -113,7 +113,7 @@ int realtime_checksumfile(const char *file_name)
                 {
                     char *updated;
                     char *old_data = buf;
-                    int nflags = sum_off;
+                    int nflags;
                     int fields = 1;
                     size_t clen = fim_sum_data_len(c_sum);
                     size_t i;
@@ -135,9 +135,9 @@ int realtime_checksumfile(const char *file_name)
                     memcpy(updated, buf, 7);
                     if (nflags >= 8) {
                         updated[7] = (fields >= 8) ? '+' : '-';
-                        /* Prefer attrs enablement from field presence; keep
-                         * disabled marker when only ACL forced a slot. */
-                        if (fields == 9 && buf[7] == '-') {
+                        /* When only ACL forced the attrs slot, keep the slot
+                         * disabled unless the old entry marked attrs enabled. */
+                        if (fields == 9 && (sum_off < 8 || buf[7] != '+')) {
                             updated[7] = '-';
                         }
                     }

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -27,6 +27,7 @@
 
 #include "syscheck.h"
 #include "error_messages/error_messages.h"
+#include "win_acl_op.h"
 
 /* Prototypes */
 int realtime_checksumfile(const char *file_name) __attribute__((nonnull));
@@ -52,7 +53,7 @@ int realtime_checksumfile(const char *file_name)
         {
             int sum_off = fim_sum_data_offset(buf);
 
-            if (strcmp(c_sum, buf + sum_off) != 0) {
+            if (!fim_sum_equal(c_sum, buf + sum_off)) {
                 char alert_msg[OS_MAXSTR + 1];
                 int real_change = fim_sum_has_real_change(buf + sum_off, c_sum);
 
@@ -60,7 +61,30 @@ int realtime_checksumfile(const char *file_name)
                     alert_msg[OS_MAXSTR] = '\0';
 
                     #ifdef WIN32
-                    snprintf(alert_msg, 912, "%s %s", c_sum, file_name);
+                    {
+                        char *sum_only = NULL;
+                        char *acl_txt = NULL;
+                        size_t slen = fim_sum_data_len(c_sum);
+
+                        os_calloc(OS_MAXSTR + 1, sizeof(char), sum_only);
+                        os_calloc(OS_MAXSTR + 1, sizeof(char), acl_txt);
+                        if (slen > (size_t)OS_MAXSTR) {
+                            slen = (size_t)OS_MAXSTR;
+                        }
+                        memcpy(sum_only, c_sum, slen);
+                        sum_only[slen] = '\0';
+
+                        if (sum_off >= 9 &&
+                                fim_win_acl_change_text(buf + sum_off, c_sum,
+                                                        acl_txt, (size_t)OS_MAXSTR + 1) > 0) {
+                            snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s",
+                                     sum_only, file_name, acl_txt);
+                        } else {
+                            snprintf(alert_msg, OS_MAXSTR, "%s %s", sum_only, file_name);
+                        }
+                        free(sum_only);
+                        free(acl_txt);
+                    }
                     #else
                     char *fullalert = NULL;
 

--- a/src/syscheckd/run_realtime.c
+++ b/src/syscheckd/run_realtime.c
@@ -74,9 +74,11 @@ int realtime_checksumfile(const char *file_name)
                         memcpy(sum_only, c_sum, slen);
                         sum_only[slen] = '\0';
 
-                        if (sum_off >= 9 &&
-                                fim_win_acl_change_text(buf + sum_off, c_sum,
-                                                        acl_txt, (size_t)OS_MAXSTR + 1) > 0) {
+                        /* fim_win_acl_change_text() already no-ops unless the
+                         * new sum carries an ACL digest/snapshot that changed,
+                         * so do not gate on sum_off (legacy 7/8-flag cache). */
+                        if (fim_win_acl_change_text(buf + sum_off, c_sum,
+                                                    acl_txt, (size_t)OS_MAXSTR + 1) > 0) {
                             snprintf(alert_msg, OS_MAXSTR, "%s %s\n%s",
                                      sum_only, file_name, acl_txt);
                         } else {
@@ -132,7 +134,17 @@ int realtime_checksumfile(const char *file_name)
                     }
 
                     os_calloc((size_t)nflags + strlen(c_sum) + 1, sizeof(char), updated);
-                    memcpy(updated, buf, 7);
+                    /* Copy only the old flag prefix — never pull size digits
+                     * from legacy 6-flag entries into the flag slots. */
+                    {
+                        size_t flag_copy = (sum_off < 7) ? (size_t)sum_off : 7;
+
+                        memcpy(updated, buf, flag_copy);
+                        if (sum_off < 7) {
+                            /* Legacy cache had no sha256 enable flag. */
+                            updated[6] = '-';
+                        }
+                    }
                     if (nflags >= 8) {
                         updated[7] = (fields >= 8) ? '+' : '-';
                         /* When only ACL forced the attrs slot, keep the slot

--- a/src/syscheckd/syscheck.h
+++ b/src/syscheckd/syscheck.h
@@ -46,8 +46,11 @@ void os_winreg_check(void);
 /* Start real time */
 int realtime_start(void);
 
-/* Add a directory to real time monitoring */
-int realtime_adddir(const char *dir) __attribute__((nonnull));
+/* Add a directory to real time monitoring.
+ * opts: syscheck directory options (Windows uses CHECK_ATTRS for the
+ * attribute notify mask; ignored on other platforms).
+ */
+int realtime_adddir(const char *dir, int opts) __attribute__((nonnull(1)));
 
 /* Process real time queue */
 int realtime_process(void);


### PR DESCRIPTION
- New directory attribute `check_acl="yes|no"` (parsed on all platforms; effective on Windows). **Not** included in `check_all`, so upgrades do not force a mass re-baseline.
- Change detection uses a **SID-stable MD5 digest** of the canonical ACE list (optional 9th sum field after attrs). Display-name renames without an ACL edit do not alert.
- When `check_acl` is on, the attrs sum slot is always present (`0` if `check_attrs` is off) so field order stays `…:sha256:attrs:acl`.
- Alert detail follows the seechanges pattern: compact digest in the sum; ACE matrix / **Added / Removed / Modified** diff (with inheritance flags) after `\n` in the payload, truncated if needed.
- Null / absent DACL handled with explicit sentinels (`NODACL` / `NULLDACL`).
- Local cache keeps a SID-stable ACE snapshot after `\n` for diffs; manager DB stores digest only.
- Realtime already watches `FILE_NOTIFY_CHANGE_SECURITY` — no mask change required.
- Fixes `LocalFree` of the owner security descriptor on the Windows FIM path.
- Docs: FAQ + `ossec_config.syscheck` syntax (separate docs PR).
- Stacks on Windows `check_attrs` (#1352 / `fix/1352-windows-fim-attrs`). Prefer that as the PR base until attrs lands on `main`.
