### PR TITLE
Support ### trailing comments in CDB list text files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Work toward the next minor release after 4.2.0.
 
 **General**
 
+- @atomicturtle - Support ``###`` trailing comments in CDB list text files (#1527)
 - @atomicturtle - Use a dedicated OSSEC iptables chain for firewall-drop active response (#678)
 - @atomicturtle - Reject dangerous/ambiguous syscheck_control flag combinations such as ``-r -u`` (#462)
 - @hyn172 / @atomicturtle - [PR 504](https://github.com/ossec/ossec-hids/pull/504) - Add Windows interactive (logon type 2) success detail rule 18262

--- a/src/analysisd/lists_make.c
+++ b/src/analysisd/lists_make.c
@@ -17,6 +17,30 @@
 #include <errno.h>
 #include "lists_make.h"
 
+/* Trailing comment marker for CDB list text files (#1527). */
+#define LIST_COMMENT_MARK "###"
+
+/*
+ * Strip a trailing "###" comment and any spaces/tabs immediately before it.
+ * Full-line comments become an empty string. Returns the (possibly empty) line.
+ */
+static char *lists_strip_comment(char *str)
+{
+    char *comment;
+    char *p;
+
+    comment = strstr(str, LIST_COMMENT_MARK);
+    if (!comment) {
+        return str;
+    }
+
+    p = comment;
+    while (p > str && (p[-1] == ' ' || p[-1] == '\t')) {
+        p--;
+    }
+    *p = '\0';
+    return str;
+}
 
 void Lists_OP_MakeAll(int force)
 {
@@ -62,6 +86,14 @@ void Lists_OP_MakeCDB(const char *txt_filename, const char *cdb_filename, int fo
             if (tmp_str) {
                 *tmp_str = '\0';
             }
+
+            lists_strip_comment(str);
+
+            /* Skip blank lines and full-line comments */
+            if (str[0] == '\0') {
+                continue;
+            }
+
             if ((val = strchr(str, ':'))) {
                 *val = '\0';
                 val++;
@@ -86,4 +118,3 @@ void Lists_OP_MakeCDB(const char *txt_filename, const char *cdb_filename, int fo
         printf(" * File %s does not need to be compiled\n", cdb_filename);
     }
 }
-


### PR DESCRIPTION
Strip ### comments (and preceding spaces/tabs) at compile time so list maintainers can annotate entries without changing stored values (#1527).