### PR TITLE
Feature/csyslog tcp tls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,8 +100,13 @@ src/win32/route-null.cmd
 src/win32/runtime_dlls.nsh
 src/win32/ossec-win32-agent.exe
 
-# Local testsuite (not tracked)
-testsuite/
+# Testsuite build artifacts (sources under testsuite/ are tracked)
+testsuite/*.rpm
+testsuite/*.deb
+testsuite/*.changes
+testsuite/*.buildinfo
+testsuite/*.tar.gz
+testsuite/*.tar.xz
 
 # Pbuilder prepared source (generate_ossec.sh -d writes here)
 contrib/debian-packages/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Work toward the next minor release after 4.2.0.
 
 **General**
 
+- @atomicturtle - Raise csyslogd syslog/CEF/JSON alert buffer from 2048 to OS_MAXSTR (#1762)
 - @atomicturtle - Add Asterisk IPv6 denied decoder so srcip omits square brackets (#1892)
 - @atomicturtle - Allow manage_agents ``-f -`` to bulk-load agents from stdin (#459)
 - @atomicturtle - Ignore deleted agents in list_agents/get_agents; fix OS_RemoveAgent agent-info cleanup (#244)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Work toward the next minor release after 4.2.0.
 
 **General**
 
+- @atomicturtle - Add optional TCP and TLS to syslog_output (ossec-csyslogd) (#1762)
 - @atomicturtle - Raise csyslogd syslog/CEF/JSON alert buffer from 2048 to OS_MAXSTR (#1762)
 - @atomicturtle - Add Asterisk IPv6 denied decoder so srcip omits square brackets (#1892)
 - @atomicturtle - Allow manage_agents ``-f -`` to bulk-load agents from stdin (#459)

--- a/src/config/csyslogd-config.c
+++ b/src/config/csyslogd-config.c
@@ -24,6 +24,11 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
     const char *xml_syslog_group = "group";
     const char *xml_syslog_location = "location";
     const char *xml_syslog_use_fqdn = "use_fqdn";
+    const char *xml_syslog_protocol = "protocol";
+    const char *xml_syslog_tls = "tls";
+    const char *xml_syslog_tls_verify = "tls_verify";
+    const char *xml_syslog_tls_ca = "tls_ca";
+    int protocol_set = 0;
 
     struct SyslogConfig_holder *config_holder = (struct SyslogConfig_holder *)config;
     SyslogConfig **syslog_config = config_holder->data;
@@ -41,6 +46,7 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
 
     /* Zero the elements */
     syslog_config[s]->server = NULL;
+    syslog_config[s]->tls_ca = NULL;
     syslog_config[s]->rule_id = NULL;
     syslog_config[s]->group = NULL;
     syslog_config[s]->location = NULL;
@@ -48,7 +54,12 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
     syslog_config[s]->port = "514";
     syslog_config[s]->format = DEFAULT_CSYSLOG;
     syslog_config[s]->use_fqdn = 0;
+    syslog_config[s]->protocol = CSYSLOG_UDP;
+    syslog_config[s]->tls = 0;
+    syslog_config[s]->tls_verify = 1;
     syslog_config[s]->socket = -1;
+    syslog_config[s]->ssl = NULL;
+    syslog_config[s]->ssl_ctx = NULL;
     /* local 0 facility (16) + severity 4 - warning. --default */
     syslog_config[s]->priority = (16 * 8) + 4;
 
@@ -162,6 +173,42 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
                 merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
                 goto fail;
             }
