### PR TITLE
Add Asterisk IPv6 denied decoder without square brackets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Work toward the next minor release after 4.2.0.
 
 **General**
 
+- @atomicturtle - Add Asterisk IPv6 denied decoder so srcip omits square brackets (#1892)
 - @atomicturtle - Allow manage_agents ``-f -`` to bulk-load agents from stdin (#459)
 - @atomicturtle - Ignore deleted agents in list_agents/get_agents; fix OS_RemoveAgent agent-info cleanup (#244)
 - @atomicturtle - Support ``###`` trailing comments in CDB list text files (#1527)

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -2330,6 +2330,13 @@ Sat May  7 03:27:57 CDT 2011 /var/ossec/active-response/bin/firewall-drop.sh del
   <order>srcip,srcport</order>
 </decoder>
 
+<decoder name="asterisk-denied3-ipv6">
+  <parent>asterisk</parent>
+  <prematch_pcre2>^NOTICE\[\d+?\]\[[A-Za-z0-9@_-]+?\]: \S+ in \S+: Call from </prematch_pcre2>
+  <pcre2 offset="after_prematch">^'\S*' \(\[([^\]]+)\]:(\d+)\) to extension '(\S+)' rejected because extension not found in context '(\S+)'\.$</pcre2>
+  <order>srcip, srcport, extra_data, extra_data</order>
+</decoder>
+
 <decoder name="asterisk-denied3">
   <parent>asterisk</parent>
   <prematch_pcre2>^NOTICE\[\d+?\]\[[A-Za-z0-9@_-]+?\]: \S+ in \S+: Call from </prematch_pcre2>


### PR DESCRIPTION
Capture bracketed IPv6 call-from addresses as bare srcip so active response can block them; leave the existing IPv4 decoder unchanged (#1892).