### PR TITLE
Add ModSecurity audit log collection and libmodsecurity decoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Work toward the next minor release after 4.2.0.
 **General**
 
 - @atomicturtle - Use a dedicated OSSEC iptables chain for firewall-drop active response (#678)
+- @atomicturtle - Add ModSecurity / libmodsecurity serial audit log support (``modsec-audit`` log format) plus nginx error-log ModSecurity decoders/rules (#1390)
 - @hyn172 / @atomicturtle - [PR 504](https://github.com/ossec/ossec-hids/pull/504) - Add Windows interactive (logon type 2) success detail rule 18262
 - @awiddersheim / @atomicturtle - [PR 578](https://github.com/ossec/ossec-hids/pull/578) - Refactor Unix MQ start/send retry loops without changing wait budgets
 - @bchurchill / @atomicturtle - [PR 633](https://github.com/ossec/ossec-hids/pull/633) - Enable Linux compile/link hardening by default (PIE, FORTIFY, stack protector, full RELRO)

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1830,7 +1830,51 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   <order>srcip</order>
 </decoder>
 
+<!-- libmodsecurity / ModSecurity-nginx error log lines use [client IP] before ModSecurity: -->
+<decoder name="nginx-errorlog-modsec-denied">
+  <parent>nginx-errorlog</parent>
+  <prematch_pcre2 offset="after_parent">\[client \S+\] ModSecurity: Access denied</prematch_pcre2>
+  <pcre2 offset="after_parent">\[client (\S+)\] ModSecurity: Access denied with code (\d+)</pcre2>
+  <order>srcip,id</order>
+</decoder>
 
+<decoder name="nginx-errorlog-modsec-warning">
+  <parent>nginx-errorlog</parent>
+  <prematch_pcre2 offset="after_parent">\[client \S+\] ModSecurity: Warning</prematch_pcre2>
+  <pcre2 offset="after_parent">\[client (\S+)\] ModSecurity: Warning</pcre2>
+  <order>srcip</order>
+</decoder>
+
+
+<!-- ModSecurity / libmodsecurity serial audit log (log_format modsec-audit).
+  - Logcollector joins a transaction (through --id-Z--) into one line.
+  - Examples (collapsed):
+  -  --fbd13fc1-A-- [22/Dec/2015:15:25:00 +0000] VnhlYH8AAQEAADYdAUkAAAAA 127.0.0.1 55275 127.0.0.1 80 --fbd13fc1-H-- Message: Access denied with code 403 (phase 2). ... Action: Intercepted (phase 2) --fbd13fc1-Z--
+  -->
+<decoder name="modsecurity-audit">
+  <prematch_pcre2>--[0-9A-Za-z]+-A--</prematch_pcre2>
+</decoder>
+
+<decoder name="modsecurity-audit-denied">
+  <parent>modsecurity-audit</parent>
+  <prematch_pcre2>Message: Access denied with code </prematch_pcre2>
+  <pcre2>\[[^\]]+\]\s+\S+\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+).*Message: Access denied with code (\d+)</pcre2>
+  <order>srcip,srcport,dstip,dstport,id</order>
+</decoder>
+
+<decoder name="modsecurity-audit-warning">
+  <parent>modsecurity-audit</parent>
+  <prematch_pcre2>Message: Warning\.</prematch_pcre2>
+  <pcre2>\[[^\]]+\]\s+\S+\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)</pcre2>
+  <order>srcip,srcport,dstip,dstport</order>
+</decoder>
+
+<decoder name="modsecurity-audit-fields">
+  <parent>modsecurity-audit</parent>
+  <prematch_pcre2 offset="after_parent">\[\d{2}/\w+/\d{4}:</prematch_pcre2>
+  <pcre2 offset="after_parent">\[[^\]]+\]\s+\S+\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)</pcre2>
+  <order>srcip,srcport,dstip,dstport</order>
+</decoder>
 
 
 <!-- NCSA common log decoder (used by apache, Lotus Domino and IIS NCSA).

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -1847,7 +1847,8 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 
 
 <!-- ModSecurity / libmodsecurity serial audit log (log_format modsec-audit).
-  - Logcollector joins a transaction (through --id-Z--) into one line.
+  - Logcollector joins a transaction (through matching --id-Z--) into one line.
+  - srcip is taken from section A; Message matches prefer the -H-- section.
   - Examples (collapsed):
   -  --fbd13fc1-A-- [22/Dec/2015:15:25:00 +0000] VnhlYH8AAQEAADYdAUkAAAAA 127.0.0.1 55275 127.0.0.1 80 --fbd13fc1-H-- Message: Access denied with code 403 (phase 2). ... Action: Intercepted (phase 2) --fbd13fc1-Z--
   -->