+        } else if (strcmp(node[i]->element, xml_syslog_protocol) == 0) {
+            if (strcmp(node[i]->content, "udp") == 0) {
+                syslog_config[s]->protocol = CSYSLOG_UDP;
+                protocol_set = 1;
+            } else if (strcmp(node[i]->content, "tcp") == 0) {
+                syslog_config[s]->protocol = CSYSLOG_TCP;
+                protocol_set = 1;
+            } else {
+                merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
+                goto fail;
+            }
+        } else if (strcmp(node[i]->element, xml_syslog_tls) == 0) {
+            if (strcmp(node[i]->content, "yes") == 0) {
+                syslog_config[s]->tls = 1;
+            } else if (strcmp(node[i]->content, "no") == 0) {
+                syslog_config[s]->tls = 0;
+            } else {
+                merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
+                goto fail;
+            }
+        } else if (strcmp(node[i]->element, xml_syslog_tls_verify) == 0) {
+            if (strcmp(node[i]->content, "yes") == 0) {
+                syslog_config[s]->tls_verify = 1;
+            } else if (strcmp(node[i]->content, "no") == 0) {
+                syslog_config[s]->tls_verify = 0;
+            } else {
+                merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
+                goto fail;
+            }
+        } else if (strcmp(node[i]->element, xml_syslog_tls_ca) == 0) {
+            if (node[i]->content[0] == '\0') {
+                merror(XML_VALUEERR, __local_name, node[i]->element, node[i]->content);
+                goto fail;
+            }
+            free(syslog_config[s]->tls_ca);
+            os_strdup(node[i]->content, syslog_config[s]->tls_ca);
         } else if (strcmp(node[i]->element, xml_syslog_group) == 0) {
             os_calloc(1, sizeof(OSMatch), syslog_config[s]->group);
             if (!OSMatch_Compile(node[i]->content,
@@ -183,6 +230,21 @@ int Read_CSyslog(XML_NODE node, void *config, __attribute__((unused)) void *conf
         goto fail;
     }
 
+    /* tls=yes implies TCP unless protocol was explicitly set to udp. */
+    if (syslog_config[s]->tls) {
+        if (protocol_set && syslog_config[s]->protocol == CSYSLOG_UDP) {
+            merror("%s: ERROR: syslog_output tls=yes requires protocol=tcp "
+                   "(got protocol=udp).", __local_name);
+            goto fail;
+        }
+        syslog_config[s]->protocol = CSYSLOG_TCP;
+#ifndef LIBOPENSSL_ENABLED
+        merror("%s: ERROR: syslog_output tls=yes requires building with OpenSSL "
+               "(LIBOPENSSL_ENABLED).", __local_name);
+        goto fail;
+#endif
+    }
+
     config_holder->data = syslog_config;
     return (0);
 
@@ -190,6 +252,7 @@ fail:
     i = 0;
     while (syslog_config[i]) {
         free(syslog_config[i]->server);
+        free(syslog_config[i]->tls_ca);
 
         if (syslog_config[i]->group) {
             OSMatch_FreePattern(syslog_config[i]->group);

--- a/src/config/csyslogd-config.h
+++ b/src/config/csyslogd-config.h
@@ -12,6 +12,10 @@
 #ifndef _CSYSLOGCONFIG__H
 #define _CSYSLOGCONFIG__H
 
+/* Syslog transport */
+#define CSYSLOG_UDP  0
+#define CSYSLOG_TCP  1
+
 /* Database config structure */
 typedef struct _SyslogConfig {
     char *port;
@@ -20,11 +24,19 @@ typedef struct _SyslogConfig {
     unsigned int *rule_id;
     unsigned int priority;
     unsigned int use_fqdn;
+    unsigned int protocol;   /* CSYSLOG_UDP or CSYSLOG_TCP */
+    unsigned int tls;        /* 1 = wrap TCP in TLS */
+    unsigned int tls_verify; /* 1 = verify peer (default) */
     int socket;
 
     char *server;
+    char *tls_ca;            /* optional CA file path (pre-chroot) */
     OSMatch *group;
     OSMatch *location;
+
+    /* Runtime transport state (updated on reconnect; not from XML). */
+    void *ssl;               /* SSL* when tls */
+    void *ssl_ctx;           /* SSL_CTX* when tls */
 } SyslogConfig;
 
 struct SyslogConfig_holder {

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -107,17 +107,14 @@ char *cefescape(const char *msg, const bool header)
 /* Send an alert via syslog
  * Returns 1 on success or 0 on error
  */
-int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
+int OS_Alert_SendSyslog(alert_data *al_data, SyslogConfig *syslog_config)
 {
     char *logmsg = NULL;
     char *tstamp;
     char *hostname;
     char syslog_msg[OS_CSYSLOG_MAX];
 
-    /* Invalid socket */
-    if (syslog_config->socket < 0) {
-        return (0);
-    }
+    /* Socket may be -1 after a prior send failure; csyslog_send reconnects. */
 
     /* Clear the memory before insert */
     memset(syslog_msg, '\0', OS_CSYSLOG_MAX);
@@ -387,7 +384,9 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         field_add_truncated(syslog_msg, OS_CSYSLOG_MAX, " message=\"%s\"", logmsg, 2);
     }
 
-    OS_SendUDPbySize(syslog_config->socket, strlen(syslog_msg), syslog_msg);
+    if (csyslog_send(syslog_config, syslog_msg, strlen(syslog_msg)) < 0) {
+        return (0);
+    }
     return (1);
 }
 

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -22,6 +22,7 @@ char *cefescape(const char *msg, const bool header)
     const char *ptr;
     char *buffptr;
     size_t size;
+    int needs_escape = 0;
 
     /* Recycle the buffer */
     if (buffer) {
@@ -29,14 +30,22 @@ char *cefescape(const char *msg, const bool header)
         buffer = NULL;
     }
 
-    /* Test if the string needs escaping */
-    if ((NULL == msg) ||                            /* Cleanup call or empty string */
-        ((header && (NULL == strchr(msg, '|'))) &&  /* | in the header must be escaped */
-        (!header && (NULL == strchr(msg, '='))) &&  /* = in the extension must be escaped */
-        (NULL == strchr(msg, '\\')) &&              /* \ must be escaped */
-        (NULL == strchr(msg, '\r')) &&              /* \r removed from header, escaped in extension */
-        (NULL == strchr(msg, '\n')))) {             /* \n removed from header, escaped in extension */
-        return buffer;
+    /* Cleanup call */
+    if (NULL == msg) {
+        return NULL;
+    }
+
+    if (header && strchr(msg, '|')) {
+        needs_escape = 1;
+    }
+    if (!header && strchr(msg, '=')) {
+        needs_escape = 1;
+    }
+    if (strchr(msg, '\\') || strchr(msg, '\r') || strchr(msg, '\n')) {
+        needs_escape = 1;
+    }
+    if (!needs_escape) {
+        return (char *)msg;
     }
 
     /* Calculate the size of the escaped message
@@ -110,6 +119,8 @@ char *cefescape(const char *msg, const bool header)
 int OS_Alert_SendSyslog(alert_data *al_data, SyslogConfig *syslog_config)
 {
     char *logmsg = NULL;
+    int logmsg_allocated = 0;
+    int result = 0;
     char *tstamp;
     char *hostname;
     char syslog_msg[OS_CSYSLOG_MAX];
@@ -186,6 +197,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, SyslogConfig *syslog_config)
             logmsg = al_data->log[0];
         } else {
             short int i = 0;
+            logmsg_allocated = 1;
             while (NULL != al_data->log[i]) {
                 logmsg = os_LoadString(logmsg, al_data->log[i]);
                 i++;
@@ -193,7 +205,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, SyslogConfig *syslog_config)
                     logmsg = os_LoadString(logmsg, "\n");
                 }
                 /* Save on memory and processing since it's going to get truncated anyway */
-                if (OS_CSYSLOG_MAX <= strlen(logmsg)) {
+                if (logmsg && OS_CSYSLOG_MAX <= strlen(logmsg)) {
                     break;
                 }
             }
@@ -333,18 +345,28 @@ int OS_Alert_SendSyslog(alert_data *al_data, SyslogConfig *syslog_config)
         /* Create the JSON string */
         json_string = cJSON_PrintUnformatted(root);
 
-        /* Create the syslog message */
-        snprintf(syslog_msg, OS_CSYSLOG_MAX,
-                 "<%u>%s %s ossec: %s",
-
-                 /* syslog header */
-                 syslog_config->priority, tstamp, hostname,
-
-                 /* JSON Encoded Data */
-                 json_string
-                );
-        /* Clean up the memory for the JSON structure */
-        free(json_string);
+        /* Create the syslog message; avoid mid-JSON truncation. */
+        if (json_string) {
+            int n = snprintf(syslog_msg, OS_CSYSLOG_MAX,
+                             "<%u>%s %s ossec: %s",
+                             syslog_config->priority, tstamp, hostname,
+                             json_string);
+            if (n < 0 || (size_t)n >= OS_CSYSLOG_MAX) {
+                merror("%s: WARN: syslog_output JSON alert truncated; "
+                       "sending compact stub (rule %u).",
+                       ARGV0, al_data->rule);
+                snprintf(syslog_msg, OS_CSYSLOG_MAX,
+                         "<%u>%s %s ossec: {\"crit\":%u,\"id\":%u,\"truncated\":true}",
+                         syslog_config->priority, tstamp, hostname,
+                         al_data->level, al_data->rule);
+            }
+            free(json_string);
+        } else {
+            snprintf(syslog_msg, OS_CSYSLOG_MAX,
+                     "<%u>%s %s ossec: {\"crit\":%u,\"id\":%u,\"error\":\"json_encode\"}",
+                     syslog_config->priority, tstamp, hostname,
+                     al_data->level, al_data->rule);
+        }
         cJSON_Delete(root);
     } else if (syslog_config->format == SPLUNK_CSYSLOG) {
         /* Build a Splunk Style Key/Value string for logging */
@@ -384,9 +406,13 @@ int OS_Alert_SendSyslog(alert_data *al_data, SyslogConfig *syslog_config)
         field_add_truncated(syslog_msg, OS_CSYSLOG_MAX, " message=\"%s\"", logmsg, 2);
     }
 
-    if (csyslog_send(syslog_config, syslog_msg, strlen(syslog_msg)) < 0) {
-        return (0);
+    if (csyslog_send(syslog_config, syslog_msg, strlen(syslog_msg)) == 0) {
+        result = 1;
     }
-    return (1);
+
+    if (logmsg_allocated) {
+        free(logmsg);
+    }
+    return (result);
 }
 

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -112,7 +112,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
     char *logmsg = NULL;
     char *tstamp;
     char *hostname;
-    char syslog_msg[OS_SIZE_2048];
+    char syslog_msg[OS_CSYSLOG_MAX];
 
     /* Invalid socket */
     if (syslog_config->socket < 0) {
@@ -120,7 +120,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
     }
 
     /* Clear the memory before insert */
-    memset(syslog_msg, '\0', OS_SIZE_2048);
+    memset(syslog_msg, '\0', OS_CSYSLOG_MAX);
 
     /* Look if location is set */
     if (syslog_config->location) {
@@ -196,7 +196,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                     logmsg = os_LoadString(logmsg, "\n");
                 }
                 /* Save on memory and processing since it's going to get truncated anyway */
-                if (OS_SIZE_2048 <= strlen(logmsg)) {
+                if (OS_CSYSLOG_MAX <= strlen(logmsg)) {
                     break;
                 }
             }
@@ -206,35 +206,35 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
     /* Insert data */
     if (syslog_config->format == DEFAULT_CSYSLOG) {
         /* Build syslog message */
-        snprintf(syslog_msg, OS_SIZE_2048,
+        snprintf(syslog_msg, OS_CSYSLOG_MAX,
                  "<%u>%s %s ossec: Alert Level: %u; Rule: %u - %s; Location: %s;",
                  syslog_config->priority, tstamp, hostname,
                  al_data->level,
                  al_data->rule, al_data->comment,
                  al_data->location
                 );
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification: %s;", al_data->group);
-        field_add_string(syslog_msg, OS_SIZE_2048, " srcip: %s;", al_data->srcip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " classification: %s;", al_data->group);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " srcip: %s;", al_data->srcip);
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " srccity: %s;", al_data->srcgeoip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " dstcity: %s;", al_data->dstgeoip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " srccity: %s;", al_data->srcgeoip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dstcity: %s;", al_data->dstgeoip);
 #endif
-        field_add_string(syslog_msg, OS_SIZE_2048, " dstip: %s;", al_data->dstip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " user: %s;", al_data->user);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Previous MD5: %s;", al_data->old_md5);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Current MD5: %s;", al_data->new_md5);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Previous SHA1: %s;", al_data->old_sha1);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Current SHA1: %s;", al_data->new_sha1);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dstip: %s;", al_data->dstip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " user: %s;", al_data->user);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Previous MD5: %s;", al_data->old_md5);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Current MD5: %s;", al_data->new_md5);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Previous SHA1: %s;", al_data->old_sha1);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Current SHA1: %s;", al_data->new_sha1);
         /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-        field_add_string(syslog_msg, OS_SIZE_2048, " Size changed: from %s;", al_data->file_size);
-        field_add_string(syslog_msg, OS_SIZE_2048, " User ownership: was %s;", al_data->owner_chg);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Group ownership: was %s;", al_data->group_chg);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Permissions changed: from %s;", al_data->perm_chg);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Size changed: from %s;", al_data->file_size);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " User ownership: was %s;", al_data->owner_chg);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Group ownership: was %s;", al_data->group_chg);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Permissions changed: from %s;", al_data->perm_chg);
         /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-        field_add_truncated(syslog_msg, OS_SIZE_2048, " %s", logmsg, 2);
+        field_add_truncated(syslog_msg, OS_CSYSLOG_MAX, " %s", logmsg, 2);
     } else if (syslog_config->format == CEF_CSYSLOG) {
         /* Start with headers */
-        snprintf(syslog_msg, OS_SIZE_2048,
+        snprintf(syslog_msg, OS_CSYSLOG_MAX,
                  "<%u>%s CEF:0|%s|%s|%s|%u|%s|%u|",
                  syslog_config->priority,
                  tstamp,
@@ -245,29 +245,29 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                  cefescape(al_data->comment, true),
                  (al_data->level > 10) ? 10 : al_data->level);
         /* Add extensions */
-        field_add_string(syslog_msg, OS_SIZE_2048, "dvc=%s", cefescape(hostname, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs1Label=Location cs1=%s", cefescape(al_data->location, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification=%s", cefescape(al_data->group, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " src=%s", al_data->srcip);
-        field_add_int(syslog_msg, OS_SIZE_2048, " dpt=%d", al_data->dstport);
-        field_add_int(syslog_msg, OS_SIZE_2048, " spt=%d", al_data->srcport);
-        field_add_string(syslog_msg, OS_SIZE_2048, " fname=%s", cefescape(al_data->filename, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " dhost=%s", al_data->dstip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " shost=%s", al_data->srcip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " suser=%s", cefescape(al_data->user, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " dst=%s", cefescape(al_data->dstip, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, "dvc=%s", cefescape(hostname, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs1Label=Location cs1=%s", cefescape(al_data->location, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " classification=%s", cefescape(al_data->group, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " src=%s", al_data->srcip);
+        field_add_int(syslog_msg, OS_CSYSLOG_MAX, " dpt=%d", al_data->dstport);
+        field_add_int(syslog_msg, OS_CSYSLOG_MAX, " spt=%d", al_data->srcport);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " fname=%s", cefescape(al_data->filename, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dhost=%s", al_data->dstip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " shost=%s", al_data->srcip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " suser=%s", cefescape(al_data->user, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dst=%s", cefescape(al_data->dstip, false));
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=SrcCity cs4=%s", cefescape(al_data->srcgeoip, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs5Label=DstCity cs5=%s", cefescape(al_data->dstgeoip, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs4Label=SrcCity cs4=%s", cefescape(al_data->srcgeoip, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs5Label=DstCity cs5=%s", cefescape(al_data->dstgeoip, false));
 #endif
         if (al_data->new_md5 && al_data->new_sha1) {
-            field_add_string(syslog_msg, OS_SIZE_2048, " cs2Label=OldMD5 cs2=%s", al_data->old_md5);
-            field_add_string(syslog_msg, OS_SIZE_2048, " cs3Label=NewMD5 cs3=%s", al_data->new_md5);
-            field_add_string(syslog_msg, OS_SIZE_2048, " oldFileHash=%s", al_data->old_sha1);
-            field_add_string(syslog_msg, OS_SIZE_2048, " fhash=%s", al_data->new_sha1);
-            field_add_string(syslog_msg, OS_SIZE_2048, " fileHash=%s", al_data->new_sha1);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs2Label=OldMD5 cs2=%s", al_data->old_md5);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs3Label=NewMD5 cs3=%s", al_data->new_md5);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " oldFileHash=%s", al_data->old_sha1);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " fhash=%s", al_data->new_sha1);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " fileHash=%s", al_data->new_sha1);
         }
-        field_add_truncated(syslog_msg, OS_SIZE_2048, " msg=%s", cefescape(logmsg, false), 2);
+        field_add_truncated(syslog_msg, OS_CSYSLOG_MAX, " msg=%s", cefescape(logmsg, false), 2);
         cefescape(NULL,0);  /* Clean up the escaping buffer */
     } else if (syslog_config->format == JSON_CSYSLOG) {
         /* Build a JSON Object for logging */
@@ -337,7 +337,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         json_string = cJSON_PrintUnformatted(root);
 
         /* Create the syslog message */
-        snprintf(syslog_msg, OS_SIZE_2048,
+        snprintf(syslog_msg, OS_CSYSLOG_MAX,
                  "<%u>%s %s ossec: %s",
 
                  /* syslog header */
@@ -351,7 +351,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         cJSON_Delete(root);
     } else if (syslog_config->format == SPLUNK_CSYSLOG) {
         /* Build a Splunk Style Key/Value string for logging */
-        snprintf(syslog_msg, OS_SIZE_2048,
+        snprintf(syslog_msg, OS_CSYSLOG_MAX,
                  "<%u>%s %s ossec: crit=%u id=%u description=\"%s\" component=\"%s\",",
 
                  /* syslog header */
@@ -362,29 +362,29 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                  al_data->location
                 );
         /* Event specifics */
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification=\"%s\",", al_data->group);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " classification=\"%s\",", al_data->group);
 
-        if (field_add_string(syslog_msg, OS_SIZE_2048, " src_ip=\"%s\",", al_data->srcip) > 0) {
-            field_add_int(syslog_msg, OS_SIZE_2048, " src_port=%d,", al_data->srcport);
+        if (field_add_string(syslog_msg, OS_CSYSLOG_MAX, " src_ip=\"%s\",", al_data->srcip) > 0) {
+            field_add_int(syslog_msg, OS_CSYSLOG_MAX, " src_port=%d,", al_data->srcport);
         }
 
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " src_city=\"%s\",", al_data->srcgeoip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " dst_city=\"%s\",", al_data->dstgeoip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " src_city=\"%s\",", al_data->srcgeoip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dst_city=\"%s\",", al_data->dstgeoip);
 #endif
 
-        if (field_add_string(syslog_msg, OS_SIZE_2048, " dst_ip=\"%s\",", al_data->dstip) > 0) {
-            field_add_int(syslog_msg, OS_SIZE_2048, " dst_port=%d,", al_data->dstport);
+        if (field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dst_ip=\"%s\",", al_data->dstip) > 0) {
+            field_add_int(syslog_msg, OS_CSYSLOG_MAX, " dst_port=%d,", al_data->dstport);
         }
 
-        field_add_string(syslog_msg, OS_SIZE_2048, " file=\"%s\",", al_data->filename);
-        field_add_string(syslog_msg, OS_SIZE_2048, " acct=\"%s\",", al_data->user);
-        field_add_string(syslog_msg, OS_SIZE_2048, " md5_old=\"%s\",", al_data->old_md5);
-        field_add_string(syslog_msg, OS_SIZE_2048, " md5_new=\"%s\",", al_data->new_md5);
-        field_add_string(syslog_msg, OS_SIZE_2048, " sha1_old=\"%s\",", al_data->old_sha1);
-        field_add_string(syslog_msg, OS_SIZE_2048, " sha1_new=\"%s\",", al_data->new_sha1);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " file=\"%s\",", al_data->filename);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " acct=\"%s\",", al_data->user);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " md5_old=\"%s\",", al_data->old_md5);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " md5_new=\"%s\",", al_data->new_md5);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " sha1_old=\"%s\",", al_data->old_sha1);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " sha1_new=\"%s\",", al_data->new_sha1);
         /* Message */
