### PR TITLE
Make PCRE2 JIT optional so analysisd starts without it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Work toward the next minor release after 4.2.0.
 
 **Bug Fixes**
 
+- @atomicturtle - Make PCRE2 JIT optional (soft-fail compile, match via pcre2_match) so analysisd starts on macOS (#2040)
 - @atomicturtle - Accept AR expect ``username`` (alias of ``user``), fall back to srcuser, and document fixed script argv (#2104)
 - @atomicturtle - Decode cPanel login lines from webmaild/whostmgrd/cpaneld as well as cpsrvd (#1132)
 - @atomicturtle - Avoid FIM false positives from xxx hash placeholders and checksum read failures (#1590, #1704)

--- a/src/Makefile
+++ b/src/Makefile
@@ -100,6 +100,10 @@ ifeq (${uname_S},Darwin)
 		DEFINES+=-DDarwin
 		DEFINES+=-DHIGHFIRST
 		LUA_PLAT=macosx
+		# System libpcre2 on macOS is often built without JIT; requiring JIT
+		# made analysisd fail to load decoder.xml (#2040). Soft-fail remains
+		# in OSPcre2_Compile; default off here to match typical packages.
+		USE_PCRE2_JIT=n
 
 else
 ifeq (${uname_S},FreeBSD)

--- a/src/os_regex/os_match_compile.c
+++ b/src/os_regex/os_match_compile.c
@@ -132,11 +132,8 @@ int OSMatch_Compile(const char *pattern, OSMatch *reg, int flags)
     }
 
 #ifdef USE_PCRE2_JIT
-    /* Just In Time compilation for faster execution */
-    if (pcre2_jit_compile(reg->regex, PCRE2_JIT_COMPLETE) != 0) {
-        reg->error = OS_REGEX_NO_JIT;
-        goto compile_error;
-    }
+    /* JIT is optional; interpreter fallback via pcre2_match (#2040). */
+    (void) pcre2_jit_compile(reg->regex, PCRE2_JIT_COMPLETE);
 #endif
 
     free(pattern_pcre2);

--- a/src/os_regex/os_match_execute.c
+++ b/src/os_regex/os_match_execute.c
@@ -43,11 +43,8 @@ int OSMatch_Execute_pcre2_match(const char *str, size_t str_len, OSMatch * reg)
         }
     }
 
-#ifdef USE_PCRE2_JIT
-    rc = pcre2_jit_match(reg->regex, (PCRE2_SPTR)str, str_len, 0, 0, match_data, NULL);
-#else
+    /* Prefer pcre2_match: uses JIT when available, interpreter otherwise (#2040). */
     rc = pcre2_match(reg->regex, (PCRE2_SPTR)str, str_len, 0, 0, match_data, NULL);
-#endif
 
     return (rc >= 0);
 }

--- a/src/os_regex/os_pcre2_compile.c
+++ b/src/os_regex/os_pcre2_compile.c
@@ -132,11 +132,14 @@ int OSPcre2_Compile(const char *pattern, OSPcre2 *reg, int flags)
     }
 
 #ifdef USE_PCRE2_JIT
-    /* Just In Time compilation for faster execution */
-    if (pcre2_jit_compile(reg->regex, PCRE2_JIT_COMPLETE) != 0) {
-        reg->error = OS_REGEX_NO_JIT;
-        goto compile_error;
-    }
+    /*
+     * JIT is an optional speedup. On some platforms (notably macOS with a
+     * non-JIT system libpcre2) compile fails; treating that as fatal
+     * prevented analysisd from starting (#2040). Ignore failure here;
+     * execute paths call pcre2_match, which uses JIT when present and
+     * otherwise falls back to the interpreter.
+     */
+    (void) pcre2_jit_compile(reg->regex, PCRE2_JIT_COMPLETE);
 #endif
 
     return (1);

--- a/src/os_regex/os_pcre2_execute.c
+++ b/src/os_regex/os_pcre2_execute.c
@@ -38,12 +38,12 @@ const char *OSPcre2_Execute_pcre2_match(const char *str, OSPcre2 *reg)
         }
     }
 
-    /* Execute the reg */
-#ifdef USE_PCRE2_JIT
-    rc = pcre2_jit_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, match_data, NULL);
-#else
+    /* Execute the reg.
+     * Prefer pcre2_match over pcre2_jit_match: when JIT code is present,
+     * pcre2_match uses it automatically; when JIT compile failed or was
+     * skipped, it falls back to the interpreter (#2040).
+     */
     rc = pcre2_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, match_data, NULL);
-#endif
 
     /* Check execution result */
     if (rc <= 0) {

--- a/src/os_regex/os_regex_compile.c
+++ b/src/os_regex/os_regex_compile.c
@@ -131,11 +131,8 @@ int OSRegex_Compile(const char *pattern, OSRegex *reg, int flags)
     }
 
 #ifdef USE_PCRE2_JIT
-    /* Just In Time compilation for faster execution */
-    if (pcre2_jit_compile(reg->regex, PCRE2_JIT_COMPLETE) != 0) {
-        reg->error = OS_REGEX_NO_JIT;
-        goto compile_error;
-    }
+    /* JIT is optional; interpreter fallback via pcre2_match (#2040). */
+    (void) pcre2_jit_compile(reg->regex, PCRE2_JIT_COMPLETE);
 #endif
 
     if (flags & OS_RETURN_SUBSTRING) {

--- a/src/os_regex/os_regex_execute.c
+++ b/src/os_regex/os_regex_execute.c
@@ -42,12 +42,12 @@ const char *OSRegex_Execute_pcre2_match(const char *str, OSRegex *reg)
         }
     }
 
-    /* Execute the reg */
-#ifdef USE_PCRE2_JIT
-    rc = pcre2_jit_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, match_data, NULL);
-#else
+    /* Execute the reg.
+     * Prefer pcre2_match over pcre2_jit_match: when JIT code is present,
+     * pcre2_match uses it automatically; when JIT compile failed or was
+     * skipped, it falls back to the interpreter (#2040).
+     */
     rc = pcre2_match(reg->regex, (PCRE2_SPTR)str, strlen(str), 0, 0, match_data, NULL);
-#endif
 
     /* Check execution result */
     if (rc <= 0) {


### PR DESCRIPTION
Ignore JIT compile failures and match via pcre2_match (uses JIT when present, interpreter otherwise). Default USE_PCRE2_JIT off on Darwin (#2040).