### PR TITLE
Ignore deleted agents in list_agents and fix remove cleanup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Work toward the next minor release after 4.2.0.
 
 **General**
 
+- @atomicturtle - Ignore deleted agents in list_agents/get_agents; fix OS_RemoveAgent agent-info cleanup (#244)
 - @atomicturtle - Support ``###`` trailing comments in CDB list text files (#1527)
 - @atomicturtle - Use a dedicated OSSEC iptables chain for firewall-drop active response (#678)
 - @atomicturtle - Reject dangerous/ambiguous syscheck_control flag combinations such as ``-r -u`` (#462)

--- a/src/addagent/validate.c
+++ b/src/addagent/validate.c
@@ -150,6 +150,9 @@ int OS_RemoveAgent(const char *u_id) {
     }
 #endif
 
+    /* Capture name-ip before blanking the keys entry (#244) */
+    full_name = getFullnameById(u_id);
+
 #ifdef REUSE_ID
     long fp_seek;
     size_t fp_read;
@@ -159,12 +162,14 @@ int OS_RemoveAgent(const char *u_id) {
 
     if (stat(AUTH_FILE, &fp_stat) < 0) {
         fclose(fp);
+        free(full_name);
         return 0;
     }
 
     buffer = malloc(fp_stat.st_size);
     if (!buffer) {
         fclose(fp);
+        free(full_name);
         return 0;
     }
 
@@ -182,10 +187,12 @@ int OS_RemoveAgent(const char *u_id) {
 
     if (!fp) {
         free(buffer);
+        free(full_name);
         return 0;
     }
 
     fwrite(buffer, sizeof(char), fp_read, fp);
+    free(buffer);
 
 #else
     /* Remove the agent, but keep the id */
@@ -194,9 +201,10 @@ int OS_RemoveAgent(const char *u_id) {
 #endif
     fclose(fp);
 
-    full_name = getFullnameById(u_id);
-    if (full_name)
+    if (full_name) {
         delete_agentinfo(full_name);
+        free(full_name);
+    }
 
     /* Remove counter for ID */
     OS_RemoveCounter(u_id);

--- a/src/shared/read-agents.c
+++ b/src/shared/read-agents.c
@@ -1523,6 +1523,110 @@ int get_agent_status(const char *agent_name, const char *agent_ip)
     return (GA_STATUS_NACTIVE);
 }
 
+/*
+ * Build name-ip strings for agents still present in client.keys.
+ * Orphaned queue/agent-info files from deleted agents are ignored (#244).
+ */
+static char **load_registered_agent_info_names(size_t *count)
+{
+    FILE *fp;
+    char buffer[OS_BUFFER_SIZE + 1];
+    char **names = NULL;
+    size_t n = 0;
+
+    *count = 0;
+
+    fp = fopen(KEYS_FILE, "r");
+    if (!fp) {
+        return (NULL);
+    }
+
+    while (fgets(buffer, OS_BUFFER_SIZE, fp) != NULL) {
+        char *tmp_str;
+        char *name;
+        char *ip;
+        char expected[OS_SIZE_1024 + 1];
+
+        if ((buffer[0] == '#') || (buffer[0] == ' ')) {
+            continue;
+        }
+
+        /* id */
+        tmp_str = strchr(buffer, ' ');
+        if (!tmp_str) {
+            continue;
+        }
+        tmp_str++;
+
+        /* Removed / placeholder entry kept for ID reuse */
+        if (*tmp_str == '#') {
+            continue;
+        }
+
+        name = tmp_str;
+        tmp_str = strchr(tmp_str, ' ');
+        if (!tmp_str) {
+            continue;
+        }
+        *tmp_str = '\0';
+        tmp_str++;
+
+        ip = tmp_str;
+        tmp_str = strchr(tmp_str, ' ');
+        if (!tmp_str) {
+            continue;
+        }
+        *tmp_str = '\0';
+
+        /* Match remoted agent-info naming (CIDR slash stripped) */
+        tmp_str = strchr(ip, '/');
+        if (tmp_str) {
+            *tmp_str = '\0';
+        }
+
+        snprintf(expected, sizeof(expected), "%s-%s", name, ip);
+
+        names = (char **)realloc(names, (n + 1) * sizeof(char *));
+        if (!names) {
+            ErrorExit(MEM_ERROR, __local_name, errno, strerror(errno));
+        }
+        os_strdup(expected, names[n]);
+        n++;
+    }
+
+    fclose(fp);
+    *count = n;
+    return (names);
+}
+
+static int agent_info_name_registered(char **names, size_t count,
+                                      const char *d_name)
+{
+    size_t i;
+
+    for (i = 0; i < count; i++) {
+        if (strcmp(names[i], d_name) == 0) {
+            return (1);
+        }
+    }
+
+    return (0);
+}
+
+static void free_registered_agent_info_names(char **names, size_t count)
+{
+    size_t i;
+
+    if (!names) {
+        return;
+    }
+
+    for (i = 0; i < count; i++) {
+        free(names[i]);
+    }
+    free(names);
+}
+
 /* List available agents with specified timeout */
 char **get_agents_with_timeout(int flag, int timeout)
 {
@@ -1530,6 +1634,8 @@ char **get_agents_with_timeout(int flag, int timeout)
     char **f_files = NULL;
     DIR *dp;
     struct dirent *entry;
+    char **registered = NULL;
+    size_t registered_count = 0;
 
     /* Open the directory */
     dp = opendir(AGENTINFO_DIR);
@@ -1541,6 +1647,8 @@ char **get_agents_with_timeout(int flag, int timeout)
         return (NULL);
     }
 
+    registered = load_registered_agent_info_names(&registered_count);
+
     /* Read directory */
     while ((entry = readdir(dp)) != NULL) {
         int status = 0;
@@ -1550,6 +1658,12 @@ char **get_agents_with_timeout(int flag, int timeout)
         /* Ignore . and ..  */
         if ((strcmp(entry->d_name, ".") == 0) ||
                 (strcmp(entry->d_name, "..") == 0)) {
+            continue;
+        }
+
+        /* Skip agent-info left behind after agent removal (#244) */
+        if (!agent_info_name_registered(registered, registered_count,
+                                        entry->d_name)) {
             continue;
         }
 
@@ -1596,6 +1710,7 @@ char **get_agents_with_timeout(int flag, int timeout)
         f_size++;
     }
 
+    free_registered_agent_info_names(registered, registered_count);
     closedir(dp);
     return (f_files);
 }

--- a/src/util/list_agents.c
+++ b/src/util/list_agents.c
@@ -24,7 +24,7 @@ static void helpmsg(int status)
     printf("\t-h    This help message.\n");
     printf("\t-a    List all agents.\n");
     printf("\t-c    List the connected (active) agents.\n");
-    printf("\t-n    List the not connected (active) agents.\n");
+    printf("\t-n    List the not connected (inactive) agents.\n");
     exit(status);
 }
 


### PR DESCRIPTION
Cross-check agent-info against client.keys so orphaned files are not listed, and capture name-ip before blanking keys in OS_RemoveAgent (#244).