-        field_add_truncated(syslog_msg, OS_SIZE_2048, " message=\"%s\"", logmsg, 2);
+        field_add_truncated(syslog_msg, OS_CSYSLOG_MAX, " message=\"%s\"", logmsg, 2);
     }
 
     OS_SendUDPbySize(syslog_config->socket, strlen(syslog_msg), syslog_msg);

--- a/src/os_csyslogd/csyslog_send.c
+++ b/src/os_csyslogd/csyslog_send.c
@@ -100,6 +100,25 @@ int csyslog_connect(SyslogConfig *cfg)
     csyslog_close(cfg);
 
     if (cfg->protocol == CSYSLOG_TCP) {
+        /* Load CA / build SSL_CTX before connect (and before chroot) so a
+         * failed first connect still leaves a usable ctx for post-chroot
+         * reconnects. */
+        if (cfg->tls) {
+#ifdef LIBOPENSSL_ENABLED
+            if (!cfg->ssl_ctx) {
+                cfg->ssl_ctx = csyslog_tls_ctx_create((int)cfg->tls_verify,
+                                                     cfg->tls_ca);
+                if (!cfg->ssl_ctx) {
+                    return -1;
+                }
+            }
+#else
+            merror("%s: ERROR: syslog_output tls requested but OpenSSL is not enabled.",
+                   ARGV0);
+            return -1;
+#endif
+        }
+
         sock = OS_ConnectTCP(cfg->port, cfg->server);
         if (sock < 0) {
             return -1;
@@ -109,29 +128,13 @@ int csyslog_connect(SyslogConfig *cfg)
 
         if (cfg->tls) {
 #ifdef LIBOPENSSL_ENABLED
-            SSL_CTX *ctx = (SSL_CTX *)cfg->ssl_ctx;
-            SSL *ssl;
-
-            if (!ctx) {
-                ctx = csyslog_tls_ctx_create((int)cfg->tls_verify, cfg->tls_ca);
-                if (!ctx) {
-                    csyslog_close(cfg);
-                    return -1;
-                }
-                cfg->ssl_ctx = ctx;
-            }
-
-            ssl = csyslog_tls_connect(ctx, sock, cfg->server, (int)cfg->tls_verify);
+            SSL *ssl = csyslog_tls_connect((SSL_CTX *)cfg->ssl_ctx, sock,
+                                           cfg->server, (int)cfg->tls_verify);
             if (!ssl) {
                 csyslog_close(cfg);
                 return -1;
             }
             cfg->ssl = ssl;
-#else
-            merror("%s: ERROR: syslog_output tls requested but OpenSSL is not enabled.",
-                   ARGV0);
-            csyslog_close(cfg);
-            return -1;
 #endif
         }
     } else {
@@ -146,6 +149,7 @@ int csyslog_connect(SyslogConfig *cfg)
 }
 
 /* Send one framed alert. TCP/TLS append a trailing newline (RFC 6587).
+ * Embedded CR/LF in the payload are flattened so one alert stays one frame.
  * On failure, reconnect once and retry. Returns 0 on success, -1 on failure.
  */
 int csyslog_send(SyslogConfig *cfg, const char *msg, size_t len)
@@ -160,12 +164,19 @@ int csyslog_send(SyslogConfig *cfg, const char *msg, size_t len)
     }
 
     if (cfg->protocol == CSYSLOG_TCP) {
+        size_t i;
+
         if (len >= OS_CSYSLOG_MAX) {
             merror("%s: WARN: syslog_output TCP message truncated from %zu to %d bytes.",
                    ARGV0, len, OS_CSYSLOG_MAX - 1);
             len = OS_CSYSLOG_MAX - 1;
         }
         memcpy(framed, msg, len);
+        for (i = 0; i < len; i++) {
+            if (framed[i] == '\n' || framed[i] == '\r') {
+                framed[i] = ' ';
+            }
+        }
         framed[len] = '\n';
         framed[len + 1] = '\0';
         out = framed;

--- a/src/os_csyslogd/csyslog_send.c
+++ b/src/os_csyslogd/csyslog_send.c
@@ -1,0 +1,212 @@
+/* Copyright (C) 2026 Atomicorp LLC
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * Connect / send / reconnect helpers for syslog_output (UDP, TCP, TLS).
+ */
+
+#include "shared.h"
+#include "csyslogd.h"
+#include "csyslog_tls.h"
+#include "os_net/os_net.h"
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <errno.h>
+
+#ifndef CSYSLOG_SNDTIMEO_SEC
+#define CSYSLOG_SNDTIMEO_SEC 10
+#endif
+
+static void csyslog_set_tcp_opts(int sock)
+{
+    int on = 1;
+    struct timeval tv;
+
+    if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on)) < 0) {
+        merror("%s: WARN: Unable to set SO_KEEPALIVE on syslog_output socket: %s",
+               ARGV0, strerror(errno));
+    }
+
+    tv.tv_sec = CSYSLOG_SNDTIMEO_SEC;
+    tv.tv_usec = 0;
+    /* Bound both directions: TLS handshake reads and TCP/TLS writes. */
+    if (setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) < 0) {
+        merror("%s: WARN: Unable to set SO_SNDTIMEO on syslog_output socket: %s",
+               ARGV0, strerror(errno));
+    }
+    if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+        merror("%s: WARN: Unable to set SO_RCVTIMEO on syslog_output socket: %s",
+               ARGV0, strerror(errno));
+    }
+}
+
+/* TCP can return short writes; loop until complete or error. */
+static int csyslog_send_tcp(int sock, const char *buf, size_t len)
+{
+    size_t off = 0;
+
+    while (off < len) {
+        ssize_t n = send(sock, buf + off, len - off, 0);
+
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        if (n == 0) {
+            return -1;
+        }
+        off += (size_t)n;
+    }
+
+    return 0;
+}
+
+void csyslog_close(SyslogConfig *cfg)
+{
+    if (!cfg) {
+        return;
+    }
+
+#ifdef LIBOPENSSL_ENABLED
+    if (cfg->ssl) {
+        SSL *ssl = (SSL *)cfg->ssl;
+        csyslog_tls_close(&ssl);
+        cfg->ssl = NULL;
+    }
+    /* Keep ssl_ctx across reconnects; freed only on shutdown if ever needed. */
+#endif
+
+    if (cfg->socket >= 0) {
+        OS_CloseSocket(cfg->socket);
+        cfg->socket = -1;
+    }
+}
+
+int csyslog_connect(SyslogConfig *cfg)
+{
+    int sock;
+
+    if (!cfg || !cfg->server || !cfg->port) {
+        return -1;
+    }
+
+    csyslog_close(cfg);
+
+    if (cfg->protocol == CSYSLOG_TCP) {
+        sock = OS_ConnectTCP(cfg->port, cfg->server);
+        if (sock < 0) {
+            return -1;
+        }
+        csyslog_set_tcp_opts(sock);
+        cfg->socket = sock;
+
+        if (cfg->tls) {
+#ifdef LIBOPENSSL_ENABLED
+            SSL_CTX *ctx = (SSL_CTX *)cfg->ssl_ctx;
+            SSL *ssl;
+
+            if (!ctx) {
+                ctx = csyslog_tls_ctx_create((int)cfg->tls_verify, cfg->tls_ca);
+                if (!ctx) {
+                    csyslog_close(cfg);
+                    return -1;
+                }
+                cfg->ssl_ctx = ctx;
+            }
+
+            ssl = csyslog_tls_connect(ctx, sock, cfg->server, (int)cfg->tls_verify);
+            if (!ssl) {
+                csyslog_close(cfg);
+                return -1;
+            }
+            cfg->ssl = ssl;
+#else
+            merror("%s: ERROR: syslog_output tls requested but OpenSSL is not enabled.",
+                   ARGV0);
+            csyslog_close(cfg);
+            return -1;
+#endif
+        }
+    } else {
+        sock = OS_ConnectUDP(cfg->port, cfg->server);
+        if (sock < 0) {
+            return -1;
+        }
+        cfg->socket = sock;
+    }
+
+    return 0;
+}
+
+/* Send one framed alert. TCP/TLS append a trailing newline (RFC 6587).
+ * On failure, reconnect once and retry. Returns 0 on success, -1 on failure.
+ */
+int csyslog_send(SyslogConfig *cfg, const char *msg, size_t len)
+{
+    char framed[OS_CSYSLOG_MAX + 2];
+    const char *out;
+    size_t out_len;
+    int attempt;
+
+    if (!cfg || !msg) {
+        return -1;
+    }
+
+    if (cfg->protocol == CSYSLOG_TCP) {
+        if (len >= OS_CSYSLOG_MAX) {
+            merror("%s: WARN: syslog_output TCP message truncated from %zu to %d bytes.",
+                   ARGV0, len, OS_CSYSLOG_MAX - 1);
+            len = OS_CSYSLOG_MAX - 1;
+        }
+        memcpy(framed, msg, len);
+        framed[len] = '\n';
+        framed[len + 1] = '\0';
+        out = framed;
+        out_len = len + 1;
+    } else {
+        out = msg;
+        out_len = len;
+    }
+
+    for (attempt = 0; attempt < 2; attempt++) {
+        if (cfg->socket < 0) {
+            if (csyslog_connect(cfg) < 0) {
+                merror("%s: ERROR: Unable to connect syslog_output to '%s:%s'.",
+                       ARGV0, cfg->server, cfg->port);
+                continue;
+            }
+        }
+
+        if (cfg->protocol == CSYSLOG_UDP) {
+            if (OS_SendUDPbySize(cfg->socket, (int)out_len, out) == 0) {
+                return 0;
+            }
+        } else if (cfg->tls) {
+#ifdef LIBOPENSSL_ENABLED
+            if (cfg->ssl &&
+                    csyslog_tls_write((SSL *)cfg->ssl, out, out_len) == 0) {
+                return 0;
+            }
+#else
+            merror("%s: ERROR: syslog_output tls send without OpenSSL.", ARGV0);
+#endif
+        } else {
+            if (csyslog_send_tcp(cfg->socket, out, out_len) == 0) {
+                return 0;
+            }
+        }
+
+        merror("%s: WARN: syslog_output send to '%s:%s' failed; reconnecting.",
+               ARGV0, cfg->server, cfg->port);
+        csyslog_close(cfg);
+    }
+
+    return -1;
+}