@@ -1857,15 +1858,15 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 
 <decoder name="modsecurity-audit-denied">
   <parent>modsecurity-audit</parent>
-  <prematch_pcre2>Message: Access denied with code </prematch_pcre2>
-  <pcre2>\[[^\]]+\]\s+\S+\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+).*Message: Access denied with code (\d+)</pcre2>
+  <prematch_pcre2>--[0-9A-Za-z]+-H--.*Message: Access denied with code </prematch_pcre2>
+  <pcre2>--[0-9A-Za-z]+-A--\s+\[[^\]]+\]\s+\S+\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+).*--[0-9A-Za-z]+-H--.*Message: Access denied with code (\d+)</pcre2>
   <order>srcip,srcport,dstip,dstport,id</order>
 </decoder>
 
 <decoder name="modsecurity-audit-warning">
   <parent>modsecurity-audit</parent>
-  <prematch_pcre2>Message: Warning\.</prematch_pcre2>
-  <pcre2>\[[^\]]+\]\s+\S+\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)</pcre2>
+  <prematch_pcre2>--[0-9A-Za-z]+-H--.*Message: Warning\.</prematch_pcre2>
+  <pcre2>--[0-9A-Za-z]+-A--\s+\[[^\]]+\]\s+\S+\s+(\S+)\s+(\d+)\s+(\S+)\s+(\d+)</pcre2>
   <order>srcip,srcport,dstip,dstport</order>
 </decoder>
 

--- a/etc/ossec-local.conf
+++ b/etc/ossec-local.conf
@@ -36,6 +36,7 @@
     <include>web_appsec_rules.xml</include>
     <include>apache_rules.xml</include>
     <include>nginx_rules.xml</include>
+    <include>modsecurity_rules.xml</include>
     <include>php_rules.xml</include>
     <include>mysql_rules.xml</include>
     <include>postgresql_rules.xml</include>

--- a/etc/ossec-server.conf
+++ b/etc/ossec-server.conf
@@ -36,6 +36,7 @@
     <include>web_appsec_rules.xml</include>
     <include>apache_rules.xml</include>
     <include>nginx_rules.xml</include>
+    <include>modsecurity_rules.xml</include>
     <include>php_rules.xml</include>
     <include>mysql_rules.xml</include>
     <include>postgresql_rules.xml</include>

--- a/etc/ossec.conf
+++ b/etc/ossec.conf
@@ -20,6 +20,7 @@
     <include>web_rules.xml</include>
     <include>web_appsec_rules.xml</include>
     <include>apache_rules.xml</include>
+    <include>modsecurity_rules.xml</include>
     <include>ids_rules.xml</include>
     <include>squid_rules.xml</include>
     <include>firewall_rules.xml</include>

--- a/etc/rules/apache_rules.xml
+++ b/etc/rules/apache_rules.xml
@@ -316,8 +316,15 @@
 
   <rule id="30411" level="7">
     <if_sid>30402</if_sid>
-    <pcre2>with code 403</pcre2>
+    <pcre2>with code 403|with code 406|with code 501|with code 505</pcre2>
     <description>ModSecurity rejected a query</description>
+  </rule>
+
+  <rule id="30412" level="12" frequency="6" timeframe="120">
+    <if_matched_sid>30411</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple attempts blocked by ModSecurity.</description>
+    <group>access_denied,</group>
   </rule>
 </group> <!-- ERROR_LOG,APACHE -->
 

--- a/etc/rules/modsecurity_rules.xml
+++ b/etc/rules/modsecurity_rules.xml
@@ -19,14 +19,14 @@
 
   <rule id="30501" level="6">
     <if_sid>30500</if_sid>
-    <pcre2>Message: Access denied with code |Action: Intercepted</pcre2>
+    <pcre2>--[0-9A-Za-z]+-H--.*Message: Access denied with code .*Action: Intercepted</pcre2>
     <description>ModSecurity blocked a request (audit log).</description>
     <group>access_denied,attack,</group>
   </rule>
 
   <rule id="30502" level="5">
     <if_sid>30500</if_sid>
-    <pcre2>Message: Warning\.</pcre2>
+    <pcre2>--[0-9A-Za-z]+-H--.*Message: Warning\.</pcre2>
     <description>ModSecurity warning (audit log).</description>
     <group>attack,</group>
   </rule>

