### PR TITLE
Stop Dovecot lip= from capturing a trailing comma as dstip.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Scott R. Shinn (https://www.atomicorp.com)
 
 - @atomicturtle
 - @bearxy123
+- @AdUser
 
 **Release Notes**
 
@@ -15,6 +16,7 @@ Work toward the next minor release after 4.3.0.
 
 **Bug Fixes**
 
+- @AdUser / @atomicturtle - [PR 2106](https://github.com/ossec/ossec-hids/pull/2106) - Stop Dovecot lip= from capturing a trailing comma as dstip
 - @bearxy123 / @atomicturtle - [PR 2107](https://github.com/ossec/ossec-hids/pull/2107) - Check cdb mmap failure with MAP_FAILED instead of DJB x+1 idiom
 
 

--- a/contrib/ossec-testing/tests/dovecot.ini
+++ b/contrib/ossec-testing/tests/dovecot.ini
@@ -51,8 +51,16 @@ rule = 9771
 alert = 5
 decoder = dovecot-info
 
+[authentication success]
+log 1 pass = Jun 23 15:04:05 hostname dovecot: imap-login: Login: user=<username>, method=PLAIN, rip=1.2.3.4, lip=4.5.6.7,
+
+rule = 9701
+alert = 3
+decoder = dovecot
+
 [session disconnected]
 log 1 pass = Jul  4 17:30:51 hostname dovecot[2992]: pop3-login: Disconnected: rip=1.2.3.4, lip=1.2.3.5
+log 2 pass = Jul  4 17:30:51 hostname dovecot[2992]: pop3-login: Disconnected: rip=1.2.3.4, lip=4.5.6.7,
 
 rule = 9706
 alert = 3

--- a/etc/decoder.xml
+++ b/etc/decoder.xml
@@ -928,6 +928,8 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
   - Jan 11 03:45:09 hostname dovecot: auth-worker(default): sql(username,1.2.3.4): unknown user
   - Jan 11 03:42:09 hostname dovecot: auth(default): pam(user@example.com,1.2.3.4): pam_authenticate() failed: User not known to the underlying authentication module
   - Jul  4 17:30:51 hostname dovecot[2992]: pop3-login: Disconnected: rip=1.2.3.4, lip=1.2.3.5
+  - Jul  4 17:30:51 hostname dovecot[2992]: pop3-login: Disconnected: rip=1.2.3.4, lip=4.5.6.7,
+  - Jun 23 15:04:05 hostname dovecot: imap-login: Login: user=<username>, method=PLAIN, rip=1.2.3.4, lip=4.5.6.7,
   - dovecot: Jun 23 15:04:06 Info: IMAP(username): Disconnected: Logged out bytes=59/566
   - dovecot: May 31 09:43:57 Info: pop3-login: Aborted login (1 authentication attempts): user=<username>, method=PLAIN, rip=::ffff:1.2.3.4, lip=::ffff:1.2.3.5, secured
   - Jan 30 09:37:55 hostname dovecot: pop3-login: Aborted login: user=<username>, method=PLAIN, rip=::ffff:1.2.3.4, lip=::ffff:1.2.3.5
@@ -944,7 +946,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="dovecot-success">
   <parent>dovecot</parent>
   <prematch_pcre2 offset="after_parent">^\w{4}-login: Login: </prematch_pcre2>
-  <pcre2 offset="after_prematch">^user=\<(\S+)\>, method=\S+, rip=(\S+), lip=(\S+), mpid=\S+, (\S*?)$</pcre2>
+  <pcre2 offset="after_prematch">^user=\<(\S+)\>, method=\S+, rip=(\S+), lip=([^,\s]+)(?:,|$)(?: mpid=\S+, (\S*?))?$</pcre2>
   <order>user, srcip, dstip, protocol</order>
 </decoder>
 
@@ -972,7 +974,7 @@ Jan  8 19:32:41 tp.lan dropbear[15165]: Pubkey auth succeeded for 'root' with ke
 <decoder name="dovecot-disconnect">
   <parent>dovecot</parent>
   <prematch_pcre2 offset="after_parent">^\w{4}-login: Disconnected: </prematch_pcre2>
-  <pcre2 offset="after_prematch">^rip=(\S+), lip=(\S+)</pcre2>
+  <pcre2 offset="after_prematch">^rip=(\S+), lip=([^,\s]+)(?:,|$)</pcre2>
   <order>srcip, dstip</order>
 </decoder>
 


### PR DESCRIPTION
Login and disconnect logs that end at lip=addr, were stuffing the comma into dstip; exclude comma from the IP capture and make mpid optional on success so both formats still match.