--- a/src/os_csyslogd/csyslog_send.c
+++ b/src/os_csyslogd/csyslog_send.c
@@ -15,11 +15,20 @@
 #include "os_net/os_net.h"
 
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <netinet/in.h>
+#include <netdb.h>
+#include <fcntl.h>
+#include <poll.h>
 #include <errno.h>
+#include <unistd.h>
 
 #ifndef CSYSLOG_SNDTIMEO_SEC
 #define CSYSLOG_SNDTIMEO_SEC 10
+#endif
+
+#ifndef CSYSLOG_CONNECT_TIMEOUT_SEC
+#define CSYSLOG_CONNECT_TIMEOUT_SEC CSYSLOG_SNDTIMEO_SEC
 #endif
 
 static void csyslog_set_tcp_opts(int sock)
@@ -43,6 +52,93 @@ static void csyslog_set_tcp_opts(int sock)
         merror("%s: WARN: Unable to set SO_RCVTIMEO on syslog_output socket: %s",
                ARGV0, strerror(errno));
     }
+}
+
+/* Non-blocking TCP connect with a hard deadline so a blackholed SIEM does
+ * not stall the single-threaded csyslogd loop during SYN retries.
+ */
+static int csyslog_connect_tcp(const char *port, const char *server)
+{
+    struct addrinfo hints;
+    struct addrinfo *result = NULL;
+    struct addrinfo *rp;
+    int sock = -1;
+    int s;
+    int flags;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    s = getaddrinfo(server, port, &hints, &result);
+    if (s != 0) {
+        hints.ai_family = AF_INET;
+        s = getaddrinfo(server, port, &hints, &result);
+    }
+    if (s != 0 || !result) {
+        return -1;
+    }
+
+    for (rp = result; rp != NULL; rp = rp->ai_next) {
+        int rv;
+        struct pollfd pfd;
+        int soerr = 0;
+        socklen_t soerr_len = sizeof(soerr);
+
+        sock = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (sock < 0) {
+            continue;
+        }
+
+        flags = fcntl(sock, F_GETFL, 0);
+        if (flags < 0 || fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0) {
+            close(sock);
+            sock = -1;
+            continue;
+        }
+
+        rv = connect(sock, rp->ai_addr, rp->ai_addrlen);
+        if (rv != 0) {
+            if (errno != EINPROGRESS) {
+                close(sock);
+                sock = -1;
+                continue;
+            }
+
+            pfd.fd = sock;
+            pfd.events = POLLOUT;
+            pfd.revents = 0;
+            rv = poll(&pfd, 1, CSYSLOG_CONNECT_TIMEOUT_SEC * 1000);
+            if (rv <= 0) {
+                close(sock);
+                sock = -1;
+                continue;
+            }
+            if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &soerr, &soerr_len) < 0 ||
+                    soerr != 0) {
+                close(sock);
+                sock = -1;
+                continue;
+            }
+        }
+
+        /* Back to blocking for SSL_connect / send with SO_*TIMEO. */
+        flags = fcntl(sock, F_GETFL, 0);
+        if (flags >= 0) {
+            fcntl(sock, F_SETFL, flags & ~O_NONBLOCK);
+        }
+        break;
+    }
+
+    freeaddrinfo(result);
+
+    if (sock < 0) {
+        return -1;
+    }
+
+    csyslog_set_tcp_opts(sock);
+    return sock;
 }
 
 /* TCP can return short writes; loop until complete or error. */
@@ -119,11 +215,10 @@ int csyslog_connect(SyslogConfig *cfg)
 #endif
         }
 
-        sock = OS_ConnectTCP(cfg->port, cfg->server);
+        sock = csyslog_connect_tcp(cfg->port, cfg->server);
         if (sock < 0) {
             return -1;
         }
-        csyslog_set_tcp_opts(sock);
         cfg->socket = sock;
 
         if (cfg->tls) {

--- a/src/os_csyslogd/csyslog_tls.c
+++ b/src/os_csyslogd/csyslog_tls.c
@@ -1,0 +1,256 @@
+/* Copyright (C) 2026 Atomicorp LLC
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ *
+ * Optional TLS for syslog_output (LIBOPENSSL_ENABLED).
+ */
+
+#include "shared.h"
+#include "csyslog_tls.h"
+
+#ifdef LIBOPENSSL_ENABLED
+
+#include <openssl/err.h>
+#include <openssl/x509v3.h>
+#include <poll.h>
+
+#ifndef CSYSLOG_TLS_WRITE_MAX_SPIN
+#define CSYSLOG_TLS_WRITE_MAX_SPIN 10000
+#endif
+
+#ifndef CSYSLOG_TLS_WRITE_WAIT_MS
+#define CSYSLOG_TLS_WRITE_WAIT_MS 1000
+#endif
+
+static void csyslog_tls_log_errors(const char *prefix)
+{
+    unsigned long e;
+
+    while ((e = ERR_get_error()) != 0) {
+        char buf[256];
+
+        ERR_error_string_n(e, buf, sizeof(buf));
+        merror("%s: ERROR: %s: %s", ARGV0, prefix, buf);
+    }
+}
+
+SSL_CTX *csyslog_tls_ctx_create(int verify, const char *ca_path)
+{
+    SSL_CTX *ctx;
+    const SSL_METHOD *method;
+    static int ssl_inited = 0;
+
+    if (!ssl_inited) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+        SSL_library_init();
+        SSL_load_error_strings();
+        OpenSSL_add_all_algorithms();
+#endif
+        ssl_inited = 1;
+    }
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    method = TLS_client_method();
+#else
+    method = TLSv1_2_client_method();
+#endif
+
+    ctx = SSL_CTX_new(method);
+    if (!ctx) {
+        merror("%s: ERROR: SSL_CTX_new failed for syslog TLS.", ARGV0);
+        csyslog_tls_log_errors("SSL_CTX_new");
+        return NULL;
+    }
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+#else
+    SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 |
+                        SSL_OP_NO_TLSv1_1);
+#endif
+
+    if (verify) {
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+        if (ca_path && ca_path[0] != '\0') {
+            if (SSL_CTX_load_verify_locations(ctx, ca_path, NULL) != 1) {
+                merror("%s: ERROR: Unable to load TLS CA file '%s' for syslog_output.",
+                       ARGV0, ca_path);
+                csyslog_tls_log_errors("load CA");
+                SSL_CTX_free(ctx);
+                return NULL;
+            }
+        } else if (SSL_CTX_set_default_verify_paths(ctx) != 1) {
+            merror("%s: ERROR: Unable to load default TLS CA paths for syslog_output.",
+                   ARGV0);
+            csyslog_tls_log_errors("default CA paths");
+            SSL_CTX_free(ctx);
+            return NULL;
+        }
+    } else {
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
+        verbose("%s: INFO: syslog_output TLS certificate verification disabled "
+                "(tls_verify=no).", ARGV0);
+    }
+
+    return ctx;
+}
+
+SSL *csyslog_tls_connect(SSL_CTX *ctx, int fd, const char *hostname, int verify)
+{
+    SSL *ssl;
+    int ret;
+    int is_ip;
+
+    if (!ctx || fd < 0) {
+        return NULL;
+    }
+
+    ssl = SSL_new(ctx);
+    if (!ssl) {
+        merror("%s: ERROR: SSL_new failed for syslog TLS.", ARGV0);
+        csyslog_tls_log_errors("SSL_new");
+        return NULL;
+    }
+
+    if (SSL_set_fd(ssl, fd) != 1) {
+        merror("%s: ERROR: SSL_set_fd failed for syslog TLS.", ARGV0);
+        SSL_free(ssl);
+        return NULL;
+    }
+
+    /* OS_IsValidIP == 1 means bare host address (not CIDR). Skip SNI for IPs. */
+    is_ip = (hostname && hostname[0] != '\0' &&
+             OS_IsValidIP(hostname, NULL) == 1) ? 1 : 0;
+
+    if (hostname && hostname[0] != '\0' && !is_ip) {
+#if OPENSSL_VERSION_NUMBER >= 0x0090806fL
+        if (SSL_set_tlsext_host_name(ssl, hostname) != 1) {
+            merror("%s: ERROR: Unable to set TLS SNI for '%s'.", ARGV0, hostname);
+            SSL_free(ssl);
+            return NULL;
+        }
+#endif
+    }
+
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+    if (verify && hostname && hostname[0] != '\0') {
+        X509_VERIFY_PARAM *param = SSL_get0_param(ssl);
+
+        if (param) {
+            X509_VERIFY_PARAM_set_hostflags(param, 0);
+            if (is_ip) {
+                if (X509_VERIFY_PARAM_set1_ip_asc(param, hostname) != 1) {
+                    merror("%s: ERROR: Unable to set TLS IP check for '%s'.",
+                           ARGV0, hostname);
+                    SSL_free(ssl);
+                    return NULL;
+                }
+            } else if (X509_VERIFY_PARAM_set1_host(param, hostname, 0) != 1) {
+                merror("%s: ERROR: Unable to set TLS hostname check for '%s'.",
+                       ARGV0, hostname);
+                SSL_free(ssl);
+                return NULL;
+            }
+        }
+    }
+#else
+    /* Hostname/IP identity checks need OpenSSL 1.0.2+. Fail closed when
+     * tls_verify=yes rather than accepting any peer name. */
+    if (verify) {
+        merror("%s: ERROR: syslog_output tls_verify=yes requires OpenSSL 1.0.2+ "
+               "for hostname/IP certificate checks.", ARGV0);
+        SSL_free(ssl);
+        return NULL;
+    }
+    (void)is_ip;
+#endif
+
+    ret = SSL_connect(ssl);
+    if (ret != 1) {
+        merror("%s: ERROR: SSL_connect failed for syslog TLS to '%s' (ret=%d).",
+               ARGV0, hostname ? hostname : "?", ret);
+        csyslog_tls_log_errors("SSL_connect");
+        SSL_free(ssl);
+        return NULL;
+    }
+
+    if (verify) {
+        long vr = SSL_get_verify_result(ssl);
+        if (vr != X509_V_OK) {
+            merror("%s: ERROR: syslog TLS peer verification failed: %s",
+                   ARGV0, X509_verify_cert_error_string(vr));
+            SSL_free(ssl);
+            return NULL;
+        }
+    }
+
+    return ssl;
+}
+
+int csyslog_tls_write(SSL *ssl, const char *buf, size_t len)
+{
+    size_t off = 0;
+    int spins = 0;
+    int fd;
+
+    if (!ssl || !buf) {
+        return -1;
+    }
+
+    fd = SSL_get_fd(ssl);
+
+    while (off < len) {
+        int n = SSL_write(ssl, buf + off, (int)(len - off));
+        if (n <= 0) {
+            int err = SSL_get_error(ssl, n);
+            if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+                if (++spins > CSYSLOG_TLS_WRITE_MAX_SPIN) {
+                    return -1;
+                }
+                if (fd >= 0) {
+                    struct pollfd pfd;
+
+                    pfd.fd = fd;
+                    pfd.events = (err == SSL_ERROR_WANT_READ) ? POLLIN : POLLOUT;
+                    pfd.revents = 0;
+                    if (poll(&pfd, 1, CSYSLOG_TLS_WRITE_WAIT_MS) <= 0) {
+                        return -1;
+                    }
+                }
+                continue;
+            }
+            return -1;
+        }
+        spins = 0;
+        off += (size_t)n;
+    }
+
+    return 0;
+}
+
+void csyslog_tls_close(SSL **ssl)
+{
+    if (!ssl || !*ssl) {
+        return;
+    }
+    /* Avoid blocking bidirectional shutdown on a dead peer. */
+    SSL_set_quiet_shutdown(*ssl, 1);
+    SSL_shutdown(*ssl);
+    SSL_free(*ssl);
+    *ssl = NULL;
+}
+
+void csyslog_tls_ctx_free(SSL_CTX **ctx)
+{
+    if (!ctx || !*ctx) {
+        return;
+    }
+    SSL_CTX_free(*ctx);
+    *ctx = NULL;
+}
+
+#endif /* LIBOPENSSL_ENABLED */

