### PR TITLE
Raise csyslogd alert buffer to OS_MAXSTR for long CEF/syslog messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Work toward the next minor release after 4.2.0.
 
 **General**
 
+- @atomicturtle - Raise csyslogd syslog/CEF/JSON alert buffer from 2048 to OS_MAXSTR (#1762)
 - @atomicturtle - Add Asterisk IPv6 denied decoder so srcip omits square brackets (#1892)
 - @atomicturtle - Allow manage_agents ``-f -`` to bulk-load agents from stdin (#459)
 - @atomicturtle - Ignore deleted agents in list_agents/get_agents; fix OS_RemoveAgent agent-info cleanup (#244)

--- a/src/os_csyslogd/alert.c
+++ b/src/os_csyslogd/alert.c
@@ -112,7 +112,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
     char *logmsg = NULL;
     char *tstamp;
     char *hostname;
-    char syslog_msg[OS_SIZE_2048];
+    char syslog_msg[OS_CSYSLOG_MAX];
 
     /* Invalid socket */
     if (syslog_config->socket < 0) {
@@ -120,7 +120,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
     }
 
     /* Clear the memory before insert */
-    memset(syslog_msg, '\0', OS_SIZE_2048);
+    memset(syslog_msg, '\0', OS_CSYSLOG_MAX);
 
     /* Look if location is set */
     if (syslog_config->location) {
@@ -196,7 +196,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                     logmsg = os_LoadString(logmsg, "\n");
                 }
                 /* Save on memory and processing since it's going to get truncated anyway */
-                if (OS_SIZE_2048 <= strlen(logmsg)) {
+                if (OS_CSYSLOG_MAX <= strlen(logmsg)) {
                     break;
                 }
             }
@@ -206,35 +206,35 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
     /* Insert data */
     if (syslog_config->format == DEFAULT_CSYSLOG) {
         /* Build syslog message */
-        snprintf(syslog_msg, OS_SIZE_2048,
+        snprintf(syslog_msg, OS_CSYSLOG_MAX,
                  "<%u>%s %s ossec: Alert Level: %u; Rule: %u - %s; Location: %s;",
                  syslog_config->priority, tstamp, hostname,
                  al_data->level,
                  al_data->rule, al_data->comment,
                  al_data->location
                 );
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification: %s;", al_data->group);
-        field_add_string(syslog_msg, OS_SIZE_2048, " srcip: %s;", al_data->srcip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " classification: %s;", al_data->group);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " srcip: %s;", al_data->srcip);
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " srccity: %s;", al_data->srcgeoip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " dstcity: %s;", al_data->dstgeoip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " srccity: %s;", al_data->srcgeoip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dstcity: %s;", al_data->dstgeoip);
 #endif
-        field_add_string(syslog_msg, OS_SIZE_2048, " dstip: %s;", al_data->dstip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " user: %s;", al_data->user);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Previous MD5: %s;", al_data->old_md5);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Current MD5: %s;", al_data->new_md5);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Previous SHA1: %s;", al_data->old_sha1);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Current SHA1: %s;", al_data->new_sha1);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dstip: %s;", al_data->dstip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " user: %s;", al_data->user);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Previous MD5: %s;", al_data->old_md5);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Current MD5: %s;", al_data->new_md5);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Previous SHA1: %s;", al_data->old_sha1);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Current SHA1: %s;", al_data->new_sha1);
         /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-        field_add_string(syslog_msg, OS_SIZE_2048, " Size changed: from %s;", al_data->file_size);
-        field_add_string(syslog_msg, OS_SIZE_2048, " User ownership: was %s;", al_data->owner_chg);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Group ownership: was %s;", al_data->group_chg);
-        field_add_string(syslog_msg, OS_SIZE_2048, " Permissions changed: from %s;", al_data->perm_chg);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Size changed: from %s;", al_data->file_size);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " User ownership: was %s;", al_data->owner_chg);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Group ownership: was %s;", al_data->group_chg);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " Permissions changed: from %s;", al_data->perm_chg);
         /* "9/19/2016 - Sivakumar Nellurandi - parsing additions" */
