### PR TITLE
Fix syscheck queue/restart races and honor FIM frequency under realtime.

### DIFF
--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -371,6 +371,16 @@ int main_analysisd(int argc, char **argv)
     }
     nowChroot();
 
+    /* Bind the analysis queue early (before decoder/rule load) so producers
+     * started by ossec-control do not connect to a stale socket path while
+     * we are still loading config. Group is already set; socket is 0660.
+     */
+    if (!test_config) {
+        if ((m_queue = StartMQ(DEFAULTQUEUE, READ)) < 0) {
+            ErrorExit(QUEUE_ERROR, ARGV0, DEFAULTQUEUE, strerror(errno));
+        }
+    }
+
     Config.decoder_order_size = (size_t)getDefine_Int("analysisd", "decoder_order_size", 8, MAX_DECODER_ORDER_SIZE);
 
 
@@ -545,10 +555,7 @@ int main_analysisd(int argc, char **argv)
         ErrorExit(PID_ERROR, ARGV0);
     }
 
-    /* Set the queue */
-    if ((m_queue = StartMQ(DEFAULTQUEUE, READ)) < 0) {
-        ErrorExit(QUEUE_ERROR, ARGV0, DEFAULTQUEUE, strerror(errno));
-    }
+    /* Queue already bound post-chroot (see StartMQ above). */
 
     /* allowlist */
     if (Config.allow_list == NULL) {

--- a/src/analysisd/analysisd.c
+++ b/src/analysisd/analysisd.c
@@ -371,16 +371,6 @@ int main_analysisd(int argc, char **argv)
     }
     nowChroot();
 
-    /* Bind the analysis queue early (before decoder/rule load) so producers
-     * started by ossec-control do not connect to a stale socket path while
-     * we are still loading config. Group is already set; socket is 0660.
-     */
-    if (!test_config) {
-        if ((m_queue = StartMQ(DEFAULTQUEUE, READ)) < 0) {
-            ErrorExit(QUEUE_ERROR, ARGV0, DEFAULTQUEUE, strerror(errno));
-        }
-    }
-
     Config.decoder_order_size = (size_t)getDefine_Int("analysisd", "decoder_order_size", 8, MAX_DECODER_ORDER_SIZE);
 
 
@@ -555,7 +545,13 @@ int main_analysisd(int argc, char **argv)
         ErrorExit(PID_ERROR, ARGV0);
     }
 