--- a/src/os_csyslogd/csyslog_tls.c
+++ b/src/os_csyslogd/csyslog_tls.c
@@ -19,7 +19,8 @@
 #include <poll.h>
 
 #ifndef CSYSLOG_TLS_WRITE_MAX_SPIN
-#define CSYSLOG_TLS_WRITE_MAX_SPIN 10000
+/* Cap total WANT_* waits (~10s) to match socket send/recv timeouts. */
+#define CSYSLOG_TLS_WRITE_MAX_SPIN 10
 #endif
 
 #ifndef CSYSLOG_TLS_WRITE_WAIT_MS

--- a/src/os_csyslogd/csyslog_tls.h
+++ b/src/os_csyslogd/csyslog_tls.h
@@ -1,0 +1,37 @@
+/* Copyright (C) 2026 Atomicorp LLC
+ * All rights reserved.
+ *
+ * This program is a free software; you can redistribute it
+ * and/or modify it under the terms of the GNU General Public
+ * License (version 2) as published by the FSF - Free Software
+ * Foundation.
+ */
+
+#ifndef CSYSLOG_TLS_H
+#define CSYSLOG_TLS_H
+
+#include "config/csyslogd-config.h"
+
+#ifdef LIBOPENSSL_ENABLED
+
+#include <openssl/ssl.h>
+
+/* Create a client SSL_CTX. verify=1 enables peer verification.
+ * ca_path may be NULL to use the default system trust store.
+ */
+SSL_CTX *csyslog_tls_ctx_create(int verify, const char *ca_path);
+
+/* Perform TLS handshake on an already-connected TCP fd.
+ * hostname is used for SNI and (when verify) hostname checks.
+ */
+SSL *csyslog_tls_connect(SSL_CTX *ctx, int fd, const char *hostname, int verify);
+
+/* Write len bytes; handles partial SSL_write. Returns 0 on success, -1 on error. */
+int csyslog_tls_write(SSL *ssl, const char *buf, size_t len);
+
+void csyslog_tls_close(SSL **ssl);
+void csyslog_tls_ctx_free(SSL_CTX **ctx);
+
+#endif /* LIBOPENSSL_ENABLED */
+
+#endif /* CSYSLOG_TLS_H */

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -73,12 +73,23 @@ void OS_CSyslogD(SyslogConfig **syslog_config)
 /* Format Field for output */
 int field_add_string(char *dest, size_t size, const char *format, const char *value )
 {
-    char buffer[OS_SIZE_2048];
+    char buffer[OS_CSYSLOG_MAX];
     int len = 0;
-    int dest_sz = size - strlen(dest);
+    size_t dest_len;
+    size_t dest_sz;
+    size_t lim;
 
-    /* Not enough room in the buffer? */
-    if (dest_sz <= 0 ) {
+    if (!dest || size == 0) {
+        return -1;
+    }
+
+    dest_len = strlen(dest);
+    if (dest_len >= size) {
+        return -1;
+    }
+
+    dest_sz = size - dest_len;
+    if (dest_sz <= 1) {
         return -1;
     }
 
@@ -89,8 +100,12 @@ int field_add_string(char *dest, size_t size, const char *format, const char *va
                 ((value[0] != 'u') && (value[1] != 'n') && (value[4] != 'k'))
             )
        ) {
-        len = snprintf(buffer, sizeof(buffer) - dest_sz - 1, format, value);
-        strncat(dest, buffer, dest_sz);
+        lim = sizeof(buffer);
+        if (lim > dest_sz) {
+            lim = dest_sz;
+        }
+        len = snprintf(buffer, lim, format, value);
+        strncat(dest, buffer, dest_sz - 1);
     }
 
     return len;
@@ -99,20 +114,35 @@ int field_add_string(char *dest, size_t size, const char *format, const char *va
 /* Add a field, but truncate if too long */
 int field_add_truncated(char *dest, size_t size, const char *format, const char *value, int fmt_size )
 {
-    char buffer[OS_SIZE_2048];
-
-    int available_sz = size - strlen(dest);
-    int total_sz = strlen(value) + strlen(format) - fmt_size;
-    int field_sz = available_sz - strlen(format) + fmt_size;
-
+    char buffer[OS_CSYSLOG_MAX];
+    size_t dest_len;
+    size_t available_sz;
+    size_t total_sz;
+    size_t field_sz;
+    size_t lim;
     int len = 0;
     char trailer[] = "...";
     char *truncated = NULL;
 
-    /* Not enough room in the buffer? */
-    if (available_sz <= 0 ) {
+    if (!dest || !value || size == 0) {
         return -1;
     }
+
+    dest_len = strlen(dest);
+    if (dest_len >= size) {
+        return -1;
+    }
+
+    available_sz = size - dest_len;
+    if (available_sz <= 1) {
+        return -1;
+    }
+
+    total_sz = strlen(value) + strlen(format) - fmt_size;
+    if (available_sz <= strlen(format) - fmt_size) {
+        return -1;
+    }
+    field_sz = available_sz - strlen(format) + fmt_size;
 
     if (
         ((value[0] != '(') && (value[1] != 'n') && (value[2] != 'o')) ||
@@ -127,10 +157,15 @@ int field_add_truncated(char *dest, size_t size, const char *format, const char 
                 strcat(truncated, trailer);
             } else {
                 strncpy(truncated, value, field_sz);
+                truncated[field_sz] = '\0';
             }
 
-            len = snprintf(buffer, available_sz, format, truncated);
-            strncat(dest, buffer, available_sz);
+            lim = sizeof(buffer);
+            if (lim > available_sz) {
+                lim = available_sz;
+            }
+            len = snprintf(buffer, lim, format, truncated);
+            strncat(dest, buffer, available_sz - 1);
         } else {
             /* Memory Error */
             len = -3;

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -138,11 +138,19 @@ int field_add_truncated(char *dest, size_t size, const char *format, const char 
         return -1;
     }
 
-    total_sz = strlen(value) + strlen(format) - fmt_size;
-    if (available_sz <= strlen(format) - fmt_size) {
-        return -1;
+    total_sz = strlen(value);
+    {
+        size_t fmt_len = strlen(format);
+
+        if (fmt_size < 0 || (size_t)fmt_size > fmt_len) {
+            return -1;
+        }
+        total_sz += fmt_len - (size_t)fmt_size;
+        if (available_sz <= fmt_len - (size_t)fmt_size) {
+            return -1;
+        }
+        field_sz = available_sz - fmt_len + (size_t)fmt_size;
     }
-    field_sz = available_sz - strlen(format) + fmt_size;
 
     if (
         ((value[0] != '(') && (value[1] != 'n') && (value[2] != 'o')) ||

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -152,8 +152,15 @@ int field_add_truncated(char *dest, size_t size, const char *format, const char 
 
         if ( (truncated = (char *) malloc(field_sz + 1)) != NULL ) {
             if ( total_sz > available_sz ) {
-                /* Truncate and add a trailer */
-                os_substr(truncated, value, 0, field_sz - strlen(trailer));
+                size_t trailer_len = strlen(trailer);
+
+                /* field_sz is size_t; subtracting trailer_len without a
+                 * guard underflows and lets os_substr overrun truncated. */
+                if (field_sz <= trailer_len) {
+                    free(truncated);
+                    return -1;
+                }
+                os_substr(truncated, value, 0, field_sz - trailer_len);
                 strcat(truncated, trailer);
             } else {
                 strncpy(truncated, value, field_sz);

--- a/src/os_csyslogd/csyslogd.h
+++ b/src/os_csyslogd/csyslogd.h
@@ -14,6 +14,9 @@
 
 #define OS_CSYSLOGD_MAX_TRIES 10
 
+/* Outbound syslog/CEF/JSON alert size (matches OS_MAXSTR elsewhere). */
+#define OS_CSYSLOG_MAX OS_MAXSTR
+
 /** Prototypes **/
 
 /* Read syslog config */

--- a/src/os_csyslogd/csyslogd.h
+++ b/src/os_csyslogd/csyslogd.h
@@ -23,7 +23,12 @@
 SyslogConfig **OS_ReadSyslogConf(int test_config, const char *cfgfile);
 
 /* Send alerts via syslog */
-int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config);
+int OS_Alert_SendSyslog(alert_data *al_data, SyslogConfig *syslog_config);
+
+/* Connect / send / close transport for one syslog_output destination */
+int csyslog_connect(SyslogConfig *cfg);
+int csyslog_send(SyslogConfig *cfg, const char *msg, size_t len);
+void csyslog_close(SyslogConfig *cfg);
 
 /* Database inserting main function */
 void OS_CSyslogD(SyslogConfig **syslog_config) __attribute__((noreturn));

--- a/src/os_csyslogd/main.c
+++ b/src/os_csyslogd/main.c
@@ -183,20 +183,24 @@ int main(int argc, char **argv)
         exit(0);
     }
 
-    /* Connect before chroot: DNS works here and OS_ConnectUDP can walk the
-     * full addrinfo list (IPv6 then IPv4 fallback). FDs survive chroot. */
+    /* Connect before chroot: DNS works here and OS_Connect* can walk the
+     * full addrinfo list (IPv6 then IPv4 fallback). FDs survive chroot.
+     * TLS loads CA paths here before the chroot jail. */
     {
         unsigned int s = 0;
 
         while (syslog_config[s]) {
-            syslog_config[s]->socket = OS_ConnectUDP(syslog_config[s]->port,
-                                                     syslog_config[s]->server);
-            if (syslog_config[s]->socket < 0) {
+            const char *proto = (syslog_config[s]->protocol == CSYSLOG_TCP) ?
+                                "tcp" : "udp";
+            const char *tls = syslog_config[s]->tls ? "+tls" : "";
+
+            if (csyslog_connect(syslog_config[s]) < 0) {
                 merror(CONNS_ERROR, ARGV0, syslog_config[s]->server);
             } else {
                 /* Use merror for visibility at default log level (historical). */
-                merror("%s: INFO: Forwarding alerts via syslog to: '%s:%s'.",
-                       ARGV0, syslog_config[s]->server, syslog_config[s]->port);
+                merror("%s: INFO: Forwarding alerts via syslog (%s%s) to: '%s:%s'.",
+                       ARGV0, proto, tls,
+                       syslog_config[s]->server, syslog_config[s]->port);
             }
             s++;
         }

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -1,0 +1,86 @@
+# OSSEC test suite
+
+**Engine roadmap:** [`analysisd-detection-improvement-plan.md`](analysisd-detection-improvement-plan.md) — sequential detection improvement plan for `analysisd` (planning; not yet implemented).
+
+Run build tests in Podman (no host installs). From the **repo root**:
+
+```bash
+./testsuite/build-test/build.sh           # all distros
+./testsuite/build-test/build.sh fedora-43  # single distro
+```
+
+By default, `build.sh` and `build-deb.sh` use `PODMAN_PLATFORM=linux/amd64` so images and compiles target x86_64 (override with e.g. `PODMAN_PLATFORM=linux/arm64` if needed).
+
+With no argument, loops over every distro in `testsuite/build-test/` (centos-7, debian-13, fedora-43/44, rockylinux-8/9/10, ubuntu-20.04/24.04/26.04, windows-cross). For each distro it builds the container image from that distro’s `Containerfile`, then:
+
+1. **Agent build** with `USE_AUDIT=yes` (FIM auditd code path + adapter)
+2. **Server build** with the same flags (full server target still includes syscheckd)
+
+Optional post-agent check (off by default): set `TEST=1` to run **`verify-syscheck-audit.sh`**, which confirms `ossec-syscheckd` links audit symbols (`audit_init`, `fim_audit_event`):
+
+```bash
+TEST=1 ./testsuite/build-test/build.sh fedora-43
+```
+
+Goal: confirm agents/servers **build** with audit enabled and system **libaudit** / **libbpf** headers installed. eBPF BPF `.o` objects are built only when the container has `bpftool`, `clang`, and kernel BTF (`smoke_bpf_build.sh` skips otherwise).
+
+### Linux container dependencies (audit FIM)
+
+| Family | Packages added to `Containerfile` |
+|--------|-----------------------------------|
+| Fedora / Rocky | `audit-libs-devel`, `libbpf-devel`, `clang`, `llvm`, `bpftool`, `pkgconfig` |
+| CentOS 7 | `audit-libs-devel` only (no libbpf toolchain) |
+| Debian | `libaudit-dev`, `libbpf-dev`, `clang`, `llvm`, `bpftool`, `pkg-config` |
+| Ubuntu | `libaudit-dev`, `libbpf-dev`, `clang`, `llvm`, `linux-tools-common` (provides `bpftool`), `pkg-config` |
+
+Make flags in CI containers: `USE_AUDIT=yes USE_CURL=yes USE_MAGIC=no`.
+
+**Source RPM** (from repo root):
+
+```bash
+./testsuite/build-srpm.sh
+```
+
+Builds a `.src.rpm` only: creates the source tarball with `git archive`, runs `rpmbuild -bs`. Output goes to `testsuite/` (or set `OUT_DIR`). Requires `rpmbuild` and `git`. Then test the spec ad hoc with mock or rpmbuild:
+
+```bash
+mock -r fedora-43-x86_64 rebuild testsuite/ossec-hids-*.src.rpm
+# or
+rpmbuild --rebuild testsuite/ossec-hids-*.src.rpm
+```
+
+The tree must have the packaging files in `contrib/specs/` (e.g. `filter-requires.sh`, `ossec-hids-hybrid.conf`, `ossec-hids.logrotate`, `ossec-authd`) for a full rebuild to succeed.
+
+**Debian packages** (from repo root, uses Podman):
+
+```bash
+./testsuite/build-deb.sh                    # build ossec-hids-agent .deb (default)
+./testsuite/build-deb.sh ossec-hids        # build server .deb
+./testsuite/build-deb.sh all                # build both agent and server
+```
+
+Builds in an `ubuntu:24.04` (noble) container (set `DEB_DIST` or `DEB_IMAGE` to use another suite/image, e.g. `DEB_DIST=bookworm DEB_IMAGE=docker.io/library/debian:bookworm ./testsuite/build-deb.sh`). Output: `.deb`, `.changes`, and `.buildinfo` in `testsuite/` (or set `OUT_DIR`). Requires `podman`. Debian build deps include `libaudit-dev` and `libbpf-dev` for FIM audit support.
+
+### Manual verify (on a built tree)
+
+From `src/` after `make TARGET=agent USE_AUDIT=yes`:
+
+```bash
+../testsuite/build-test/verify-syscheck-audit.sh .
+syscheckd/ebpf/smoke_bpf_build.sh   # optional; needs BTF on host
+```
+
+### Unit / regression tests (host, after build)
+
+From `src/` after `make TARGET=server` (or `hybrid`):
+
+```bash
+make regression                 # shared/tests + analysisd regressions
+make -C shared/tests check      # queue_op / thread_pool / helpers only
+make -f tests/regressions/Makefile check
+```
+
+`make regression` covers EventList sharding, frequency `last_events` ownership,
+sid-list overflow free-safety, auth IPv6 key handling, and `os_queue` timedwait
+(used by the always-on analysisd pipeline). See
+[`src/tests/regressions/README.md`](../src/tests/regressions/README.md).

--- a/testsuite/build-deb.sh
+++ b/testsuite/build-deb.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Build Debian packages for ossec-hids in a Podman container (like build-srpm.sh for RPM).
+# Run from repo root: ./testsuite/build-deb.sh [ossec-hids-agent|ossec-hids|all]
+# Default: ossec-hids-agent. Output: testsuite/*.deb (and .changes, .buildinfo).
+# Requires: podman. Uses ubuntu:24.04 (noble) by default (set DEB_DIST to override).
+set -e -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+PACKAGE="${1:-ossec-hids-agent}"
+VERSION="${VERSION:-4.0.0}"
+DEB_DIST="${DEB_DIST:-noble}"
+DEB_IMAGE="${DEB_IMAGE:-docker.io/library/ubuntu:24.04}"
+PODMAN_PLATFORM="${PODMAN_PLATFORM:-linux/amd64}"
+NAME="ossec-hids"
+OUT_DIR="${OUT_DIR:-$SCRIPT_DIR}"
+
+if ! command -v podman &>/dev/null; then
+    echo "Error: podman is required." >&2
+    exit 1
+fi
+
+if [[ ! -d "$ROOT_DIR/contrib/debian-packages" ]] || [[ ! -d "$ROOT_DIR/src" ]]; then
+    echo "Error: Expected repo root with contrib/debian-packages/ and src/." >&2
+    exit 1
+fi
+
+if [[ "$PACKAGE" != "ossec-hids-agent" && "$PACKAGE" != "ossec-hids" && "$PACKAGE" != "all" ]]; then
+    echo "Usage: $0 [ossec-hids-agent|ossec-hids|all]" >&2
+    exit 1
+fi
+
+# Read version from spec if present
+if [[ -f "$ROOT_DIR/ossec-hids.spec" ]]; then
+    SPEC_VER=$(sed -n 's/^Version:[[:space:]]*//p' "$ROOT_DIR/ossec-hids.spec" | head -1)
+    [[ -n "$SPEC_VER" ]] && VERSION="$SPEC_VER"
+fi
+
+mkdir -p "$OUT_DIR"
+TARBALL="${NAME}-${VERSION}.tar.gz"
+
+echo "Building Debian package(s) for $NAME $VERSION (dist: $DEB_DIST)"
+echo "Package(s): $PACKAGE"
+echo "Root: $ROOT_DIR"
+
+# Build in container: create tarball from repo, then build .deb
+podman run --rm --platform "$PODMAN_PLATFORM" \
+    -v "$ROOT_DIR:/source:ro" \
+    -v "$OUT_DIR:/output:rw" \
+    -e PACKAGE="$PACKAGE" \
+    -e VERSION="$VERSION" \
+    -e NAME="$NAME" \
+    -e DEB_DIST="$DEB_DIST" \
+    "$DEB_IMAGE" \
+    bash -c '
+        set -e
+        TARBALL="${NAME}-${VERSION}.tar.gz"
+        apt-get -qq update
+        apt-get -qq install -y build-essential devscripts debhelper libssl-dev linux-libc-dev \
+            libpcre2-dev libevent-dev zlib1g-dev libsystemd-dev libmagic-dev \
+            libaudit-dev libbpf-dev clang llvm linux-tools-common pkg-config patch
+        cd /tmp
+        mkdir -p work && cd work
+        # Tarball from repo (same layout as build-srpm: prefix name-version)
+        tar -czf "$TARBALL" -C /source --exclude=.git --exclude="$TARBALL" \
+            --transform "s,^\./,$NAME-$VERSION/," .
+        build_one() {
+            local pkg="$1"
+            local dir="${pkg}-${VERSION}"
+            rm -rf "$dir" "${pkg}_${VERSION}.orig.tar.gz"
+            tar -xzf "$TARBALL"
+            mv "$NAME-$VERSION" "$dir"
+            cp -r "/source/contrib/debian-packages/$pkg/debian" "$dir/"
+            # Apply patches in series order
+            if [[ -f "$dir/debian/patches/series" ]]; then
+                while read -r patch; do
+                    [[ -z "$patch" || "$patch" =~ ^# ]] && continue
+                    patch -d "$dir" -p1 < "$dir/debian/patches/$patch" || true
+                done < "$dir/debian/patches/series"
+            fi
+            tar -czf "${pkg}_${VERSION}.orig.tar.gz" "$dir"
+            cd "$dir"
+            dpkg-buildpackage -b -us -uc -d
+            cd ..
+            mv ${pkg}_*.deb ${pkg}_*.changes ${pkg}_*.buildinfo /output/ 2>/dev/null || true
+        }
+        if [[ "$PACKAGE" == "all" ]]; then
+            build_one ossec-hids-agent
+            build_one ossec-hids
+        else
+            build_one "$PACKAGE"
+        fi
+    '
+
+echo "SUCCESS: .deb (and .changes, .buildinfo) written to $OUT_DIR/"
+ls -la "$OUT_DIR"/*.deb "$OUT_DIR"/*.changes 2>/dev/null || true
+ls -la "$OUT_DIR"/*.buildinfo 2>/dev/null || true

--- a/testsuite/build-srpm.sh
+++ b/testsuite/build-srpm.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Generate a source RPM (.src.rpm) for ossec-hids. You can then test with:
+#   mock -r fedora-43-x86_64 rebuild ossec-hids-*.src.rpm
+#   rpmbuild --rebuild ossec-hids-*.src.rpm
+# Run from repo root: ./testsuite/build-srpm.sh
+# Requires: rpmbuild. The spec expects only Source0 (tarball); the tarball
+# is created from the current tree (tar from disk), so untracked files are included.
+# If rpmbuild fails with "Illegal char '-'" in Release, some rpm versions reject
+# hyphens in the Release tag; use a numeric release in the spec for local builds.
+set -e -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if ! command -v rpmbuild &>/dev/null; then
+    echo "Error: rpmbuild is required (e.g. rpm-build package)." >&2
+    exit 1
+fi
+
+if [[ ! -f "$ROOT_DIR/ossec-hids.spec" ]]; then
+    echo "Error: ossec-hids.spec not found at $ROOT_DIR" >&2
+    exit 1
+fi
+
+if [[ ! -d "$ROOT_DIR/src" ]] || [[ ! -f "$ROOT_DIR/ossec-hids.spec" ]]; then
+    echo "Error: Expected repo root with src/ and ossec-hids.spec." >&2
+    exit 1
+fi
+
+VERSION=$(sed -n 's/^Version:[[:space:]]*//p' "$ROOT_DIR/ossec-hids.spec" | head -1)
+NAME="ossec-hids"
+TARBALL="${NAME}-${VERSION}.tar.gz"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Error: Could not read Version from ossec-hids.spec" >&2
+    exit 1
+fi
+
+OUT_DIR="${OUT_DIR:-$SCRIPT_DIR}"
+mkdir -p "$OUT_DIR"
+
+# Use a temp dir for SPECS/SOURCES/SRPMS so we don't clutter the repo
+TOP=$(mktemp -d)
+trap "rm -rf '$TOP'" EXIT
+mkdir -p "$TOP"/{SPECS,SOURCES,SRPMS}
+
+echo "Building source RPM for $NAME $VERSION"
+echo "Root: $ROOT_DIR"
+
+cd "$ROOT_DIR"
+# Tarball from current tree (includes untracked files), same layout as git archive
+tar -czf "$TOP/SOURCES/$TARBALL" --exclude='.git' --exclude="$TARBALL" \
+    --transform "s,^\./,$NAME-$VERSION/," .
+cp ossec-hids.spec "$TOP/SPECS/"
+
+rpmbuild -bs \
+    --define "_topdir $TOP" \
+    "$TOP/SPECS/ossec-hids.spec"
+
+SRPM=$(echo "$TOP/SRPMS/"*.src.rpm)
+if [[ ! -f "$SRPM" ]]; then
+    echo "Error: No .src.rpm was produced." >&2
+    exit 1
+fi
+
+cp "$SRPM" "$OUT_DIR/"
+echo "SUCCESS: source RPM written to $OUT_DIR/$(basename "$SRPM")"
+echo "Test with: mock -r <config> rebuild $OUT_DIR/$(basename "$SRPM")"
+echo "       or: rpmbuild --rebuild $OUT_DIR/$(basename "$SRPM")"

--- a/testsuite/build-test/build-linux.sh
+++ b/testsuite/build-test/build-linux.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Invoked inside the build container (cwd = repo src/). Keep POSIX sh for /bin/sh.
+set -eu
+
+MAKE_TARGET="${MAKE_TARGET:-server}"
+MAKE_OPTS="${MAKE_OPTS:-USE_AUDIT=yes USE_CURL=yes USE_MAGIC=no}"
+
+echo "== make clean =="
+make clean
+
+echo "== make TARGET=${MAKE_TARGET} ${MAKE_OPTS} =="
+# shellcheck disable=SC2086
+make TARGET="${MAKE_TARGET}" ${MAKE_OPTS} -j"$(nproc 2>/dev/null || echo 2)"
+
+if [ "${TEST:-}" = "1" ]; then
+    echo "== verify syscheck audit =="
+    chmod +x ../testsuite/build-test/verify-syscheck-audit.sh
+    ../testsuite/build-test/verify-syscheck-audit.sh .
+else
+    echo "== skip syscheck audit verify (set TEST=1 to enable) =="
+fi

--- a/testsuite/build-test/build.sh
+++ b/testsuite/build-test/build.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -u
+
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$BASE_DIR")")"
+PODMAN_PLATFORM="${PODMAN_PLATFORM:-linux/amd64}"
+TEST="${TEST:-}"
+FAILURES=0
+
+echo "Starting build test suite..."
+echo "Root Dir: $ROOT_DIR"
+
+# Ensure we have podman
+if ! command -v podman &> /dev/null; then
+    echo "Error: podman could not be found."
+    exit 1
+fi
+
+# Optional: run a single distro (e.g. ./build.sh centos-7)
+if [[ -n "${1:-}" ]]; then
+    single_dir="$BASE_DIR/$1"
+    if [[ ! -d "$single_dir" ]]; then
+        echo "Error: distro '$1' not found (expected a directory under $(basename "$BASE_DIR")/)." >&2
+        exit 1
+    fi
+    DISTRO_DIRS=("$single_dir")
+else
+    DISTRO_DIRS=("$BASE_DIR"/*/)
+fi
+
+for distro_dir in "${DISTRO_DIRS[@]}"; do
+    # Remove trailing slash
+    distro_dir="${distro_dir%/}"
+    distro_name=$(basename "$distro_dir")
+    
+    # Skip non-directories or hidden files just in case
+    if [[ ! -d "$distro_dir" ]]; then continue; fi
+
+    echo "------------------------------------------------"
+    echo "Testing build for: $distro_name"
+    
+    # Sanitize image name
+    image_name="build-test-${distro_name//./-}"
+    
+    echo "Building container image: $image_name"
+    if ! podman build --platform "$PODMAN_PLATFORM" -t "$image_name" "$distro_dir"; then
+        echo "FAILED: Container build for $distro_name failed."
+        ((FAILURES++))
+        continue
+    fi
+    
+    echo "Running compilation on $distro_name..."
+    # We run make clean first to ensure a fresh build, then build server target.
+    # Using -v with :Z to handle SELinux if present.
+    # cd src is required because the Makefile is in src/
+    
+    BUILD_TARGET="server"
+    if [ "$distro_name" == "windows-cross" ]; then
+        echo "Building Windows agent (Cross-compiling)..."
+        # Download missing PCRE2 source for Windows build
+        if ! podman run --rm --platform "$PODMAN_PLATFORM" -v "$ROOT_DIR:/src_origin:Z" "$image_name" /bin/sh -c "
+            mkdir -p /src && cp -r /src_origin/* /src/ && \
+            cd /src/src/external && \
+            wget -q https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.32/pcre2-10.32.tar.gz && \
+            tar xzf pcre2-10.32.tar.gz && \
+            cd /src/src && \
+            make clean && \
+            make TARGET=winagent -j$(nproc)"; then
+            
+            echo "FAILED: Compilation for $distro_name failed."
+            ((FAILURES++))
+        else
+            echo "SUCCESS: $distro_name passed."
+        fi
+        continue
+    fi
+
+    # Agent build exercises syscheckd with USE_AUDIT (auditd + optional eBPF).
+    MAKE_OPTS="USE_AUDIT=yes USE_CURL=yes"
+    case "$distro_name" in
+        debian-13)
+            # Container lacks libmagic; avoid USE_MAGIC=yes default on Linux.
+            MAKE_OPTS="$MAKE_OPTS USE_MAGIC=no"
+            ;;
+        *)
+            MAKE_OPTS="$MAKE_OPTS USE_MAGIC=no"
+            ;;
+    esac
+
+    if ! podman run --rm --platform "$PODMAN_PLATFORM" \
+        -v "$ROOT_DIR:/src:Z" \
+        -e MAKE_TARGET=agent \
+        -e MAKE_OPTS="$MAKE_OPTS" \
+        -e TEST="$TEST" \
+        "$image_name" \
+        /bin/sh -c "cd /src/src && chmod +x ../testsuite/build-test/build-linux.sh && ../testsuite/build-test/build-linux.sh"; then
+        echo "FAILED: Agent compilation for $distro_name failed."
+        ((FAILURES++))
+        continue
+    fi
+
+    echo "Running server build on $distro_name..."
+    if ! podman run --rm --platform "$PODMAN_PLATFORM" \
+        -v "$ROOT_DIR:/src:Z" \
+        -e MAKE_TARGET=server \
+        -e MAKE_OPTS="$MAKE_OPTS" \
+        "$image_name" \
+        /bin/sh -c "cd /src/src && make clean && make TARGET=server ${MAKE_OPTS} -j\$(nproc 2>/dev/null || echo 2)"; then
+        echo "FAILED: Server compilation for $distro_name failed."
+        ((FAILURES++))
+    else
+        echo "SUCCESS: $distro_name passed (agent, server)."
+    fi
+done
+
+if [ "$FAILURES" -eq 0 ]; then
+    echo "------------------------------------------------"
+    echo "All tests passed successfully!"
+    exit 0
+else
+    echo "------------------------------------------------"
+    echo "$FAILURES tests failed."
+    exit 1
+fi

--- a/testsuite/build-test/centos-7/Containerfile
+++ b/testsuite/build-test/centos-7/Containerfile
@@ -1,0 +1,23 @@
+FROM centos:7
+
+# Fix EOL repositories
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+RUN yum -y install epel-release && \
+    yum -y update && \
+    yum -y install \
+    gcc \
+    make \
+    openssl-devel \
+    pcre2-devel \
+    zlib-devel \
+    systemd-devel \
+    file-devel \
+    libcurl-devel \
+    audit-libs-devel \
+    findutils \
+    && \
+    yum clean all
+
+WORKDIR /src

--- a/testsuite/build-test/debian-13/Containerfile
+++ b/testsuite/build-test/debian-13/Containerfile
@@ -1,0 +1,23 @@
+FROM debian:trixie
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    libssl-dev \
+    libpcre2-dev \
+    zlib1g-dev \
+    libsystemd-dev \
+    libmagic-dev \
+    libcurl4-openssl-dev \
+    libaudit-dev \
+    libbpf-dev \
+    clang \
+    llvm \
+    bpftool \
+    pkg-config \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src

--- a/testsuite/build-test/fedora-43/Containerfile
+++ b/testsuite/build-test/fedora-43/Containerfile
@@ -1,0 +1,24 @@
+FROM fedora:43
+
+RUN dnf -y update && \
+    dnf -y install \
+    gcc \
+    make \
+    openssl-devel \
+    pcre2-devel \
+    zlib-devel \
+    systemd-devel \
+    file-devel \
+    libcurl-devel \
+    audit-libs-devel \
+    libbpf-devel \
+    clang \
+    llvm \
+    bpftool \
+    pkgconf-pkg-config \
+    findutils \
+    which \
+    && \
+    dnf clean all
+
+WORKDIR /src

--- a/testsuite/build-test/fedora-44/Containerfile
+++ b/testsuite/build-test/fedora-44/Containerfile
@@ -1,0 +1,24 @@
+FROM fedora:44
+
+RUN dnf -y update && \
+    dnf -y install \
+    gcc \
+    make \
+    openssl-devel \
+    pcre2-devel \
+    zlib-devel \
+    systemd-devel \
+    file-devel \
+    libcurl-devel \
+    audit-libs-devel \
+    libbpf-devel \
+    clang \
+    llvm \
+    bpftool \
+    pkgconf-pkg-config \
+    findutils \
+    which \
+    && \
+    dnf clean all
+
+WORKDIR /src

--- a/testsuite/build-test/rockylinux-10/Containerfile
+++ b/testsuite/build-test/rockylinux-10/Containerfile
@@ -1,0 +1,26 @@
+FROM rockylinux:10
+
+# file-devel (libmagic) is in the CRB repo on EL10
+RUN dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y update && \
+    dnf -y install \
+    gcc \
+    make \
+    openssl-devel \
+    pcre2-devel \
+    zlib-devel \
+    systemd-devel \
+    file-devel \
+    libcurl-devel \
+    audit-libs-devel \
+    libbpf-devel \
+    clang \
+    llvm \
+    bpftool \
+    pkgconfig \
+    findutils \
+    && \
+    dnf clean all
+
+WORKDIR /src

--- a/testsuite/build-test/rockylinux-8/Containerfile
+++ b/testsuite/build-test/rockylinux-8/Containerfile
@@ -1,0 +1,26 @@
+FROM rockylinux:8
+
+# file-devel (libmagic) is in the powertools repo on EL8
+RUN dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled powertools && \
+    dnf -y update && \
+    dnf -y install \
+    gcc \
+    make \
+    openssl-devel \
+    pcre2-devel \
+    zlib-devel \
+    systemd-devel \
+    file-devel \
+    libcurl-devel \
+    audit-libs-devel \
+    libbpf-devel \
+    clang \
+    llvm \
+    bpftool \
+    pkgconfig \
+    findutils \
+    && \
+    dnf clean all
+
+WORKDIR /src

--- a/testsuite/build-test/rockylinux-9/Containerfile
+++ b/testsuite/build-test/rockylinux-9/Containerfile
@@ -1,0 +1,26 @@
+FROM rockylinux:9
+
+# file-devel (libmagic) is in the CRB repo
+RUN dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y update && \
+    dnf -y install \
+    gcc \
+    make \
+    openssl-devel \
+    pcre2-devel \
+    zlib-devel \
+    systemd-devel \
+    file-devel \
+    libcurl-devel \
+    audit-libs-devel \
+    libbpf-devel \
+    clang \
+    llvm \
+    bpftool \
+    pkgconfig \
+    findutils \
+    && \
+    dnf clean all
+
+WORKDIR /src

--- a/testsuite/build-test/ubuntu-20.04/Containerfile
+++ b/testsuite/build-test/ubuntu-20.04/Containerfile
@@ -1,0 +1,23 @@
+FROM docker.io/library/ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    libssl-dev \
+    libpcre2-dev \
+    zlib1g-dev \
+    libsystemd-dev \
+    libmagic-dev \
+    libcurl4-openssl-dev \
+    libaudit-dev \
+    libbpf-dev \
+    clang \
+    llvm \
+    linux-tools-common \
+    pkg-config \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src

--- a/testsuite/build-test/ubuntu-24.04/Containerfile
+++ b/testsuite/build-test/ubuntu-24.04/Containerfile
@@ -1,0 +1,23 @@
+FROM docker.io/library/ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    libssl-dev \
+    libpcre2-dev \
+    zlib1g-dev \
+    libsystemd-dev \
+    libmagic-dev \
+    libcurl4-openssl-dev \
+    libaudit-dev \
+    libbpf-dev \
+    clang \
+    llvm \
+    linux-tools-common \
+    pkg-config \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src

--- a/testsuite/build-test/ubuntu-26.04/Containerfile
+++ b/testsuite/build-test/ubuntu-26.04/Containerfile
@@ -1,0 +1,23 @@
+FROM docker.io/library/ubuntu:26.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+    build-essential \
+    libssl-dev \
+    libpcre2-dev \
+    zlib1g-dev \
+    libsystemd-dev \
+    libmagic-dev \
+    libcurl4-openssl-dev \
+    libaudit-dev \
+    libbpf-dev \
+    clang \
+    llvm \
+    linux-tools-common \
+    pkg-config \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src

--- a/testsuite/build-test/verify-syscheck-audit.sh
+++ b/testsuite/build-test/verify-syscheck-audit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Post-build checks for FIM audit / optional eBPF (run inside container with cwd=src).
+set -euo pipefail
+
+SRC_DIR="${1:-.}"
+cd "$SRC_DIR"
+
+fail() { echo "VERIFY FAIL: $*" >&2; exit 1; }
+ok() { echo "VERIFY OK: $*"; }
+
+[[ -x ossec-syscheckd ]] || fail "ossec-syscheckd binary missing"
+
+if ! strings ossec-syscheckd | grep -q 'audit_init'; then
+    fail "ossec-syscheckd does not reference audit_init (ENABLE_AUDIT / audit objects?)"
+fi
+
+if strings ossec-syscheckd | grep -q 'fim_audit_event'; then
+    ok "audit adapter symbols present"
+else
+    fail "fim_audit_event not found in ossec-syscheckd"
+fi
+
+# Optional: BPF object build when host has BTF + toolchain (skipped in most containers).
+if [[ -x syscheckd/ebpf/smoke_bpf_build.sh ]]; then
+    if syscheckd/ebpf/smoke_bpf_build.sh; then
+        ok "eBPF smoke script passed or skipped cleanly"
+    else
+        fail "eBPF smoke script failed"
+    fi
+fi
+
+ok "syscheck audit build verification complete"

--- a/testsuite/build-test/windows-cross/Containerfile
+++ b/testsuite/build-test/windows-cross/Containerfile
@@ -1,0 +1,21 @@
+FROM fedora:40
+
+RUN dnf -y update && \
+    dnf -y install \
+    gcc \
+    make \
+    mingw32-gcc \
+    mingw32-binutils \
+    mingw32-nsis \
+    mingw32-pcre2 \
+    mingw32-zlib \
+    mingw32-openssl \
+    perl \
+    wget \
+    tar \
+    perl-Time-HiRes \
+    which \
+    && \
+    dnf clean all
+
+WORKDIR /src


### PR DESCRIPTION
- Raise `ossec-csyslogd` alert assemble buffer from 2048 to `OS_MAXSTR` (6144) so long CEF/JSON/syslog payloads are not cut mid-field (#1762).
- Add optional `protocol` (`udp`|`tcp`), `tls`, `tls_verify`, and `tls_ca` on each `<syslog_output>` destination.
- TCP uses RFC 6587 newline framing; TLS wraps TCP via OpenSSL (`LIBOPENSSL_ENABLED`) with peer/hostname (or IP) verification when `tls_verify=yes`.
- Reconnect once on send failure; set keepalive and send/recv timeouts so a wedged collector does not stall the single-threaded daemon.
- Docs companion: `atomicturtle:ossec-docs:docs/csyslog-tcp-tls`.
## Related
- Fixes / advances: #1762
- Related truncation: #473
- Context (already addressed / historical): #2272, #1744, #812, #1716, #1718