-        field_add_truncated(syslog_msg, OS_SIZE_2048, " %s", logmsg, 2);
+        field_add_truncated(syslog_msg, OS_CSYSLOG_MAX, " %s", logmsg, 2);
     } else if (syslog_config->format == CEF_CSYSLOG) {
         /* Start with headers */
-        snprintf(syslog_msg, OS_SIZE_2048,
+        snprintf(syslog_msg, OS_CSYSLOG_MAX,
                  "<%u>%s CEF:0|%s|%s|%s|%u|%s|%u|",
                  syslog_config->priority,
                  tstamp,
@@ -245,29 +245,29 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                  cefescape(al_data->comment, true),
                  (al_data->level > 10) ? 10 : al_data->level);
         /* Add extensions */
-        field_add_string(syslog_msg, OS_SIZE_2048, "dvc=%s", cefescape(hostname, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs1Label=Location cs1=%s", cefescape(al_data->location, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification=%s", cefescape(al_data->group, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " src=%s", al_data->srcip);
-        field_add_int(syslog_msg, OS_SIZE_2048, " dpt=%d", al_data->dstport);
-        field_add_int(syslog_msg, OS_SIZE_2048, " spt=%d", al_data->srcport);
-        field_add_string(syslog_msg, OS_SIZE_2048, " fname=%s", cefescape(al_data->filename, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " dhost=%s", al_data->dstip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " shost=%s", al_data->srcip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " suser=%s", cefescape(al_data->user, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " dst=%s", cefescape(al_data->dstip, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, "dvc=%s", cefescape(hostname, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs1Label=Location cs1=%s", cefescape(al_data->location, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " classification=%s", cefescape(al_data->group, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " src=%s", al_data->srcip);
+        field_add_int(syslog_msg, OS_CSYSLOG_MAX, " dpt=%d", al_data->dstport);
+        field_add_int(syslog_msg, OS_CSYSLOG_MAX, " spt=%d", al_data->srcport);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " fname=%s", cefescape(al_data->filename, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dhost=%s", al_data->dstip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " shost=%s", al_data->srcip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " suser=%s", cefescape(al_data->user, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dst=%s", cefescape(al_data->dstip, false));
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs4Label=SrcCity cs4=%s", cefescape(al_data->srcgeoip, false));
-        field_add_string(syslog_msg, OS_SIZE_2048, " cs5Label=DstCity cs5=%s", cefescape(al_data->dstgeoip, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs4Label=SrcCity cs4=%s", cefescape(al_data->srcgeoip, false));
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs5Label=DstCity cs5=%s", cefescape(al_data->dstgeoip, false));
 #endif
         if (al_data->new_md5 && al_data->new_sha1) {
-            field_add_string(syslog_msg, OS_SIZE_2048, " cs2Label=OldMD5 cs2=%s", al_data->old_md5);
-            field_add_string(syslog_msg, OS_SIZE_2048, " cs3Label=NewMD5 cs3=%s", al_data->new_md5);
-            field_add_string(syslog_msg, OS_SIZE_2048, " oldFileHash=%s", al_data->old_sha1);
-            field_add_string(syslog_msg, OS_SIZE_2048, " fhash=%s", al_data->new_sha1);
-            field_add_string(syslog_msg, OS_SIZE_2048, " fileHash=%s", al_data->new_sha1);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs2Label=OldMD5 cs2=%s", al_data->old_md5);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " cs3Label=NewMD5 cs3=%s", al_data->new_md5);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " oldFileHash=%s", al_data->old_sha1);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " fhash=%s", al_data->new_sha1);
+            field_add_string(syslog_msg, OS_CSYSLOG_MAX, " fileHash=%s", al_data->new_sha1);
         }
-        field_add_truncated(syslog_msg, OS_SIZE_2048, " msg=%s", cefescape(logmsg, false), 2);
+        field_add_truncated(syslog_msg, OS_CSYSLOG_MAX, " msg=%s", cefescape(logmsg, false), 2);
         cefescape(NULL,0);  /* Clean up the escaping buffer */
     } else if (syslog_config->format == JSON_CSYSLOG) {
         /* Build a JSON Object for logging */
@@ -337,7 +337,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         json_string = cJSON_PrintUnformatted(root);
 
         /* Create the syslog message */
-        snprintf(syslog_msg, OS_SIZE_2048,
+        snprintf(syslog_msg, OS_CSYSLOG_MAX,
                  "<%u>%s %s ossec: %s",
 
                  /* syslog header */
@@ -351,7 +351,7 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
         cJSON_Delete(root);
     } else if (syslog_config->format == SPLUNK_CSYSLOG) {
         /* Build a Splunk Style Key/Value string for logging */
-        snprintf(syslog_msg, OS_SIZE_2048,
+        snprintf(syslog_msg, OS_CSYSLOG_MAX,
                  "<%u>%s %s ossec: crit=%u id=%u description=\"%s\" component=\"%s\",",
 
                  /* syslog header */
@@ -362,29 +362,29 @@ int OS_Alert_SendSyslog(alert_data *al_data, const SyslogConfig *syslog_config)
                  al_data->location
                 );
         /* Event specifics */
-        field_add_string(syslog_msg, OS_SIZE_2048, " classification=\"%s\",", al_data->group);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " classification=\"%s\",", al_data->group);
 
-        if (field_add_string(syslog_msg, OS_SIZE_2048, " src_ip=\"%s\",", al_data->srcip) > 0) {
-            field_add_int(syslog_msg, OS_SIZE_2048, " src_port=%d,", al_data->srcport);
+        if (field_add_string(syslog_msg, OS_CSYSLOG_MAX, " src_ip=\"%s\",", al_data->srcip) > 0) {
+            field_add_int(syslog_msg, OS_CSYSLOG_MAX, " src_port=%d,", al_data->srcport);
         }
 
 #ifdef LIBGEOIP_ENABLED
-        field_add_string(syslog_msg, OS_SIZE_2048, " src_city=\"%s\",", al_data->srcgeoip);
-        field_add_string(syslog_msg, OS_SIZE_2048, " dst_city=\"%s\",", al_data->dstgeoip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " src_city=\"%s\",", al_data->srcgeoip);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dst_city=\"%s\",", al_data->dstgeoip);
 #endif
 
-        if (field_add_string(syslog_msg, OS_SIZE_2048, " dst_ip=\"%s\",", al_data->dstip) > 0) {
-            field_add_int(syslog_msg, OS_SIZE_2048, " dst_port=%d,", al_data->dstport);
+        if (field_add_string(syslog_msg, OS_CSYSLOG_MAX, " dst_ip=\"%s\",", al_data->dstip) > 0) {
+            field_add_int(syslog_msg, OS_CSYSLOG_MAX, " dst_port=%d,", al_data->dstport);
         }
 
-        field_add_string(syslog_msg, OS_SIZE_2048, " file=\"%s\",", al_data->filename);
-        field_add_string(syslog_msg, OS_SIZE_2048, " acct=\"%s\",", al_data->user);
-        field_add_string(syslog_msg, OS_SIZE_2048, " md5_old=\"%s\",", al_data->old_md5);
-        field_add_string(syslog_msg, OS_SIZE_2048, " md5_new=\"%s\",", al_data->new_md5);
-        field_add_string(syslog_msg, OS_SIZE_2048, " sha1_old=\"%s\",", al_data->old_sha1);
-        field_add_string(syslog_msg, OS_SIZE_2048, " sha1_new=\"%s\",", al_data->new_sha1);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " file=\"%s\",", al_data->filename);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " acct=\"%s\",", al_data->user);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " md5_old=\"%s\",", al_data->old_md5);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " md5_new=\"%s\",", al_data->new_md5);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " sha1_old=\"%s\",", al_data->old_sha1);
+        field_add_string(syslog_msg, OS_CSYSLOG_MAX, " sha1_new=\"%s\",", al_data->new_sha1);
         /* Message */
-        field_add_truncated(syslog_msg, OS_SIZE_2048, " message=\"%s\"", logmsg, 2);
+        field_add_truncated(syslog_msg, OS_CSYSLOG_MAX, " message=\"%s\"", logmsg, 2);
     }
 
     OS_SendUDPbySize(syslog_config->socket, strlen(syslog_msg), syslog_msg);

--- a/src/os_csyslogd/csyslogd.c
+++ b/src/os_csyslogd/csyslogd.c
@@ -73,12 +73,23 @@ void OS_CSyslogD(SyslogConfig **syslog_config)
 /* Format Field for output */
 int field_add_string(char *dest, size_t size, const char *format, const char *value )
 {
-    char buffer[OS_SIZE_2048];
+    char buffer[OS_CSYSLOG_MAX];
     int len = 0;
-    int dest_sz = size - strlen(dest);
+    size_t dest_len;
+    size_t dest_sz;
+    size_t lim;
 
-    /* Not enough room in the buffer? */
-    if (dest_sz <= 0 ) {
+    if (!dest || size == 0) {
+        return -1;
+    }
+
+    dest_len = strlen(dest);
+    if (dest_len >= size) {
+        return -1;
+    }
+
+    dest_sz = size - dest_len;
+    if (dest_sz <= 1) {
         return -1;
     }
 
@@ -89,8 +100,12 @@ int field_add_string(char *dest, size_t size, const char *format, const char *va
                 ((value[0] != 'u') && (value[1] != 'n') && (value[4] != 'k'))
             )
        ) {
-        len = snprintf(buffer, sizeof(buffer) - dest_sz - 1, format, value);
-        strncat(dest, buffer, dest_sz);
+        lim = sizeof(buffer);
+        if (lim > dest_sz) {
+            lim = dest_sz;
+        }
+        len = snprintf(buffer, lim, format, value);
+        strncat(dest, buffer, dest_sz - 1);
     }
 
     return len;
@@ -99,20 +114,35 @@ int field_add_string(char *dest, size_t size, const char *format, const char *va
 /* Add a field, but truncate if too long */
 int field_add_truncated(char *dest, size_t size, const char *format, const char *value, int fmt_size )
 {
-    char buffer[OS_SIZE_2048];
-
-    int available_sz = size - strlen(dest);
-    int total_sz = strlen(value) + strlen(format) - fmt_size;
-    int field_sz = available_sz - strlen(format) + fmt_size;
-
+    char buffer[OS_CSYSLOG_MAX];
+    size_t dest_len;
+    size_t available_sz;
+    size_t total_sz;
+    size_t field_sz;
+    size_t lim;
     int len = 0;
     char trailer[] = "...";
     char *truncated = NULL;
 
-    /* Not enough room in the buffer? */
-    if (available_sz <= 0 ) {
+    if (!dest || !value || size == 0) {
         return -1;
     }
+
+    dest_len = strlen(dest);
+    if (dest_len >= size) {
+        return -1;
+    }
+
+    available_sz = size - dest_len;
+    if (available_sz <= 1) {
+        return -1;
+    }
+
+    total_sz = strlen(value) + strlen(format) - fmt_size;
+    if (available_sz <= strlen(format) - fmt_size) {
+        return -1;
+    }
+    field_sz = available_sz - strlen(format) + fmt_size;
 
     if (
         ((value[0] != '(') && (value[1] != 'n') && (value[2] != 'o')) ||
@@ -127,10 +157,15 @@ int field_add_truncated(char *dest, size_t size, const char *format, const char 
                 strcat(truncated, trailer);
             } else {
                 strncpy(truncated, value, field_sz);
+                truncated[field_sz] = '\0';
             }
 
-            len = snprintf(buffer, available_sz, format, truncated);
-            strncat(dest, buffer, available_sz);
+            lim = sizeof(buffer);
+            if (lim > available_sz) {
+                lim = available_sz;
+            }
+            len = snprintf(buffer, lim, format, truncated);
+            strncat(dest, buffer, available_sz - 1);
         } else {
             /* Memory Error */
             len = -3;

--- a/src/os_csyslogd/csyslogd.h
+++ b/src/os_csyslogd/csyslogd.h
@@ -14,6 +14,9 @@
 
 #define OS_CSYSLOGD_MAX_TRIES 10
 
+/* Outbound syslog/CEF/JSON alert size (matches OS_MAXSTR elsewhere). */
+#define OS_CSYSLOG_MAX OS_MAXSTR
+
 /** Prototypes **/
 
 /* Read syslog config */


### PR DESCRIPTION
ossec-csyslogd truncated forwarded alerts at 2048 bytes, cutting ~3KB Graylog CEF payloads. Use OS_MAXSTR (6144) and harden field_add helpers (#1762).