-    /* Queue already bound post-chroot (see StartMQ above). */
+    /* Bind after decoder/rule load so ossec-control's connect-based queue
+     * wait does not release producers while we still cannot drain the MQ.
+     * Stale sockets are removed on stop; StartMQ(WRITE) waits for connect.
+     */
+    if ((m_queue = StartMQ(DEFAULTQUEUE, READ)) < 0) {
+        ErrorExit(QUEUE_ERROR, ARGV0, DEFAULTQUEUE, strerror(errno));
+    }
 
     /* allowlist */
     if (Config.allow_list == NULL) {

--- a/src/analysisd/pipeline.c
+++ b/src/analysisd/pipeline.c
@@ -30,8 +30,10 @@
 #endif
 
 #include <errno.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdint.h>
+#include <sys/socket.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -67,8 +69,8 @@ os_queue *writer_queue_firewall = NULL;
 os_queue *writer_queue_fts = NULL;
 os_queue *raw_input_queue = NULL;
 
-static volatile int analysisd_shutting_down = 0;
-static int pipeline_m_queue = 0;
+static volatile sig_atomic_t analysisd_shutting_down = 0;
+static volatile sig_atomic_t pipeline_m_queue = -1;
 static volatile long alert_ticket = 0;
 
 static int cfg_event_threads = 1;
@@ -926,14 +928,38 @@ static void *analysisd_input_recv_thread(void *arg)
     char msg[OS_MAXSTR + 1];
     char *copy;
     int recv_len;
+    struct pollfd pfd;
 
     (void)arg;
     os_block_worker_signals();
 
     while (!analysisd_shutting_down) {
-        recv_len = OS_RecvUnix(pipeline_m_queue, OS_MAXSTR, msg);
+        int fd = (int)pipeline_m_queue;
+
+        if (fd < 0) {
+            break;
+        }
+
+        pfd.fd = fd;
+        pfd.events = POLLIN;
+        pfd.revents = 0;
+
+        /* Short poll so shutdown flag / closed FD is observed promptly. */
+        if (poll(&pfd, 1, 1000) <= 0) {
+            continue;
+        }
+
+        if (analysisd_shutting_down || (int)pipeline_m_queue < 0) {
+            break;
+        }
+
+        if (!(pfd.revents & (POLLIN | POLLHUP | POLLERR))) {
+            continue;
+        }
+
+        recv_len = OS_RecvUnix(fd, OS_MAXSTR, msg);
         if (recv_len <= 0) {
-            if (analysisd_shutting_down) {
+            if (analysisd_shutting_down || (int)pipeline_m_queue < 0) {
                 break;
             }
             continue;
@@ -961,6 +987,20 @@ static void *analysisd_input_recv_thread(void *arg)
     }
 
     return NULL;
+}
+
+static void analysisd_close_input_queue(void)
+{
+    int fd = (int)pipeline_m_queue;
+
+    if (fd < 0) {
+        return;
+    }
+
+    /* Publish closed state before shutdown/close so the recv loop exits. */
+    pipeline_m_queue = -1;
+    (void)shutdown(fd, SHUT_RDWR);
+    (void)close(fd);
 }
 
 static void *analysisd_input_demux_thread(void *arg)
@@ -994,6 +1034,9 @@ static void *analysisd_input_demux_thread(void *arg)
 void analysisd_pipeline_request_shutdown(void)
 {
     analysisd_shutting_down = 1;
+    /* Wake input_recv if it is blocked in poll/recv (producers may already
+     * be dead, so no datagrams arrive to unblock a plain recvfrom). */
+    analysisd_close_input_queue();
 }
 
 void analysisd_log_pipeline_metrics(unsigned int decoded, unsigned int processed,
@@ -1093,10 +1136,7 @@ void analysisd_pipeline_shutdown(void)
     analysisd_state_shutdown();
 
     /* Stage 1: stop accepting new messages, then drain decode input. */
-    if (pipeline_m_queue >= 0) {
-        close(pipeline_m_queue);
-        pipeline_m_queue = -1;
-    }
+    analysisd_close_input_queue();
 
     if (analysisd_join_thread(input_recv_thread_id, "input recv thread") != 0) {
         join_failed = 1;

--- a/src/analysisd/pipeline.c
+++ b/src/analysisd/pipeline.c
@@ -31,7 +31,7 @@
 
 #include <errno.h>
 #include <poll.h>
-#include <signal.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <sys/socket.h>
 #include <time.h>
@@ -69,8 +69,11 @@ os_queue *writer_queue_firewall = NULL;
 os_queue *writer_queue_fts = NULL;
 os_queue *raw_input_queue = NULL;
 
-static volatile sig_atomic_t analysisd_shutting_down = 0;
-static volatile sig_atomic_t pipeline_m_queue = -1;
+/* Cross-thread flags/fd: sig_atomic_t is only defined vs signal handlers.
+ * _Atomic gives well-defined concurrent loads/stores between pthreads.
+ */
+static _Atomic int analysisd_shutting_down = 0;
+static _Atomic int pipeline_m_queue = -1;
 static volatile long alert_ticket = 0;
 
 static int cfg_event_threads = 1;
@@ -934,8 +937,8 @@ static void *analysisd_input_recv_thread(void *arg)
     (void)arg;
     os_block_worker_signals();
 
-    while (!analysisd_shutting_down) {
-        int fd = (int)pipeline_m_queue;
+    while (!atomic_load(&analysisd_shutting_down)) {
+        int fd = atomic_load(&pipeline_m_queue);
 
         if (fd < 0) {
             break;
@@ -950,7 +953,8 @@ static void *analysisd_input_recv_thread(void *arg)
             continue;
         }
 
-        if (analysisd_shutting_down || (int)pipeline_m_queue != fd) {
+        if (atomic_load(&analysisd_shutting_down) ||
+            atomic_load(&pipeline_m_queue) != fd) {
             break;
         }
 
@@ -960,7 +964,8 @@ static void *analysisd_input_recv_thread(void *arg)
 
         recv_len = OS_RecvUnix(fd, OS_MAXSTR, msg);
         if (recv_len <= 0) {
-            if (analysisd_shutting_down || (int)pipeline_m_queue != fd) {
+            if (atomic_load(&analysisd_shutting_down) ||
+                atomic_load(&pipeline_m_queue) != fd) {
                 break;
             }
             continue;
@@ -998,14 +1003,14 @@ static void analysisd_close_input_queue(void)
      * same fd twice (and accidentally close a reused descriptor).
      */
     os_mutex_lock(&input_queue_close_mutex);
-    fd = (int)pipeline_m_queue;
+    fd = atomic_load(&pipeline_m_queue);
     if (fd < 0) {
         os_mutex_unlock(&input_queue_close_mutex);
         return;
     }
 
     /* Publish closed state before shutdown/close so the recv loop exits. */
-    pipeline_m_queue = -1;
+    atomic_store(&pipeline_m_queue, -1);
     os_mutex_unlock(&input_queue_close_mutex);
 
     (void)shutdown(fd, SHUT_RDWR);
@@ -1042,7 +1047,7 @@ static void *analysisd_input_demux_thread(void *arg)
 
 void analysisd_pipeline_request_shutdown(void)
 {
-    analysisd_shutting_down = 1;
+    atomic_store(&analysisd_shutting_down, 1);
     /* Wake input_recv if it is blocked in poll/recv (producers may already
      * be dead, so no datagrams arrive to unblock a plain recvfrom). */
     analysisd_close_input_queue();
@@ -1141,7 +1146,7 @@ void analysisd_pipeline_shutdown(void)
     char name[64];
     int join_failed = 0;
 
-    analysisd_shutting_down = 1;
+    atomic_store(&analysisd_shutting_down, 1);
     analysisd_state_shutdown();
 
     /* Stage 1: stop accepting new messages, then drain decode input. */
@@ -1271,7 +1276,7 @@ void analysisd_pipeline_run(int m_queue)
 {
     int i;
 
-    pipeline_m_queue = m_queue;
+    atomic_store(&pipeline_m_queue, m_queue);
 
     cfg_event_threads = analysisd_resolve_threads("event_threads");
     cfg_syscheck_threads = analysisd_resolve_threads("syscheck_threads");

--- a/src/analysisd/pipeline.c
+++ b/src/analysisd/pipeline.c
@@ -950,7 +950,7 @@ static void *analysisd_input_recv_thread(void *arg)
             continue;
         }
 
-        if (analysisd_shutting_down || (int)pipeline_m_queue < 0) {
+        if (analysisd_shutting_down || (int)pipeline_m_queue != fd) {
             break;
         }
 
@@ -960,7 +960,7 @@ static void *analysisd_input_recv_thread(void *arg)
 
         recv_len = OS_RecvUnix(fd, OS_MAXSTR, msg);
         if (recv_len <= 0) {
-            if (analysisd_shutting_down || (int)pipeline_m_queue < 0) {
+            if (analysisd_shutting_down || (int)pipeline_m_queue != fd) {
                 break;
             }
             continue;

--- a/src/analysisd/pipeline.c
+++ b/src/analysisd/pipeline.c
@@ -115,6 +115,7 @@ static pthread_t writer_firewall_thread_id;
 static pthread_t writer_fts_thread_id;
 static pthread_t state_thread_id;
 static pthread_mutex_t writer_threads_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t input_queue_close_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static int decode_event_thread_count = 0;
 static int decode_syscheck_thread_count = 0;
@@ -991,14 +992,22 @@ static void *analysisd_input_recv_thread(void *arg)
 
 static void analysisd_close_input_queue(void)
 {
-    int fd = (int)pipeline_m_queue;
+    int fd;
 
+    /* Serialize so request_shutdown and pipeline_shutdown cannot close the
+     * same fd twice (and accidentally close a reused descriptor).
+     */
+    os_mutex_lock(&input_queue_close_mutex);
+    fd = (int)pipeline_m_queue;
     if (fd < 0) {
+        os_mutex_unlock(&input_queue_close_mutex);
         return;
     }
 
     /* Publish closed state before shutdown/close so the recv loop exits. */
     pipeline_m_queue = -1;
+    os_mutex_unlock(&input_queue_close_mutex);
+
     (void)shutdown(fd, SHUT_RDWR);
     (void)close(fd);
 }

--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -135,6 +135,15 @@ start()
             fi
 
             echo "Started ${i}..."
+
+            # Agent queue owner is ossec-agentd (local producers connect to it).
+            if [ X"$i" = "Xossec-agentd" ]; then
+                wait_for_agent_queue
+                if [ $? != 0 ]; then
+                    unlock;
+                    exit 1;
+                fi
+            fi
         else
             echo "${i} already running..."
         fi
@@ -176,16 +185,56 @@ pstatus()
     return 0;
 }
 
+wait_pids_gone()
+{
+    local grace=45
+    local elapsed=0
+    local pid
+    local still
+
+    if [ "X$*" = "X" ]; then
+        return 0
+    fi
+
+    while [ ${elapsed} -lt ${grace} ]; do
+        still=0
+        for pid in $*; do
+            kill -0 ${pid} >/dev/null 2>&1
+            if [ $? = 0 ]; then
+                still=1
+                break
+            fi
+        done
+        if [ ${still} = 0 ]; then
+            return 0
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+
+    for pid in $*; do
+        kill -0 ${pid} >/dev/null 2>&1
+        if [ $? = 0 ]; then
+            echo "Process ${pid} did not exit; sending SIGKILL .."
+            kill -9 ${pid} >/dev/null 2>&1
+        fi
+    done
+    sleep 1
+}
+
 stopa()
 {
     lock;
     checkpid;
+    WAIT_PIDS=""
     for i in ${DAEMONS}; do
         pstatus ${i};
         if [ $? = 1 ]; then
             echo "Killing ${i} .. ";
-
-            kill `cat ${DIR}/var/run/${i}*.pid`;
+            for j in `cat ${DIR}/var/run/${i}*.pid 2>/dev/null`; do
+                kill ${j} >/dev/null 2>&1
+                WAIT_PIDS="${WAIT_PIDS} ${j}"
+            done
         else
             echo "${i} not running ..";
         fi
@@ -193,8 +242,43 @@ stopa()
         rm -f ${DIR}/var/run/${i}*.pid
      done
 
+    wait_pids_gone ${WAIT_PIDS}
+
+    rm -f ${DIR}/queue/ossec/queue 2>/dev/null
+
     unlock;
     echo "$NAME $VERSION Stopped"
+}
+
+wait_for_agent_queue()
+{
+    local elapsed=0
+    local max=60
+    local qpath="${DIR}/queue/ossec/queue"
+
+    while [ ${elapsed} -lt ${max} ]; do
+        if [ -S "${qpath}" ] || [ -e "${qpath}" ]; then
+            python3 - "${qpath}" <<'PY' 2>/dev/null
+import socket, sys
+path = sys.argv[1]
+s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+try:
+    s.connect(path)
+except Exception:
+    sys.exit(1)
+finally:
+    s.close()
+sys.exit(0)
+PY
+            if [ $? = 0 ]; then
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+    echo "ERROR: agent queue not ready at ${qpath} after ${max}s"
+    return 1
 }
 
 ### MAIN HERE ###
@@ -210,7 +294,6 @@ stop)
 restart)
     testconfig
     stopa
-    sleep 1;
     start
     ;;
 reload)

--- a/src/init/ossec-client.sh
+++ b/src/init/ossec-client.sh
@@ -187,10 +187,11 @@ pstatus()
 
 wait_pids_gone()
 {
-    local grace=45
-    local elapsed=0
-    local pid
-    local still
+    # No `local`: scripts are #!/bin/sh (POSIX); dash rejects `local`.
+    grace=45
+    elapsed=0
+    pid=""
+    still=0
 
     if [ "X$*" = "X" ]; then
         return 0
@@ -252,13 +253,24 @@ stopa()
 
 wait_for_agent_queue()
 {
-    local elapsed=0
-    local max=60
-    local qpath="${DIR}/queue/ossec/queue"
+    # No `local`: scripts are #!/bin/sh (POSIX); dash rejects `local`.
+    elapsed=0
+    max=60
+    qpath="${DIR}/queue/ossec/queue"
+    py=""
+
+    if command -v python3 >/dev/null 2>&1; then
+        py=python3
+    elif command -v python >/dev/null 2>&1; then
+        py=python
+    else
+        echo "ERROR: python3 or python required to probe agent queue at ${qpath}"
+        return 1
+    fi
 
     while [ ${elapsed} -lt ${max} ]; do
         if [ -S "${qpath}" ] || [ -e "${qpath}" ]; then
-            python3 - "${qpath}" <<'PY' 2>/dev/null
+            ${py} - "${qpath}" <<'PY' 2>/dev/null
 import socket, sys
 path = sys.argv[1]
 s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -200,6 +200,14 @@ start()
                 exit 1;
             fi
             echo "Started ${i}..."
+
+            if [ X"$i" = "Xossec-analysisd" ]; then
+                wait_for_analysis_queue
+                if [ $? != 0 ]; then
+                    unlock;
+                    exit 1;
+                fi
+            fi
         else
             echo "${i} already running..."
         fi
@@ -249,20 +257,65 @@ pstatus()
     return 0;
 }
 
+wait_pids_gone()
+{
+    local grace=45
+    local elapsed=0
+    local pid
+    local still
+
+    if [ "X$*" = "X" ]; then
+        return 0
+    fi
+
+    while [ ${elapsed} -lt ${grace} ]; do
+        still=0
+        for pid in $*; do
+            kill -0 ${pid} >/dev/null 2>&1
+            if [ $? = 0 ]; then
+                still=1
+                break
+            fi
+        done
+        if [ ${still} = 0 ]; then
+            return 0
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+
+    for pid in $*; do
+        kill -0 ${pid} >/dev/null 2>&1
+        if [ $? = 0 ]; then
+            echo "Process ${pid} did not exit; sending SIGKILL .."
+            kill -9 ${pid} >/dev/null 2>&1
+        fi
+    done
+    sleep 1
+}
+
 stopa()
 {
     lock;
     checkpid;
+    WAIT_PIDS=""
     for i in ${DAEMONS}; do
         pstatus ${i};
         if [ $? = 1 ]; then
             echo "Killing ${i} .. ";
-            kill `cat ${DIR}/var/run/${i}*.pid`;
+            for j in `cat ${DIR}/var/run/${i}*.pid 2>/dev/null`; do
+                kill ${j} >/dev/null 2>&1
+                WAIT_PIDS="${WAIT_PIDS} ${j}"
+            done
         else
             echo "${i} not running ..";
         fi
         rm -f ${DIR}/var/run/${i}*.pid
     done
+
+    wait_pids_gone ${WAIT_PIDS}
+
+    rm -f ${DIR}/queue/ossec/queue 2>/dev/null
 
     unlock;
 
@@ -273,6 +326,37 @@ stopa()
         ${DIR}/ossec-agent/bin/ossec-control stop
     fi
     echo "$NAME $VERSION Stopped"
+}
+
+wait_for_analysis_queue()
+{
+    local elapsed=0
+    local max=60
+    local qpath="${DIR}/queue/ossec/queue"
+
+    while [ ${elapsed} -lt ${max} ]; do
+        if [ -S "${qpath}" ] || [ -e "${qpath}" ]; then
+            python3 - "${qpath}" <<'PY' 2>/dev/null
+import socket, sys
+path = sys.argv[1]
+s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+try:
+    s.connect(path)
+except Exception:
+    sys.exit(1)
+finally:
+    s.close()
+sys.exit(0)
+PY
+            if [ $? = 0 ]; then
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+    echo "ERROR: analysis queue not ready at ${qpath} after ${max}s"
+    return 1
 }
 
 ### MAIN HERE ###
@@ -288,7 +372,6 @@ stop)
 restart)
     testconfig
     stopa
-    sleep 1;
     start
     ;;
 status)

--- a/src/init/ossec-local.sh
+++ b/src/init/ossec-local.sh
@@ -259,10 +259,11 @@ pstatus()
 
 wait_pids_gone()
 {
-    local grace=45
-    local elapsed=0
-    local pid
-    local still
+    # No `local`: scripts are #!/bin/sh (POSIX); dash rejects `local`.
+    grace=45
+    elapsed=0
+    pid=""
+    still=0
 
     if [ "X$*" = "X" ]; then
         return 0
@@ -330,13 +331,24 @@ stopa()
 
 wait_for_analysis_queue()
 {
-    local elapsed=0
-    local max=60
-    local qpath="${DIR}/queue/ossec/queue"
+    # No `local`: scripts are #!/bin/sh (POSIX); dash rejects `local`.
+    elapsed=0
+    max=60
+    qpath="${DIR}/queue/ossec/queue"
+    py=""
+
+    if command -v python3 >/dev/null 2>&1; then
+        py=python3
+    elif command -v python >/dev/null 2>&1; then
+        py=python
+    else
+        echo "ERROR: python3 or python required to probe analysis queue at ${qpath}"
+        return 1
+    fi
 
     while [ ${elapsed} -lt ${max} ]; do
         if [ -S "${qpath}" ] || [ -e "${qpath}" ]; then
-            python3 - "${qpath}" <<'PY' 2>/dev/null
+            ${py} - "${qpath}" <<'PY' 2>/dev/null
 import socket, sys
 path = sys.argv[1]
 s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -223,6 +223,15 @@ start()
             fi
 
             echo "Started ${i}..."
+
+            # Producers must not start until analysisd has bound the queue.
+            if [ X"$i" = "Xossec-analysisd" ]; then
+                wait_for_analysis_queue
+                if [ $? != 0 ]; then
+                    unlock;
+                    exit 1;
+                fi
+            fi
         else
             echo "${i} already running..."
         fi
@@ -264,24 +273,105 @@ pstatus()
     return 0;
 }
 
+# After SIGTERM, wait for process exit (analysisd may need a few seconds to
+# drain). Escalate to SIGKILL after grace so restart does not race a half-dead
+# daemon.
+wait_pids_gone()
+{
+    local grace=45
+    local elapsed=0
+    local pid
+    local still
+
+    if [ "X$*" = "X" ]; then
+        return 0
+    fi
+
+    while [ ${elapsed} -lt ${grace} ]; do
+        still=0
+        for pid in $*; do
+            kill -0 ${pid} >/dev/null 2>&1
+            if [ $? = 0 ]; then
+                still=1
+                break
+            fi
+        done
+        if [ ${still} = 0 ]; then
+            return 0
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+
+    for pid in $*; do
+        kill -0 ${pid} >/dev/null 2>&1
+        if [ $? = 0 ]; then
+            echo "Process ${pid} did not exit; sending SIGKILL .."
+            kill -9 ${pid} >/dev/null 2>&1
+        fi
+    done
+    sleep 1
+}
+
 stopa()
 {
     lock;
     checkpid;
+    WAIT_PIDS=""
     for i in ${DAEMONS}; do
         pstatus ${i};
         if [ $? = 1 ]; then
             echo "Killing ${i} .. ";
-
-            kill `cat ${DIR}/var/run/${i}*.pid`;
+            for j in `cat ${DIR}/var/run/${i}*.pid 2>/dev/null`; do
+                kill ${j} >/dev/null 2>&1
+                WAIT_PIDS="${WAIT_PIDS} ${j}"
+            done
         else
             echo "${i} not running ..";
         fi
         rm -f ${DIR}/var/run/${i}*.pid
     done
 
+    wait_pids_gone ${WAIT_PIDS}
+
+    # Drop stale analysis queue path so the next StartMQ(WRITE) cannot
+    # connect to a dead peer inode left behind after stop.
+    rm -f ${DIR}/queue/ossec/queue 2>/dev/null
+
     unlock;
     echo "$NAME $VERSION Stopped"
+}
+
+# Wait until DEFAULTQUEUE accepts a datagram connect (analysisd early-bind).
+wait_for_analysis_queue()
+{
+    local elapsed=0
+    local max=60
+    local qpath="${DIR}/queue/ossec/queue"
+
+    while [ ${elapsed} -lt ${max} ]; do
+        if [ -S "${qpath}" ] || [ -e "${qpath}" ]; then
+            python3 - "${qpath}" <<'PY' 2>/dev/null
+import socket, sys
+path = sys.argv[1]
+s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+try:
+    s.connect(path)
+except Exception:
+    sys.exit(1)
+finally:
+    s.close()
+sys.exit(0)
+PY
+            if [ $? = 0 ]; then
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=`expr ${elapsed} + 1`
+    done
+    echo "ERROR: analysis queue not ready at ${qpath} after ${max}s"
+    return 1
 }
 
 ### MAIN HERE ###
@@ -297,7 +387,6 @@ stop)
 restart)
     testconfig
     stopa
-    sleep 1;
     start
     ;;
 reload)

--- a/src/init/ossec-server.sh
+++ b/src/init/ossec-server.sh
@@ -278,10 +278,11 @@ pstatus()
 # daemon.
 wait_pids_gone()
 {
-    local grace=45
-    local elapsed=0
-    local pid
-    local still
+    # No `local`: scripts are #!/bin/sh (POSIX); dash rejects `local`.
+    grace=45
+    elapsed=0
+    pid=""
+    still=0
 
     if [ "X$*" = "X" ]; then
         return 0
@@ -345,13 +346,24 @@ stopa()
 # Wait until DEFAULTQUEUE accepts a datagram connect (analysisd early-bind).
 wait_for_analysis_queue()
 {
-    local elapsed=0
-    local max=60
-    local qpath="${DIR}/queue/ossec/queue"
+    # No `local`: scripts are #!/bin/sh (POSIX); dash rejects `local`.
+    elapsed=0
+    max=60
+    qpath="${DIR}/queue/ossec/queue"
+    py=""
+
+    if command -v python3 >/dev/null 2>&1; then
+        py=python3
+    elif command -v python >/dev/null 2>&1; then
+        py=python
+    else
+        echo "ERROR: python3 or python required to probe analysis queue at ${qpath}"
+        return 1
+    fi
 
     while [ ${elapsed} -lt ${max} ]; do
         if [ -S "${qpath}" ] || [ -e "${qpath}" ]; then
-            python3 - "${qpath}" <<'PY' 2>/dev/null
+            ${py} - "${qpath}" <<'PY' 2>/dev/null
 import socket, sys
 path = sys.argv[1]
 s = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)

--- a/src/logcollector/logcollector.c
+++ b/src/logcollector/logcollector.c
@@ -14,6 +14,7 @@
 int update_fname(int i);
 static int logformat_is_shared(int idx);
 static void clear_logreader_entry(int idx);
+static void logcollector_queue_send(const char *msg, const char *locmsg);
 
 /* Global variables */
 int loop_timeout;
@@ -37,6 +38,20 @@ static char *rand_keepalive_str(char *dst, int size)
     }
     dst[i] = '\0';
     return dst;
+}
+
+/* SendMSG closes the fd on hard socket errors; reconnect before reuse. */
+static void logcollector_queue_send(const char *msg, const char *locmsg)
+{
+    if (SendMSG(logr_queue, msg, locmsg, LOCALFILE_MQ) < 0) {
+        merror(QUEUE_SEND, ARGV0);
+        if ((logr_queue = StartMQ(DEFAULTQPATH, WRITE)) < 0) {
+            ErrorExit(QUEUE_FATAL, ARGV0, DEFAULTQPATH);
+        }
+        if (SendMSG(logr_queue, msg, locmsg, LOCALFILE_MQ) < 0) {
+            merror(QUEUE_SEND, ARGV0);
+        }
+    }
 }
 
 /* Return 1 if another logreader entry shares the same logformat pointer
@@ -453,7 +468,7 @@ void LogCollectorStart()
 
         /* Send keep alive message */
         rand_keepalive_str(keepalive, 700);
-        SendMSG(logr_queue, keepalive, "ossec-keepalive", LOCALFILE_MQ);
+        logcollector_queue_send(keepalive, "ossec-keepalive");
 
         /* Zero f_check */
         f_check = 0;
@@ -551,8 +566,7 @@ void LogCollectorStart()
                              logff[i].file);
 
                     /* Send message about log rotated */
-                    SendMSG(logr_queue, msg_alert,
-                            "ossec-logcollector", LOCALFILE_MQ);
+                    logcollector_queue_send(msg_alert, "ossec-logcollector");
 
                     debug1("%s: DEBUG: File inode changed. %s",
                            ARGV0, logff[i].file);
@@ -581,8 +595,7 @@ void LogCollectorStart()
                              logff[i].file);
 
                     /* Send message about log rotated */
-                    SendMSG(logr_queue, msg_alert,
-                            "ossec-logcollector", LOCALFILE_MQ);
+                    logcollector_queue_send(msg_alert, "ossec-logcollector");
 
                     debug1("%s: DEBUG: File size reduced. %s",
                            ARGV0, logff[i].file);

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -229,10 +229,8 @@ int OS_BindUnixDomain(const char *path, mode_t mode, int max_msg_size)
     socklen_t optlen = sizeof(len);
 
     /* Make sure the path isn't there */
-    int urc = -1;
-    if (( urc = unlink(path)) < 0) {
-        /* XXX I think we're blindly unlinking path, so if it doesn't exist, don't log an error */
-        if (urc != ENOENT) {
+    if (unlink(path) < 0) {
+        if (errno != ENOENT) {
             merror("ERROR: Cannot unlink file %s: %s", path, strerror(errno));
         }
     }

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -17,21 +17,26 @@
  * nested sleep ladders (see PR #578 / @awiddersheim).
  */
 
-/* Wait for the queue socket path to appear. Returns 0 if present, -1 if not.
- * delays[] are sleeps between existence checks (total wait 1+5+15 = 21s).
+/* Wait until a live AF_UNIX connect succeeds (not merely path presence).
+ * Stale socket files left after analysisd exit otherwise look "ready".
+ * Returns a connected fd, or -1 on timeout/failure.
  */
-static int mq_wait_for_path(const char *path, const unsigned int *delays, size_t ndelays)
+static int mq_wait_connect(const char *path, const unsigned int *delays,
+                           size_t ndelays)
 {
     size_t i;
+    int rc;
 
-    if (File_DateofChange(path) >= 0) {
-        return (0);
+    rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
+    if (rc >= 0) {
+        return (rc);
     }
 
     for (i = 0; i < ndelays; i++) {
         sleep(delays[i]);
-        if (File_DateofChange(path) >= 0) {
-            return (0);
+        rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
+        if (rc >= 0) {
+            return (rc);
         }
     }
 
@@ -42,29 +47,18 @@ static int mq_wait_for_path(const char *path, const unsigned int *delays, size_t
 int StartMQ(const char *path, short int type)
 {
     int rc;
-    size_t i;
-    static const unsigned int path_waits[] = { 1, 5, 15 };
-    static const unsigned int connect_waits[] = { 1, 2 };
+    /* Total sleep budget similar to historical 1+5+15 path wait + connect. */
+    static const unsigned int connect_waits[] = { 1, 2, 5, 10, 15 };
 
     if (type == READ) {
         return (OS_BindUnixDomain(path, 0660, OS_MAXSTR + 512));
     }
 
-    /* Give the other end up to 21 seconds to create the socket. */
-    if (mq_wait_for_path(path, path_waits,
-                         sizeof(path_waits) / sizeof(path_waits[0])) < 0) {
-        merror(QUEUE_ERROR, __local_name, path, "Queue not found");
-        return (-1);
-    }
-
-    /* Up to 3 connect attempts with 1s then 2s between failures (~3s sleeps). */
-    rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
-    for (i = 0; rc < 0 && i < sizeof(connect_waits) / sizeof(connect_waits[0]); i++) {
-        sleep(connect_waits[i]);
-        rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
-    }
+    rc = mq_wait_connect(path, connect_waits,
+                         sizeof(connect_waits) / sizeof(connect_waits[0]));
     if (rc < 0) {
-        merror(QUEUE_ERROR, __local_name, path, strerror(errno));
+        merror(QUEUE_ERROR, __local_name, path,
+               (File_DateofChange(path) < 0) ? "Queue not found" : strerror(errno));
         return (-1);
     }
 
@@ -110,8 +104,8 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc)
     }
 
     /* Five send attempts; after the first failure, sleep 1/3/5/10s
-     * between retries (total sleep budget 19s). OS_SOCKTERR is fatal
-     * only on the initial attempt, matching historical behavior.
+     * between retries (total sleep budget 19s). On OS_SOCKTERR close the
+     * fd so callers can StartMQ again; they see -1 as before.
      */
     __mq_rcode = OS_SendUnix(queue, tmpstr, 0);
     if (__mq_rcode < 0) {

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -111,8 +111,10 @@ int SendMSG(int queue, const char *message, const char *locmsg, char loc)
     }
 
     /* Five send attempts; after the first failure, sleep 1/3/5/10s
-     * between retries (total sleep budget 19s). On OS_SOCKTERR close the
-     * fd so callers can StartMQ again; they see -1 as before.
+     * between retries (total sleep budget 19s). OS_SOCKTERR is fatal
+     * only on the initial attempt; close(queue) so callers that StartMQ
+     * again do not leak the dead fd. Callers must not reuse queue after -1
+     * without StartMQ (pass-by-value cannot clear the caller's variable).
      */
     __mq_rcode = OS_SendUnix(queue, tmpstr, 0);
     if (__mq_rcode < 0) {

--- a/src/shared/mq_op.c
+++ b/src/shared/mq_op.c
@@ -26,11 +26,13 @@ static int mq_wait_connect(const char *path, const unsigned int *delays,
 {
     size_t i;
     int rc;
+    int last_errno = 0;
 
     rc = OS_ConnectUnixDomain(path, OS_MAXSTR + 256);
     if (rc >= 0) {
         return (rc);
     }
+    last_errno = errno;
 
     for (i = 0; i < ndelays; i++) {
         sleep(delays[i]);
@@ -38,8 +40,10 @@ static int mq_wait_connect(const char *path, const unsigned int *delays,
         if (rc >= 0) {
             return (rc);
         }
+        last_errno = errno;
     }
 
+    errno = last_errno;
     return (-1);
 }
 
@@ -57,8 +61,11 @@ int StartMQ(const char *path, short int type)
     rc = mq_wait_connect(path, connect_waits,
                          sizeof(connect_waits) / sizeof(connect_waits[0]));
     if (rc < 0) {
+        int saved_errno = errno;
+
         merror(QUEUE_ERROR, __local_name, path,
-               (File_DateofChange(path) < 0) ? "Queue not found" : strerror(errno));
+               (File_DateofChange(path) < 0) ? "Queue not found"
+                                             : strerror(saved_errno));
         return (-1);
     }
 

--- a/src/syscheckd/run_check.c
+++ b/src/syscheckd/run_check.c
@@ -29,9 +29,43 @@
 /* Prototypes */
 static void send_sk_db(void);
 static void syscheck_log_send_failures(void);
+static time_t syscheck_idle_wait(time_t curr_time, time_t prev_time_sk,
+                                 time_t prev_time_rk);
 
 /* Count of baseline/update messages that could not reach the agent queue. */
 static unsigned int syscheck_send_failures = 0;
+
+/* Max idle between daemon-loop iterations: honor <frequency> / rootcheck
+ * cadence while still capping at SYSCHECK_WAIT so long frequencies do not
+ * block forever in select/sleep.
+ */
+static time_t syscheck_idle_wait(time_t curr_time, time_t prev_time_sk,
+                                 time_t prev_time_rk)
+{
+    time_t remaining;
+    time_t next_sk;
+    time_t sk_remain;
+
+    next_sk = prev_time_sk + (time_t)syscheck.time;
+    sk_remain = next_sk - curr_time;
+    remaining = sk_remain;
+
+    if (syscheck.rootcheck && rootcheck.time > 0) {
+        time_t next_rk = prev_time_rk + (time_t)rootcheck.time;
+        time_t rk_remain = next_rk - curr_time;
+        if (rk_remain < remaining) {
+            remaining = rk_remain;
+        }
+    }
+
+    if (remaining < 1) {
+        remaining = 1;
+    }
+    if (remaining > SYSCHECK_WAIT) {
+        remaining = SYSCHECK_WAIT;
+    }
+    return remaining;
+}
 
 
 /* Send a message related to syscheck change/addition.
@@ -206,9 +240,11 @@ void start_daemon()
         }
     }
 
-    /* Check every SYSCHECK_WAIT */
+    /* Loop: run due scans, then idle up to min(SYSCHECK_WAIT, remaining freq). */
     while (1) {
         int run_now = 0;
+        int select_rc;
+        time_t idle_wait;
         curr_time = time(0);
 
         /* Check if syscheck should be restarted */
@@ -300,41 +336,45 @@ void start_daemon()
             prev_time_sk = time(0);
         }
 
+        curr_time = time(0);
+        idle_wait = syscheck_idle_wait(curr_time, prev_time_sk, prev_time_rk);
+
 #ifdef INOTIFY_ENABLED
         if (syscheck.realtime && (syscheck.realtime->fd >= 0)) {
-            selecttime.tv_sec = SYSCHECK_WAIT;
+            selecttime.tv_sec = (long)idle_wait;
             selecttime.tv_usec = 0;
 
             /* zero-out the fd_set */
             FD_ZERO (&rfds);
             FD_SET(syscheck.realtime->fd, &rfds);
 
-            run_now = select(syscheck.realtime->fd + 1, &rfds,
-                             NULL, NULL, &selecttime);
-            if (run_now < 0) {
+            select_rc = select(syscheck.realtime->fd + 1, &rfds,
+                               NULL, NULL, &selecttime);
+            if (select_rc < 0) {
                 merror("%s: ERROR: Select failed (for realtime fim).", ARGV0);
-                sleep(SYSCHECK_WAIT);
-            } else if (run_now == 0) {
-                /* Timeout */
+                sleep((unsigned int)idle_wait);
+            } else if (select_rc == 0) {
+                /* Timeout — re-evaluate frequency */
             } else if (FD_ISSET (syscheck.realtime->fd, &rfds)) {
                 realtime_process();
             }
         } else {
-            sleep(SYSCHECK_WAIT);
+            sleep((unsigned int)idle_wait);
         }
 #elif defined(WIN32)
         if (syscheck.realtime && (syscheck.realtime->fd >= 0)) {
-            if (WaitForSingleObjectEx(syscheck.realtime->evt, SYSCHECK_WAIT * 1000, TRUE) == WAIT_FAILED) {
+            if (WaitForSingleObjectEx(syscheck.realtime->evt,
+                                      (DWORD)(idle_wait * 1000), TRUE) == WAIT_FAILED) {
                 merror("%s: ERROR: WaitForSingleObjectEx failed (for realtime fim).", ARGV0);
-                sleep(SYSCHECK_WAIT);
+                sleep((unsigned int)idle_wait);
             } else {
                 sleep(1);
             }
         } else {
-            sleep(SYSCHECK_WAIT);
+            sleep((unsigned int)idle_wait);
         }
 #else
-        sleep(SYSCHECK_WAIT);
+        sleep((unsigned int)idle_wait);
 #endif
     }
 }


### PR DESCRIPTION
Bind analysisd MQ early, wake recv on shutdown with PID wait before restart, and use adaptive syscheck idle waits so short <frequency> is not capped by SYSCHECK_WAIT.