--- a/etc/rules/modsecurity_rules.xml
+++ b/etc/rules/modsecurity_rules.xml
@@ -1,0 +1,54 @@
+<!--
+  -  Official ModSecurity / libmodsecurity rules for OSSEC.
+  -
+  -  Covers serial audit logs collected with:
+  -    <localfile>
+  -      <log_format>modsec-audit</log_format>
+  -      <location>/var/log/modsec_audit.log</location>
+  -    </localfile>
+  -
+  -  Apache/nginx error-log ModSecurity lines remain in apache_rules.xml /
+  -  nginx_rules.xml.
+  -->
+
+<group name="modsecurity,">
+  <rule id="30500" level="0">
+    <decoded_as>modsecurity-audit</decoded_as>
+    <description>ModSecurity audit log messages grouped.</description>
+  </rule>
+
+  <rule id="30501" level="6">
+    <if_sid>30500</if_sid>
+    <pcre2>Message: Access denied with code |Action: Intercepted</pcre2>
+    <description>ModSecurity blocked a request (audit log).</description>
+    <group>access_denied,attack,</group>
+  </rule>
+
+  <rule id="30502" level="5">
+    <if_sid>30500</if_sid>
+    <pcre2>Message: Warning\.</pcre2>
+    <description>ModSecurity warning (audit log).</description>
+    <group>attack,</group>
+  </rule>
+
+  <rule id="30503" level="7">
+    <if_sid>30501</if_sid>
+    <id_pcre2>^403$</id_pcre2>
+    <description>ModSecurity denied request with HTTP 403.</description>
+    <group>access_denied,attack,</group>
+  </rule>
+
+  <rule id="30504" level="7">
+    <if_sid>30501</if_sid>
+    <id_pcre2>^406$|^501$|^505$</id_pcre2>
+    <description>ModSecurity denied request (non-403 block code).</description>
+    <group>access_denied,attack,</group>
+  </rule>
+
+  <rule id="30510" level="10" frequency="8" timeframe="120">
+    <if_matched_sid>30501</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple ModSecurity blocks from same source.</description>
+    <group>access_denied,attack,</group>
+  </rule>
+</group>

--- a/etc/rules/nginx_rules.xml
+++ b/etc/rules/nginx_rules.xml
@@ -82,6 +82,35 @@
     <description>Invalid URI, file name too long.</description>
     <group>invalid_request,</group>
   </rule>
+
+  <!-- libmodsecurity / ModSecurity-nginx (error log) -->
+  <rule id="31330" level="6">
+    <if_sid>31301</if_sid>
+    <pcre2>ModSecurity: Access denied</pcre2>
+    <description>Access attempt blocked by ModSecurity.</description>
+    <group>access_denied,modsecurity,</group>
+  </rule>
+
+  <rule id="31331" level="5">
+    <if_sid>31301</if_sid>
+    <pcre2>ModSecurity: Warning</pcre2>
+    <description>ModSecurity warning.</description>
+    <group>modsecurity,</group>
+  </rule>
+
+  <rule id="31332" level="7">
+    <if_sid>31330</if_sid>
+    <id_pcre2>^403$</id_pcre2>
+    <description>ModSecurity rejected a query (403).</description>
+    <group>access_denied,modsecurity,</group>
+  </rule>
+
+  <rule id="31333" level="12" frequency="6" timeframe="120">
+    <if_matched_sid>31330</if_matched_sid>
+    <same_source_ip />
+    <description>Multiple attempts blocked by ModSecurity.</description>
+    <group>access_denied,modsecurity,</group>
+  </rule>
 </group> <!-- ERROR_LOG,NGINX -->
 
 <!-- EOF -->

--- a/etc/templates/config/rules.template
+++ b/etc/templates/config/rules.template
@@ -26,6 +26,7 @@
     <include>web_appsec_rules.xml</include>
     <include>apache_rules.xml</include>
     <include>nginx_rules.xml</include>
+    <include>modsecurity_rules.xml</include>
     <include>php_rules.xml</include>
     <include>mysql_rules.xml</include>
     <include>postgresql_rules.xml</include>

