### PR TITLE
Allow manage_agents -f - to bulk-load agents from stdin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Work toward the next minor release after 4.2.0.
 
 **General**
 
+- @atomicturtle - Allow manage_agents ``-f -`` to bulk-load agents from stdin (#459)
 - @atomicturtle - Ignore deleted agents in list_agents/get_agents; fix OS_RemoveAgent agent-info cleanup (#244)
 - @atomicturtle - Support ``###`` trailing comments in CDB list text files (#1527)
 - @atomicturtle - Use a dedicated OSSEC iptables chain for firewall-drop active response (#678)

--- a/src/addagent/main.c
+++ b/src/addagent/main.c
@@ -51,7 +51,7 @@ static void helpmsg(int status)
     print_out("    -F <sec>    Remove agents with duplicated IP if disconnected since <sec> seconds");
     print_out("    -f <file>   Bulk generate client keys from file (Manager only)");
     print_out("                <file> contains lines in IP,NAME format");
-    print_out("                <file> should also exist within /var/ossec due to manage_agents chrooting");
+    print_out("                Use -f - to read the same format from stdin");
     exit(status);
 }
 

--- a/src/addagent/manage_keys.c
+++ b/src/addagent/manage_keys.c
@@ -339,12 +339,17 @@ int k_bulkload(const char *cmdbulk)
 
     extern int willchroot;
 
-    /* Check if we can open the input file */
-    printf("Opening: [%s]\n", cmdbulk);
-    infp = fopen(cmdbulk, "r");
-    if (!infp) {
-        perror("Failed.");
-        ErrorExit(FOPEN_ERROR, ARGV0, cmdbulk, errno, strerror(errno));
+    /* Check if we can open the input file (or stdin for "-") */
+    if (strcmp(cmdbulk, "-") == 0) {
+        printf("Reading bulk agents from stdin\n");
+        infp = stdin;
+    } else {
+        printf("Opening: [%s]\n", cmdbulk);
+        infp = fopen(cmdbulk, "r");
+        if (!infp) {
+            perror("Failed.");
+            ErrorExit(FOPEN_ERROR, ARGV0, cmdbulk, errno, strerror(errno));
+        }
     }
 
     /* Check if we can open the auth_file */
@@ -372,10 +377,17 @@ int k_bulkload(const char *cmdbulk)
 
         memset(ip, '\0', FILE_SIZE + 1);
         token = strtok(line, delims);
+        if (!token) {
+            continue;
+        }
         strncpy(ip, trimwhitespace(token), FILE_SIZE - 1);
 
         memset(name, '\0', FILE_SIZE + 1);
         token = strtok(NULL, delims);
+        if (!token) {
+            printf(INVALID_NAME, "");
+            continue;
+        }
         strncpy(name, trimwhitespace(token), FILE_SIZE - 1);
 
 #ifndef WIN32
@@ -480,6 +492,8 @@ cleanup:
         }
     };
 
-    fclose(infp);
+    if (infp != stdin) {
+        fclose(infp);
+    }
     return (status);
 }


### PR DESCRIPTION
Follow the usual '-' convention for stdin input and tighten bulk-line parsing so a missing name does not crash (#459).