--- a/src/config/localfile-config.c
+++ b/src/config/localfile-config.c
@@ -279,6 +279,7 @@ int Read_Localfile(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             } else if (strcmp(logf[pl].logformat, "command") == 0) {
             } else if (strcmp(logf[pl].logformat, "full_command") == 0) {
             } else if (strcmp(logf[pl].logformat, "audit") == 0) {
+            } else if (strcmp(logf[pl].logformat, "modsec-audit") == 0) {
             } else if (strcmp(logf[pl].logformat, "journald") == 0) {
             } else if (strcmp(logf[pl].logformat, "multi-line_indented") == 0) {
             } else if (strncmp(logf[pl].logformat, "multi-line", 10) == 0) {

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -290,6 +290,8 @@ void LogCollectorStart()
                 logff[i].read = read_multiline;
             } else if (strcmp("audit", logff[i].logformat) == 0) {
                 logff[i].read = read_audit;
+            } else if (strcmp("modsec-audit", logff[i].logformat) == 0) {
+                logff[i].read = read_modsec_audit;
             } else if (strcmp("multi-line_indented", logff[i].logformat) == 0) {
                 logff[i].read = read_multiline_indented;
             } else {

--- a/src/logcollector/logcollector.h
+++ b/src/logcollector/logcollector.h
@@ -68,6 +68,9 @@ void *read_fullcommand(int pos, int *rc, int drop_it);
 /* Read auditd events */
 void *read_audit(int pos, int *rc, int drop_it);
 
+/* Read ModSecurity / libmodsecurity serial audit logs */
+void *read_modsec_audit(int pos, int *rc, int drop_it);
+
 #ifdef WIN32
 void win_startel(char *evt_log);
 void win_readel();

--- a/src/logcollector/read_modsec_audit.c
+++ b/src/logcollector/read_modsec_audit.c
@@ -12,36 +12,91 @@
 
 /* Serial ModSecurity / libmodsecurity audit logs use section markers:
  *   --abcd1234-A-- ... --abcd1234-H-- ... --abcd1234-Z--
- * Accumulate lines until the Z (trailer) section, then emit one event.
+ * Accumulate lines from a matching -A-- through the same-id -Z-- trailer.
+ *
+ * Transaction IDs are bound across sections so a crafted request/response
+ * body line that looks like "--evil-Z--" cannot prematurely end (or forge)
+ * an audit event (#1390 security review).
  */
 
 #define MODSEC_MAX_CACHE 96
+#define MODSEC_ID_MAX    64
 
-static int is_modsec_boundary(const char *line, char section)
+typedef struct {
+    char id[MODSEC_ID_MAX];
+    size_t id_len;
+} modsec_txn_t;
+
+/* Parse "--<id>-X--" into id and section. Returns 1 on success. */
+static int parse_modsec_boundary(const char *line, char *id_out, size_t id_cap,
+                                 size_t *id_len_out, char *section_out)
 {
     const char *p;
+    size_t id_len = 0;
 
-    if (!line || line[0] != '-' || line[1] != '-') {
+    if (!line || !id_out || !section_out || id_cap < 2) {
+        return 0;
+    }
+
+    if (line[0] != '-' || line[1] != '-') {
         return 0;
     }
 
     p = line + 2;
-    while ((*p >= '0' && *p <= '9') ||
-           (*p >= 'a' && *p <= 'z') ||
-           (*p >= 'A' && *p <= 'Z')) {
-        p++;
+    while (((*p >= '0' && *p <= '9') ||
+            (*p >= 'a' && *p <= 'z') ||
+            (*p >= 'A' && *p <= 'Z')) &&
+           id_len + 1 < id_cap) {
+        id_out[id_len++] = *p++;
     }
 
-    /* Expect "-X--" after the id (X = section letter) */
-    if (p[0] != '-' || p[1] != section || p[2] != '-' || p[3] != '-') {
+    /* Require a non-empty, fully-consumed id (no truncation mid-id). */
+    if (id_len == 0) {
         return 0;
     }
+    if ((*p >= '0' && *p <= '9') ||
+        (*p >= 'a' && *p <= 'z') ||
+        (*p >= 'A' && *p <= 'Z')) {
+        return 0; /* id longer than id_cap - 1 */
+    }
 
+    /* Expect "-X--" after the id */
+    if (p[0] != '-' || p[1] == '\0' || p[2] != '-' || p[3] != '-') {
+        return 0;
+    }
     if (p[4] != '\0' && p[4] != '\r') {
         return 0;
     }
 
+    id_out[id_len] = '\0';
+    if (id_len_out) {
+        *id_len_out = id_len;
+    }
+    *section_out = p[1];
     return 1;
+}
+
+static int txn_id_eq(const modsec_txn_t *txn, const char *id, size_t id_len)
+{
+    return (txn->id_len == id_len &&
+            txn->id_len > 0 &&
+            memcmp(txn->id, id, id_len) == 0);
+}
+
+static void txn_clear(modsec_txn_t *txn)
+{
+    txn->id[0] = '\0';
+    txn->id_len = 0;
+}
+
+static void txn_set(modsec_txn_t *txn, const char *id, size_t id_len)
+{
+    if (id_len >= MODSEC_ID_MAX) {
+        id_len = MODSEC_ID_MAX - 1;
+    }
+    memcpy(txn->id, id, id_len);
+    txn->id[id_len] = '\0';
+    txn->id_len = id_len;
 }
 
 static void modsec_free_cache(char **cache, int top)
@@ -66,6 +121,7 @@ static void modsec_send_msg(char **cache, int top, const char *file, int drop_it
     for (i = 0; i < top; i++) {
         z = strlen(cache[i]);
 
+        /* Cap join length; still free every cache entry. */
         if (n + z + 1 < OS_MAXSTR) {
             if (n > 0) {
                 message[n++] = ' ';
@@ -97,8 +153,13 @@ void *read_modsec_audit(int pos, int *rc, int drop_it)
     char *p;
     long offset;
     long txn_start = -1;
+    modsec_txn_t txn;
+    char bid[MODSEC_ID_MAX];
+    size_t bid_len = 0;
+    char section = '\0';
 
     memset(cache, 0, sizeof(cache));
+    txn_clear(&txn);
     *rc = 0;
 
     offset = ftell(logff[pos].fp);
@@ -112,10 +173,11 @@ void *read_modsec_audit(int pos, int *rc, int drop_it)
             *p = '\0';
         } else {
             if (strlen(buffer) == OS_MAXSTR - 1) {
+                /* Discard remainder of overlong line; do not treat as a marker. */
                 while (fgets(buffer, OS_MAXSTR, logff[pos].fp) &&
                        !strchr(buffer, '\n')) {
-                    /* discard rest of overlong line */
                 }
+                offset = ftell(logff[pos].fp);
                 continue;
             }
             debug1("%s: Message not complete. Trying again: '%s'", ARGV0, buffer);
@@ -138,27 +200,67 @@ void *read_modsec_audit(int pos, int *rc, int drop_it)
             continue;
         }
 
-        if (icache == 0) {
-            txn_start = offset;
-        }
+        if (parse_modsec_boundary(buffer, bid, sizeof(bid), &bid_len, &section)) {
+            if (section == 'A' && icache == 0) {
+                /* Start of a new transaction (only when not already inside one). */
+                txn_set(&txn, bid, bid_len);
+                txn_start = offset;
+                os_strdup(buffer, cache[icache]);
+                icache = 1;
+            } else if (txn.id_len > 0 && txn_id_eq(&txn, bid, bid_len)) {
+                /* Same-id section marker (-B--, -H--, -Z--, ...). */
+                if (icache >= MODSEC_MAX_CACHE) {
+                    merror("%s: WARN: ModSecurity audit entry exceeded %d "
+                           "lines; discarding event from '%s'",
+                           ARGV0, MODSEC_MAX_CACHE, logff[pos].file);
+                    modsec_free_cache(cache, icache);
+                    icache = 0;
+                    txn_clear(&txn);
+                    txn_start = -1;
+                } else {
+                    os_strdup(buffer, cache[icache]);
+                    icache++;
+                }
 
-        if (icache >= MODSEC_MAX_CACHE) {
-            merror("%s: WARN: ModSecurity audit entry exceeded %d lines; "
-                   "sending partial event from '%s'",
-                   ARGV0, MODSEC_MAX_CACHE, logff[pos].file);
-            modsec_send_msg(cache, icache, logff[pos].file, drop_it);
-            icache = 0;
-            txn_start = -1;
+                if (section == 'Z' && icache > 0 && txn.id_len > 0) {
+                    modsec_send_msg(cache, icache, logff[pos].file, drop_it);
+                    icache = 0;
+                    txn_clear(&txn);
+                    txn_start = -1;
+                }
+            } else if (icache > 0) {
+                /* Lookalike marker inside request/response body: keep as data,
+                 * do not retarget the open transaction. */
+                if (icache >= MODSEC_MAX_CACHE) {
+                    merror("%s: WARN: ModSecurity audit entry exceeded %d "
+                           "lines; discarding event from '%s'",
+                           ARGV0, MODSEC_MAX_CACHE, logff[pos].file);
+                    modsec_free_cache(cache, icache);
+                    icache = 0;
+                    txn_clear(&txn);
+                    txn_start = -1;
+                } else {
+                    os_strdup(buffer, cache[icache]);
+                    icache++;
+                }
+            }
+            /* else: marker noise outside a transaction — ignore */
+        } else if (txn.id_len > 0) {
+            /* Body / header line inside an open transaction. */
+            if (icache >= MODSEC_MAX_CACHE) {
+                merror("%s: WARN: ModSecurity audit entry exceeded %d lines; "
+                       "discarding event from '%s'",
+                       ARGV0, MODSEC_MAX_CACHE, logff[pos].file);
+                modsec_free_cache(cache, icache);
+                icache = 0;
+                txn_clear(&txn);
+                txn_start = -1;
+            } else {
+                os_strdup(buffer, cache[icache]);
+                icache++;
+            }
         }
-
-        os_strdup(buffer, cache[icache]);
-        icache++;
-
-        if (is_modsec_boundary(buffer, 'Z')) {
-            modsec_send_msg(cache, icache, logff[pos].file, drop_it);
-            icache = 0;
-            txn_start = -1;
-        }
+        /* else: noise outside a transaction — ignore */
 
         offset = ftell(logff[pos].fp);
         if (offset < 0) {

--- a/src/logcollector/read_modsec_audit.c
+++ b/src/logcollector/read_modsec_audit.c
@@ -1,0 +1,179 @@
+/* Copyright (C) 2026 OSSEC Project
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation
+ */
+
+#include "shared.h"
+#include "logcollector.h"
+
+/* Serial ModSecurity / libmodsecurity audit logs use section markers:
+ *   --abcd1234-A-- ... --abcd1234-H-- ... --abcd1234-Z--
+ * Accumulate lines until the Z (trailer) section, then emit one event.
+ */
+
+#define MODSEC_MAX_CACHE 96
+
+static int is_modsec_boundary(const char *line, char section)
+{
+    const char *p;
+
+    if (!line || line[0] != '-' || line[1] != '-') {
+        return 0;
+    }
+
+    p = line + 2;
+    while ((*p >= '0' && *p <= '9') ||
+           (*p >= 'a' && *p <= 'z') ||
+           (*p >= 'A' && *p <= 'Z')) {
+        p++;
+    }
+
+    /* Expect "-X--" after the id (X = section letter) */
+    if (p[0] != '-' || p[1] != section || p[2] != '-' || p[3] != '-') {
+        return 0;
+    }
+
+    if (p[4] != '\0' && p[4] != '\r') {
+        return 0;
+    }
+
+    return 1;
+}
+
+static void modsec_free_cache(char **cache, int top)
+{
+    int i;
+
+    for (i = 0; i < top; i++) {
+        free(cache[i]);
+        cache[i] = NULL;
+    }
+}
+
+static void modsec_send_msg(char **cache, int top, const char *file, int drop_it)
+{
+    int i;
+    size_t n = 0;
+    size_t z;
+    char message[OS_MAXSTR];
+
+    message[0] = '\0';
+
+    for (i = 0; i < top; i++) {
+        z = strlen(cache[i]);
+
+        if (n + z + 1 < OS_MAXSTR) {
+            if (n > 0) {
+                message[n++] = ' ';
+            }
+            memcpy(message + n, cache[i], z);
+            n += z;
+            message[n] = '\0';
+        }
+
+        free(cache[i]);
+        cache[i] = NULL;
+    }
+
+    if (!drop_it && n > 0) {
+        if (SendMSG(logr_queue, message, file, LOCALFILE_MQ) < 0) {
+            merror(QUEUE_SEND, ARGV0);
+            if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+                ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQPATH);
+            }
+        }
+    }
+}
+
+void *read_modsec_audit(int pos, int *rc, int drop_it)
+{
+    char *cache[MODSEC_MAX_CACHE];
+    int icache = 0;
+    char buffer[OS_MAXSTR];
+    char *p;
+    long offset;
+    long txn_start = -1;
+
+    memset(cache, 0, sizeof(cache));
+    *rc = 0;
+
+    offset = ftell(logff[pos].fp);
+    if (offset < 0) {
+        merror(FTELL_ERROR, ARGV0, logff[pos].file, errno, strerror(errno));
+        return NULL;
+    }
+
+    while (fgets(buffer, OS_MAXSTR, logff[pos].fp)) {
+        if ((p = strchr(buffer, '\n')) != NULL) {
+            *p = '\0';
+        } else {
+            if (strlen(buffer) == OS_MAXSTR - 1) {
+                while (fgets(buffer, OS_MAXSTR, logff[pos].fp) &&
+                       !strchr(buffer, '\n')) {
+                    /* discard rest of overlong line */
+                }
+                continue;
+            }
+            debug1("%s: Message not complete. Trying again: '%s'", ARGV0, buffer);
+            if (fseek(logff[pos].fp, offset, SEEK_SET) < 0) {
+                merror(FSEEK_ERROR, ARGV0, logff[pos].file, errno, strerror(errno));
+                break;
+            }
+            break;
+        }
+
+#ifdef WIN32
+        if ((p = strrchr(buffer, '\r')) != NULL) {
+            *p = '\0';
+        }
+#endif
+
+        /* Skip empty lines between transactions */
+        if (buffer[0] == '\0' && icache == 0) {
+            offset = ftell(logff[pos].fp);
+            continue;
+        }
+
+        if (icache == 0) {
+            txn_start = offset;
+        }
+
+        if (icache >= MODSEC_MAX_CACHE) {
+            merror("%s: WARN: ModSecurity audit entry exceeded %d lines; "
+                   "sending partial event from '%s'",
+                   ARGV0, MODSEC_MAX_CACHE, logff[pos].file);
+            modsec_send_msg(cache, icache, logff[pos].file, drop_it);
+            icache = 0;
+            txn_start = -1;
+        }
+
+        os_strdup(buffer, cache[icache]);
+        icache++;
+
+        if (is_modsec_boundary(buffer, 'Z')) {
+            modsec_send_msg(cache, icache, logff[pos].file, drop_it);
+            icache = 0;
+            txn_start = -1;
+        }
+
+        offset = ftell(logff[pos].fp);
+        if (offset < 0) {
+            merror(FTELL_ERROR, ARGV0, logff[pos].file, errno, strerror(errno));
+            break;
+        }
+    }
+
+    /* Incomplete transaction — rewind to its start for the next read cycle */
+    if (icache > 0) {
+        modsec_free_cache(cache, icache);
+        if (txn_start >= 0 && fseek(logff[pos].fp, txn_start, SEEK_SET) < 0) {
+            merror(FSEEK_ERROR, ARGV0, logff[pos].file, errno, strerror(errno));
+        }
+    }
+
+    return NULL;
+}

--- a/src/logcollector/tests/modsec_audit_boundary_test.c
+++ b/src/logcollector/tests/modsec_audit_boundary_test.c
@@ -1,45 +1,98 @@
-/* Minimal unit checks for ModSecurity audit boundary parsing. */
+/* Unit checks for ModSecurity audit boundary parsing / ID binding. */
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
 
-/* Mirror of is_modsec_boundary() in read_modsec_audit.c */
-static int is_modsec_boundary(const char *line, char section)
+#define MODSEC_ID_MAX 64
+
+static int parse_modsec_boundary(const char *line, char *id_out, size_t id_cap,
+                                 size_t *id_len_out, char *section_out)
 {
     const char *p;
+    size_t id_len = 0;
 
-    if (!line || line[0] != '-' || line[1] != '-') {
+    if (!line || !id_out || !section_out || id_cap < 2) {
+        return 0;
+    }
+
+    if (line[0] != '-' || line[1] != '-') {
         return 0;
     }
 
     p = line + 2;
-    while ((*p >= '0' && *p <= '9') ||
-           (*p >= 'a' && *p <= 'z') ||
-           (*p >= 'A' && *p <= 'Z')) {
-        p++;
+    while (((*p >= '0' && *p <= '9') ||
+            (*p >= 'a' && *p <= 'z') ||
+            (*p >= 'A' && *p <= 'Z')) &&
+           id_len + 1 < id_cap) {
+        id_out[id_len++] = *p++;
     }
 
-    if (p[0] != '-' || p[1] != section || p[2] != '-' || p[3] != '-') {
+    if (id_len == 0) {
+        return 0;
+    }
+    if ((*p >= '0' && *p <= '9') ||
+        (*p >= 'a' && *p <= 'z') ||
+        (*p >= 'A' && *p <= 'Z')) {
         return 0;
     }
 
+    if (p[0] != '-' || p[1] == '\0' || p[2] != '-' || p[3] != '-') {
+        return 0;
+    }
     if (p[4] != '\0' && p[4] != '\r') {
         return 0;
     }
 
+    id_out[id_len] = '\0';
+    if (id_len_out) {
+        *id_len_out = id_len;
+    }
+    *section_out = p[1];
     return 1;
 }
 
 int main(void)
 {
-    assert(is_modsec_boundary("--fbd13fc1-A--", 'A'));
-    assert(is_modsec_boundary("--fbd13fc1-Z--", 'Z'));
-    assert(is_modsec_boundary("--abc123-H--", 'H'));
-    assert(!is_modsec_boundary("--fbd13fc1-A--", 'Z'));
-    assert(!is_modsec_boundary("--fbd13fc1-Z-", 'Z'));
-    assert(!is_modsec_boundary("-fbd13fc1-Z--", 'Z'));
-    assert(!is_modsec_boundary("Message: Access denied", 'Z'));
-    assert(is_modsec_boundary("--fbd13fc1-Z--\r", 'Z'));
+    char id[MODSEC_ID_MAX];
+    size_t id_len = 0;
+    char section = 0;
+
+    assert(parse_modsec_boundary("--fbd13fc1-A--", id, sizeof(id), &id_len, &section));
+    assert(section == 'A');
+    assert(strcmp(id, "fbd13fc1") == 0);
+    assert(id_len == 8);
+
+    assert(parse_modsec_boundary("--fbd13fc1-Z--", id, sizeof(id), &id_len, &section));
+    assert(section == 'Z');
+    assert(strcmp(id, "fbd13fc1") == 0);
+
+    assert(parse_modsec_boundary("--abc123-H--", id, sizeof(id), &id_len, &section));
+    assert(section == 'H');
+
+    /* Empty id rejected */
+    assert(!parse_modsec_boundary("--Z--", id, sizeof(id), &id_len, &section));
+    assert(!parse_modsec_boundary("---Z--", id, sizeof(id), &id_len, &section));
+
+    /* Truncated / malformed */
+    assert(!parse_modsec_boundary("--fbd13fc1-Z-", id, sizeof(id), &id_len, &section));
+    assert(!parse_modsec_boundary("-fbd13fc1-Z--", id, sizeof(id), &id_len, &section));
+    assert(!parse_modsec_boundary("Message: Access denied", id, sizeof(id), &id_len, &section));
+
+    /* CR-terminated OK */
+    assert(parse_modsec_boundary("--fbd13fc1-Z--\r", id, sizeof(id), &id_len, &section));
+    assert(section == 'Z');
+
+    /* Overlong id rejected (id_cap-1 max) */
+    {
+        char longline[MODSEC_ID_MAX + 16];
+        memset(longline, 'a', sizeof(longline));
+        memcpy(longline, "--", 2);
+        /* fill id past MODSEC_ID_MAX-1 */
+        memset(longline + 2, 'b', MODSEC_ID_MAX);
+        memcpy(longline + 2 + MODSEC_ID_MAX, "-Z--", 5);
+        assert(!parse_modsec_boundary(longline, id, MODSEC_ID_MAX, &id_len, &section));
+    }
+
     printf("modsec_audit_boundary_test: ok\n");
     return 0;
 }

--- a/src/logcollector/tests/modsec_audit_boundary_test.c
+++ b/src/logcollector/tests/modsec_audit_boundary_test.c
@@ -1,0 +1,45 @@
+/* Minimal unit checks for ModSecurity audit boundary parsing. */
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+/* Mirror of is_modsec_boundary() in read_modsec_audit.c */
+static int is_modsec_boundary(const char *line, char section)
+{
+    const char *p;
+
+    if (!line || line[0] != '-' || line[1] != '-') {
+        return 0;
+    }
+
+    p = line + 2;
+    while ((*p >= '0' && *p <= '9') ||
+           (*p >= 'a' && *p <= 'z') ||
+           (*p >= 'A' && *p <= 'Z')) {
+        p++;
+    }
+
+    if (p[0] != '-' || p[1] != section || p[2] != '-' || p[3] != '-') {
+        return 0;
+    }
+
+    if (p[4] != '\0' && p[4] != '\r') {
+        return 0;
+    }
+
+    return 1;
+}
+
+int main(void)
+{
+    assert(is_modsec_boundary("--fbd13fc1-A--", 'A'));
+    assert(is_modsec_boundary("--fbd13fc1-Z--", 'Z'));
+    assert(is_modsec_boundary("--abc123-H--", 'H'));
+    assert(!is_modsec_boundary("--fbd13fc1-A--", 'Z'));
+    assert(!is_modsec_boundary("--fbd13fc1-Z-", 'Z'));
+    assert(!is_modsec_boundary("-fbd13fc1-Z--", 'Z'));
+    assert(!is_modsec_boundary("Message: Access denied", 'Z'));
+    assert(is_modsec_boundary("--fbd13fc1-Z--\r", 'Z'));
+    printf("modsec_audit_boundary_test: ok\n");
+    return 0;
+}


### PR DESCRIPTION
Introduce modsec-audit localfile format for serial audit transactions, nginx error-log ModSecurity decoders/rules, and dedicated audit rules so nginx+libmodsecurity deployments are covered beyond Apache error logs (#1390).