### PR TITLE
Bind remoted to a set <local_ip> in that address family only (#1611)

### DIFF
--- a/src/config/remote-config.c
+++ b/src/config/remote-config.c
@@ -157,7 +157,13 @@ int Read_Remote(XML_NODE node, void *d1, __attribute__((unused)) void *d2)
             }
         } else if (strcasecmp(node[i]->element, xml_remote_ipv6) == 0) {
             if (strcasecmp(node[i]->content, "yes") == 0) {
-                logr->ipv6[pl] = 1;
+                logr->ipv6[pl] = OS_BIND_IPV6_YES;
+            } else if (strcasecmp(node[i]->content, "no") == 0) {
+                logr->ipv6[pl] = OS_BIND_IPV6_NO;
+            } else {
+                merror(XML_VALUEERR, __local_name, node[i]->element,
+                       node[i]->content);
+                return (OS_INVALID);
             }
         } else if (strcasecmp(node[i]->element, xml_remote_lip) == 0) {
             os_strdup(node[i]->content, logr->lip[pl]);

--- a/src/config/remote-config.h
+++ b/src/config/remote-config.h
@@ -28,7 +28,7 @@ typedef struct _remoted {
     int *proto;
     char **port;
     int *conn;
-    int *ipv6;
+    int *ipv6; /* OS_BIND_IPV6_*: ignored when lip is set */
 
     char **lip;
     os_ip **allowips;

--- a/src/os_auth/main-server.c
+++ b/src/os_auth/main-server.c
@@ -359,7 +359,7 @@ int main(int argc, char **argv)
     }
 
     /* Connect via TCP */
-    netinfo = OS_Bindporttcp(port, NULL);
+    netinfo = OS_Bindporttcp(port, NULL, OS_BIND_IPV6_DEFAULT);
     if (netinfo->status < 0) {
         merror("%s: Unable to bind to port %s", ARGV0, port);
         exit(1);

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -149,7 +149,11 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip, int ip
 
     /* Try to support legacy ipv4 only hosts (dual-stack wildcard only). */
     if ((ip_family == AF_UNSPEC) && (ipv6 != OS_BIND_IPV6_NO) &&
-        ((s == EAI_FAMILY) || (s == EAI_NONAME))) {
+        ((s == EAI_FAMILY) || (s == EAI_NONAME)
+#ifdef EAI_SYSTEM
+         || (s == EAI_SYSTEM)
+#endif
+        )) {
         hints.ai_family = AF_INET;
         hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG;
         s = getaddrinfo(_ip, _port, &hints, &result);
@@ -216,14 +220,14 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip, int ip
             * previous iteration of this loop.
             */
             if (errno == EADDRINUSE) {
-                close (ossock);
+                OS_CloseSocket(ossock);
                 continue;
             }
 
             /* tell them why this address failed */
             verbose ("Bind failed on socket for %s: %s",
                      OS_DecodeSockaddr (rp->ai_addr), strerror (errno));
-            close (ossock);
+            OS_CloseSocket(ossock);
             continue;
         }
 
@@ -231,7 +235,7 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip, int ip
             if (listen(ossock, 32) < 0) {
                 verbose ("Request to listen() failed on socket for %s: %s",
                           OS_DecodeSockaddr (rp->ai_addr), strerror (errno));
-                close (ossock);
+                OS_CloseSocket(ossock);
                 continue;
             }
             verbose ("Request for TCP listen() succeeded.");
@@ -239,6 +243,13 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip, int ip
 
         /* success - accumulate data for select call */
         verbose ("Socket bound for %s", OS_DecodeSockaddr (rp->ai_addr));
+
+        if (ni->fdcnt >= (int)(sizeof(ni->fds) / sizeof(ni->fds[0]))) {
+            verbose ("Too many bound sockets for select(); dropping %s",
+                     OS_DecodeSockaddr (rp->ai_addr));
+            OS_CloseSocket(ossock);
+            break;
+        }
 
         /* save bound socket info for select() */
         ni->fds[ni->fdcnt++] = ossock;  /* increment after use! */

--- a/src/os_net/os_net.c
+++ b/src/os_net/os_net.c
@@ -17,13 +17,14 @@
 agent *os_net_agt;
 
 /* Prototypes */
-static OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip);
+static OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip, int ipv6);
 static int OS_Connect(char *_port, unsigned int protocol, const char *_ip);
 static int OS_DecodeAddrinfo (struct addrinfo *res);
 static char *OS_DecodeSockaddr (struct sockaddr *sa);
 static char *DecodeFamily (int val);
 static char *DecodeSocktype (int val);
 static char *DecodeProtocol (int val);
+static int os_numeric_ip_family(const char *ip);
 
 /* Unix socket -- not for windows */
 #ifndef WIN32
@@ -44,11 +45,36 @@ static socklen_t us_l = sizeof(n_us);
 
 #endif /* WIN32*/
 
+/* Return AF_INET / AF_INET6 for a numeric address, or AF_UNSPEC. */
+static int os_numeric_ip_family(const char *ip)
+{
+    struct addrinfo hints, *res;
+    int family;
+    int s;
+
+    if (ip == NULL || ip[0] == '\0') {
+        return (AF_UNSPEC);
+    }
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_flags = AI_NUMERICHOST;
+    s = getaddrinfo(ip, NULL, &hints, &res);
+    if (s != 0) {
+        return (AF_UNSPEC);
+    }
+
+    family = res->ai_family;
+    freeaddrinfo(res);
+    return (family);
+}
+
 
 /* Bind all relevant ports */
-OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
+OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip, int ipv6)
 {
     int ossock = 0, s;
+    int ip_family;
     struct addrinfo hints, *result, *rp;
     OSNetInfo *ni;			/* return data */
 
@@ -64,31 +90,48 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
     /* init hints for getaddrinfo() */
     memset(&hints, 0, sizeof(struct addrinfo));
 
-   /*
-    * If you cannot bind both IPv4 and IPv6, the problem is likely due to the
-    * AF_INET6 family with the AI_V4MAPPED flag. Alter your Makefile to use the
-    * NOV4MAP define and it should work like a breeze. All of the *BSDs fall
-    * into this category even though AI_V4MAPPED exists in netdb.h (true for
-    * all modern OS's). This should work with all Linux versions too, but the
-    * original code for AF_INET6 was left for Linux because it works.
-    *
-    * d. stoddard - 4/19/2018
-    */
+    ip_family = os_numeric_ip_family(_ip);
+
+    if (ip_family == AF_INET || ip_family == AF_INET6) {
+        /* <local_ip> is set: bind only that address, in its own family. */
+        if (ipv6 != OS_BIND_IPV6_DEFAULT) {
+            verbose("local_ip is set; ipv6 option ignored");
+        }
+        hints.ai_family = ip_family;
+        hints.ai_flags = AI_PASSIVE | AI_NUMERICHOST;
+    } else if (ipv6 == OS_BIND_IPV6_NO) {
+        /* No local_ip, ipv6 disabled: IPv4 wildcard only. */
+        hints.ai_family = AF_INET;
+        hints.ai_flags = AI_PASSIVE | AI_ADDRCONFIG;
+    } else {
+       /*
+        * No local_ip (or a non-numeric host): dual-stack wildcard.
+        *
+        * If you cannot bind both IPv4 and IPv6, the problem is likely due to the
+        * AF_INET6 family with the AI_V4MAPPED flag. Alter your Makefile to use the
+        * NOV4MAP define and it should work like a breeze. All of the *BSDs fall
+        * into this category even though AI_V4MAPPED exists in netdb.h (true for
+        * all modern OS's). This should work with all Linux versions too, but the
+        * original code for AF_INET6 was left for Linux because it works.
+        *
+        * d. stoddard - 4/19/2018
+        */
 
 #if defined(__linux__) && !defined(NOV4MAP)
 #if defined (AI_V4MAPPED)
-    hints.ai_family = AF_INET6;		/* Allow IPv4 and IPv6 */
-    hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG | AI_V4MAPPED;
+        hints.ai_family = AF_INET6;		/* Allow IPv4 and IPv6 */
+        hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG | AI_V4MAPPED;
 #else
-    /* handle as normal IPv4 and IPv6 multi request */
-    hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
-    hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG;
+        /* handle as normal IPv4 and IPv6 multi request */
+        hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
+        hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG;
 #endif /* AI_V4MAPPED */
 #else
-    /* FreeBSD, OpenBSD, NetBSD, and others */
-    hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
-    hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG;
+        /* FreeBSD, OpenBSD, NetBSD, and others */
+        hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
+        hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG;
 #endif
+    }
 
     hints.ai_protocol = _proto;
     if (_proto == IPPROTO_UDP) {
@@ -104,8 +147,9 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
     /* get linked list of adresses */
     s = getaddrinfo(_ip, _port, &hints, &result);
 
-    /* Try to support legacy ipv4 only hosts */
-    if((s == EAI_FAMILY) || (s == EAI_NONAME)) {
+    /* Try to support legacy ipv4 only hosts (dual-stack wildcard only). */
+    if ((ip_family == AF_UNSPEC) && (ipv6 != OS_BIND_IPV6_NO) &&
+        ((s == EAI_FAMILY) || (s == EAI_NONAME))) {
         hints.ai_family = AF_INET;
         hints.ai_flags  = AI_PASSIVE | AI_ADDRCONFIG;
         s = getaddrinfo(_ip, _port, &hints, &result);
@@ -138,6 +182,19 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
                      strerror(errno));
             continue;
         }
+
+#ifdef IPV6_V6ONLY
+        /* A specific IPv6 local_ip must not also accept IPv4-mapped traffic. */
+        if (ip_family == AF_INET6 && rp->ai_family == AF_INET6) {
+            int v6only = 1;
+            if (setsockopt(ossock, IPPROTO_IPV6, IPV6_V6ONLY,
+                           (char *)&v6only, sizeof(v6only)) < 0) {
+                verbose ("setsockopt error: IPV6_V6ONLY: %s", strerror(errno));
+                OS_CloseSocket(ossock);
+                continue;
+            }
+        }
+#endif
 
         if (_proto == IPPROTO_TCP) {
             int flag = 1;
@@ -209,15 +266,15 @@ OSNetInfo *OS_Bindport(char *_port, unsigned int _proto, const char *_ip)
 
 
 /* Bind a TCP port, using the OS_Bindport */
-OSNetInfo *OS_Bindporttcp(char *_port, const char *_ip)
+OSNetInfo *OS_Bindporttcp(char *_port, const char *_ip, int ipv6)
 {
-    return (OS_Bindport(_port, IPPROTO_TCP, _ip));
+    return (OS_Bindport(_port, IPPROTO_TCP, _ip, ipv6));
 }
 
 /* Bind a UDP port, using the OS_Bindport */
-OSNetInfo *OS_Bindportudp(char *_port, const char *_ip)
+OSNetInfo *OS_Bindportudp(char *_port, const char *_ip, int ipv6)
 {
-    return (OS_Bindport(_port, IPPROTO_UDP, _ip));
+    return (OS_Bindport(_port, IPPROTO_UDP, _ip, ipv6));
 }
 
 #ifndef WIN32

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -54,8 +54,8 @@ typedef struct _OSNetInfo {
 } OSNetInfo;
 
 /*
- * OS_Bindport ipv6 flag (used only when _ip is unset).
- * DEFAULT/YES: dual-stack IPv4+IPv6. NO: IPv4-only wildcard.
+ * OS_Bindport ipv6 flag (used when _ip is not a numeric address).
+ * DEFAULT/YES: dual-stack IPv4+IPv6. NO: IPv4-only.
  * A numeric _ip always wins; the ipv6 flag is ignored.
  */
 #define OS_BIND_IPV6_DEFAULT 0
@@ -65,9 +65,9 @@ typedef struct _OSNetInfo {
 /*
  * OS_Bindport*
  * Bind a specific port (protocol and a ip).
- * If the IP is not set, bind all addresses (IPv4 and IPv6 dual-stack)
+ * If _ip is not a numeric address, bind all addresses (IPv4 and IPv6 dual-stack)
  * unless ipv6 is OS_BIND_IPV6_NO (IPv4-only).
- * If the IP is set, bind only that address in its own family.
+ * If _ip is numeric, bind only that address in its own family.
  * Return a pointer to the OSNetInfo struct.
  */
 

--- a/src/os_net/os_net.h
+++ b/src/os_net/os_net.h
@@ -54,14 +54,25 @@ typedef struct _OSNetInfo {
 } OSNetInfo;
 
 /*
+ * OS_Bindport ipv6 flag (used only when _ip is unset).
+ * DEFAULT/YES: dual-stack IPv4+IPv6. NO: IPv4-only wildcard.
+ * A numeric _ip always wins; the ipv6 flag is ignored.
+ */
+#define OS_BIND_IPV6_DEFAULT 0
+#define OS_BIND_IPV6_YES     1
+#define OS_BIND_IPV6_NO      2
+
+/*
  * OS_Bindport*
  * Bind a specific port (protocol and a ip).
- * If the IP is not set, it is going to use ADDR_ANY
+ * If the IP is not set, bind all addresses (IPv4 and IPv6 dual-stack)
+ * unless ipv6 is OS_BIND_IPV6_NO (IPv4-only).
+ * If the IP is set, bind only that address in its own family.
  * Return a pointer to the OSNetInfo struct.
  */
 
-OSNetInfo *OS_Bindporttcp(char *_port, const char *_ip);
-OSNetInfo *OS_Bindportudp(char *_port, const char *_ip);
+OSNetInfo *OS_Bindporttcp(char *_port, const char *_ip, int ipv6);
+OSNetInfo *OS_Bindportudp(char *_port, const char *_ip, int ipv6);
 
 /* OS_BindUnixDomain
  * Bind to a specific file, using the "mode" permissions in

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -161,12 +161,14 @@ int remoted_bind_listener(int position)
 
     /* Bind TCP */
     if (logr.proto[position] == IPPROTO_TCP) {
-        listener->netinfo = OS_Bindporttcp(logr.port[position], logr.lip[position]);
+        listener->netinfo = OS_Bindporttcp(logr.port[position], logr.lip[position],
+                                           logr.ipv6[position]);
         if (listener->netinfo->status < 0) {
             ErrorExit(BIND_ERROR, ARGV0, logr.port[position]);
         }
     } else {
-        listener->netinfo = OS_Bindportudp(logr.port[position], logr.lip[position]);
+        listener->netinfo = OS_Bindportudp(logr.port[position], logr.lip[position],
+                                           logr.ipv6[position]);
         if (listener->netinfo->status < 0) {
             ErrorExit(BIND_ERROR, ARGV0, logr.port[position]);
         }

--- a/src/remoted/remoted.c
+++ b/src/remoted/remoted.c
@@ -159,16 +159,19 @@ int remoted_bind_listener(int position)
         }
     }
 
+    int ipv6_flag;
+
     /* Bind TCP */
+    ipv6_flag = (logr.ipv6) ? logr.ipv6[position] : OS_BIND_IPV6_DEFAULT;
     if (logr.proto[position] == IPPROTO_TCP) {
         listener->netinfo = OS_Bindporttcp(logr.port[position], logr.lip[position],
-                                           logr.ipv6[position]);
+                                           ipv6_flag);
         if (listener->netinfo->status < 0) {
             ErrorExit(BIND_ERROR, ARGV0, logr.port[position]);
         }
     } else {
         listener->netinfo = OS_Bindportudp(logr.port[position], logr.lip[position],
-                                           logr.ipv6[position]);
+                                           ipv6_flag);
         if (listener->netinfo->status < 0) {
             ErrorExit(BIND_ERROR, ARGV0, logr.port[position]);
         }

--- a/src/tests/regressions/Makefile
+++ b/src/tests/regressions/Makefile
@@ -22,6 +22,7 @@ REGRESSION_BINS = \
 	issue_1748_sid_list_crash \
 	issue_1274_auth_ipv6_key \
 	issue_2065_sender_counter \
+	issue_1611_local_ip_bind \
 	jsonout_default
 
 .PHONY: all check clean
@@ -59,6 +60,11 @@ issue_2065_sender_counter: tests/regressions/issue_2065_sender_counter.c os_cryp
 	$(CC) $(CFLAGS) -o $@ tests/regressions/issue_2065_sender_counter.c \
 		-Wl,--start-group shared.a os_regex.a os_crypto.a os_net.a os_xml.a os_zlib.a -Wl,--end-group \
 		-lpcre2-8 -lm -lpthread -lssl -lcrypto -lz
+
+issue_1611_local_ip_bind: tests/regressions/issue_1611_local_ip_bind.c os_net.a shared.a
+	$(CC) $(CFLAGS) -o $@ tests/regressions/issue_1611_local_ip_bind.c \
+		-Wl,--start-group shared.a os_regex.a os_net.a os_xml.a os_zlib.a -Wl,--end-group \
+		-lpcre2-8 -lm -lpthread -lz
 
 # GlobalConf lives in analysisd/config.c (defines _Config Config).
 # Link config.a from a current server build; do not also compile

--- a/src/tests/regressions/README.md
+++ b/src/tests/regressions/README.md
@@ -23,6 +23,8 @@
 #                                      if_matched_sid cross-location
 #   - issue_1748_sid_list_crash        sid_prev_matched overflow + free callback
 #   - issue_1274_auth_ipv6_key         auth IPv6 key handling
+#   - issue_2065_sender_counter        sender_counter isolated from agent 0 rids
+#   - issue_1611_local_ip_bind         remoted local_ip / ipv6 bind family
 #   - jsonout_default                  jsonout_output on when the XML tag is omitted
 #
 # Additional scripts without unified Make targets (manual / historical):

--- a/src/tests/regressions/issue_1611_local_ip_bind.c
+++ b/src/tests/regressions/issue_1611_local_ip_bind.c
@@ -1,0 +1,438 @@
+/*
+ * Regression for issue #1611: <local_ip> binds only that address.
+ *
+ *   make TARGET=server
+ *   make -f tests/regressions/Makefile check
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "shared.h"
+#include "os_net/os_net.h"
+
+static void close_ni(OSNetInfo *ni)
+{
+    int i;
+
+    if (!ni) {
+        return;
+    }
+
+    if (ni->status >= 0) {
+        for (i = 0; i < ni->fdcnt; i++) {
+            OS_CloseSocket(ni->fds[i]);
+        }
+    }
+
+    free(ni);
+}
+
+static int ipv6_loopback_ok(void)
+{
+    int fd;
+    struct sockaddr_in6 sa;
+
+    fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+    if (fd < 0) {
+        return (0);
+    }
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sin6_family = AF_INET6;
+    sa.sin6_addr = in6addr_loopback;
+    sa.sin6_port = 0;
+    if (bind(fd, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        close(fd);
+        return (0);
+    }
+
+    close(fd);
+    return (1);
+}
+
+static int sock_name(int fd, struct sockaddr_storage *ss)
+{
+    socklen_t len = sizeof(*ss);
+
+    memset(ss, 0, sizeof(*ss));
+    if (getsockname(fd, (struct sockaddr *)ss, &len) != 0) {
+        fprintf(stderr, "FAIL: getsockname: %s\n", strerror(errno));
+        return (-1);
+    }
+
+    return (0);
+}
+
+static unsigned short sock_port(const struct sockaddr_storage *ss)
+{
+    if (ss->ss_family == AF_INET) {
+        return (ntohs(((const struct sockaddr_in *)ss)->sin_port));
+    }
+    if (ss->ss_family == AF_INET6) {
+        return (ntohs(((const struct sockaddr_in6 *)ss)->sin6_port));
+    }
+    return (0);
+}
+
+static int addr_is(const struct sockaddr_storage *ss, int family, const char *expect)
+{
+    char buf[INET6_ADDRSTRLEN];
+
+    if (ss->ss_family != family) {
+        return (0);
+    }
+
+    memset(buf, 0, sizeof(buf));
+    if (family == AF_INET) {
+        inet_ntop(AF_INET, &((const struct sockaddr_in *)ss)->sin_addr, buf, sizeof(buf));
+    } else {
+        inet_ntop(AF_INET6, &((const struct sockaddr_in6 *)ss)->sin6_addr, buf, sizeof(buf));
+    }
+
+    return (strcmp(buf, expect) == 0);
+}
+
+static int udp_ready(int fd, int timeout_ms)
+{
+    fd_set rfds;
+    struct timeval tv;
+
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    return (select(fd + 1, &rfds, NULL, NULL, &tv));
+}
+
+static int send_udp(const char *ip, unsigned short port, const char *msg)
+{
+    int fd;
+    int rc;
+    char portstr[8];
+
+    snprintf(portstr, sizeof(portstr), "%u", (unsigned int)port);
+    fd = OS_ConnectUDP(portstr, ip);
+    if (fd < 0) {
+        return (-1);
+    }
+
+    rc = OS_SendUDPbySize(fd, (int)strlen(msg), msg);
+    OS_CloseSocket(fd);
+    return (rc);
+}
+
+static int test_local_ipv4(void)
+{
+    OSNetInfo *ni;
+    struct sockaddr_storage ss;
+    char buf[64];
+    int n;
+
+    ni = OS_Bindportudp("0", "127.0.0.1", OS_BIND_IPV6_DEFAULT);
+    if (!ni || ni->status < 0 || ni->fdcnt != 1) {
+        fprintf(stderr, "FAIL: bind 127.0.0.1\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (sock_name(ni->fds[0], &ss) != 0) {
+        close_ni(ni);
+        return (1);
+    }
+
+    if (!addr_is(&ss, AF_INET, "127.0.0.1")) {
+        fprintf(stderr, "FAIL: 127.0.0.1 bind is not AF_INET 127.0.0.1 (family %d)\n",
+                (int)ss.ss_family);
+        close_ni(ni);
+        return (1);
+    }
+
+    if (send_udp("127.0.0.1", sock_port(&ss), "v4") != 0) {
+        fprintf(stderr, "FAIL: send to 127.0.0.1\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (udp_ready(ni->fds[0], 500) <= 0) {
+        fprintf(stderr, "FAIL: no datagram on IPv4-only bind\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    n = recv(ni->fds[0], buf, sizeof(buf) - 1, 0);
+    if (n < 2 || strncmp(buf, "v4", 2) != 0) {
+        fprintf(stderr, "FAIL: IPv4 payload\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (ipv6_loopback_ok()) {
+        if (send_udp("::1", sock_port(&ss), "v6") == 0) {
+            if (udp_ready(ni->fds[0], 200) > 0) {
+                fprintf(stderr, "FAIL: IPv4 local_ip accepted IPv6 traffic\n");
+                close_ni(ni);
+                return (1);
+            }
+        }
+    }
+
+    close_ni(ni);
+    return (0);
+}
+
+static int test_local_ipv6(void)
+{
+    OSNetInfo *ni;
+    struct sockaddr_storage ss;
+    char buf[64];
+    int n;
+
+    if (!ipv6_loopback_ok()) {
+        printf("SKIP: no IPv6 loopback for ::1 bind\n");
+        return (0);
+    }
+
+    ni = OS_Bindportudp("0", "::1", OS_BIND_IPV6_DEFAULT);
+    if (!ni || ni->status < 0 || ni->fdcnt != 1) {
+        fprintf(stderr, "FAIL: bind ::1\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (sock_name(ni->fds[0], &ss) != 0) {
+        close_ni(ni);
+        return (1);
+    }
+
+    if (!addr_is(&ss, AF_INET6, "::1")) {
+        fprintf(stderr, "FAIL: ::1 bind is not AF_INET6 ::1 (family %d)\n",
+                (int)ss.ss_family);
+        close_ni(ni);
+        return (1);
+    }
+
+    if (send_udp("::1", sock_port(&ss), "v6") != 0) {
+        fprintf(stderr, "FAIL: send to ::1\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (udp_ready(ni->fds[0], 500) <= 0) {
+        fprintf(stderr, "FAIL: no datagram on IPv6-only bind\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    n = recv(ni->fds[0], buf, sizeof(buf) - 1, 0);
+    if (n < 2 || strncmp(buf, "v6", 2) != 0) {
+        fprintf(stderr, "FAIL: IPv6 payload\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (send_udp("127.0.0.1", sock_port(&ss), "v4") == 0) {
+        if (udp_ready(ni->fds[0], 200) > 0) {
+            fprintf(stderr, "FAIL: IPv6 local_ip accepted IPv4 traffic\n");
+            close_ni(ni);
+            return (1);
+        }
+    }
+
+    close_ni(ni);
+    return (0);
+}
+
+static int test_wildcard(void)
+{
+    OSNetInfo *ni;
+    struct sockaddr_storage ss;
+    char buf[64];
+    int n;
+
+    ni = OS_Bindportudp("0", NULL, OS_BIND_IPV6_DEFAULT);
+    if (!ni || ni->status < 0 || ni->fdcnt < 1) {
+        fprintf(stderr, "FAIL: wildcard bind\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (sock_name(ni->fds[0], &ss) != 0) {
+        close_ni(ni);
+        return (1);
+    }
+
+    if (send_udp("127.0.0.1", sock_port(&ss), "v4") != 0) {
+        fprintf(stderr, "FAIL: send IPv4 to wildcard\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (udp_ready(ni->fds[0], 500) <= 0) {
+        fprintf(stderr, "FAIL: wildcard did not accept IPv4\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    n = recv(ni->fds[0], buf, sizeof(buf) - 1, 0);
+    if (n < 2 || strncmp(buf, "v4", 2) != 0) {
+        fprintf(stderr, "FAIL: wildcard IPv4 payload\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (ipv6_loopback_ok()) {
+        int i;
+        int got = 0;
+
+        if (send_udp("::1", sock_port(&ss), "v6") != 0) {
+            fprintf(stderr, "FAIL: send IPv6 to wildcard\n");
+            close_ni(ni);
+            return (1);
+        }
+
+        for (i = 0; i < ni->fdcnt; i++) {
+            if (udp_ready(ni->fds[i], 300) > 0) {
+                n = recv(ni->fds[i], buf, sizeof(buf) - 1, 0);
+                if (n >= 2 && strncmp(buf, "v6", 2) == 0) {
+                    got = 1;
+                    break;
+                }
+            }
+        }
+
+        if (!got) {
+            fprintf(stderr, "FAIL: wildcard did not accept IPv6\n");
+            close_ni(ni);
+            return (1);
+        }
+    }
+
+    close_ni(ni);
+    return (0);
+}
+
+static int test_ipv6_no_wildcard(void)
+{
+    OSNetInfo *ni;
+    struct sockaddr_storage ss;
+
+    ni = OS_Bindportudp("0", NULL, OS_BIND_IPV6_NO);
+    if (!ni || ni->status < 0 || ni->fdcnt != 1) {
+        fprintf(stderr, "FAIL: ipv6=no wildcard bind\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (sock_name(ni->fds[0], &ss) != 0) {
+        close_ni(ni);
+        return (1);
+    }
+
+    if (ss.ss_family != AF_INET) {
+        fprintf(stderr, "FAIL: ipv6=no should bind AF_INET (family %d)\n",
+                (int)ss.ss_family);
+        close_ni(ni);
+        return (1);
+    }
+
+    if (ipv6_loopback_ok()) {
+        if (send_udp("::1", sock_port(&ss), "v6") == 0) {
+            if (udp_ready(ni->fds[0], 200) > 0) {
+                fprintf(stderr, "FAIL: ipv6=no accepted IPv6 traffic\n");
+                close_ni(ni);
+                return (1);
+            }
+        }
+    }
+
+    if (send_udp("127.0.0.1", sock_port(&ss), "v4") != 0) {
+        fprintf(stderr, "FAIL: send IPv4 to ipv6=no wildcard\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (udp_ready(ni->fds[0], 500) <= 0) {
+        fprintf(stderr, "FAIL: ipv6=no wildcard did not accept IPv4\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    close_ni(ni);
+    return (0);
+}
+
+static int test_local_ip_ignores_ipv6(void)
+{
+    OSNetInfo *ni;
+    struct sockaddr_storage ss;
+
+    ni = OS_Bindportudp("0", "127.0.0.1", OS_BIND_IPV6_YES);
+    if (!ni || ni->status < 0 || ni->fdcnt != 1) {
+        fprintf(stderr, "FAIL: local_ip with ipv6=yes\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (sock_name(ni->fds[0], &ss) != 0) {
+        close_ni(ni);
+        return (1);
+    }
+
+    if (!addr_is(&ss, AF_INET, "127.0.0.1")) {
+        fprintf(stderr, "FAIL: ipv6=yes must not override IPv4 local_ip\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    close_ni(ni);
+
+    if (!ipv6_loopback_ok()) {
+        return (0);
+    }
+
+    ni = OS_Bindportudp("0", "::1", OS_BIND_IPV6_NO);
+    if (!ni || ni->status < 0 || ni->fdcnt != 1) {
+        fprintf(stderr, "FAIL: local_ip with ipv6=no\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    if (sock_name(ni->fds[0], &ss) != 0) {
+        close_ni(ni);
+        return (1);
+    }
+
+    if (!addr_is(&ss, AF_INET6, "::1")) {
+        fprintf(stderr, "FAIL: ipv6=no must not override IPv6 local_ip\n");
+        close_ni(ni);
+        return (1);
+    }
+
+    close_ni(ni);
+    return (0);
+}
+
+int main(void)
+{
+    int failed = 0;
+
+    failed |= test_local_ipv4();
+    failed |= test_local_ipv6();
+    failed |= test_wildcard();
+    failed |= test_ipv6_no_wildcard();
+    failed |= test_local_ip_ignores_ipv6();
+
+    if (failed) {
+        return (1);
+    }
+
+    printf("PASS: issue #1611 local_ip bind family\n");
+    return (0);
+}

--- a/src/tests/regressions/issue_1611_local_ip_bind.c
+++ b/src/tests/regressions/issue_1611_local_ip_bind.c
@@ -25,7 +25,7 @@ static void close_ni(OSNetInfo *ni)
         return;
     }
 
-    if (ni->status >= 0) {
+    if (ni->status >= 0 || ni->fdcnt > 0) {
         for (i = 0; i < ni->fdcnt; i++) {
             OS_CloseSocket(ni->fds[i]);
         }
@@ -70,17 +70,6 @@ static int sock_name(int fd, struct sockaddr_storage *ss)
     return (0);
 }
 
-static unsigned short sock_port(const struct sockaddr_storage *ss)
-{
-    if (ss->ss_family == AF_INET) {
-        return (ntohs(((const struct sockaddr_in *)ss)->sin_port));
-    }
-    if (ss->ss_family == AF_INET6) {
-        return (ntohs(((const struct sockaddr_in6 *)ss)->sin6_port));
-    }
-    return (0);
-}
-
 static int addr_is(const struct sockaddr_storage *ss, int family, const char *expect)
 {
     char buf[INET6_ADDRSTRLEN];
@@ -111,6 +100,25 @@ static int udp_ready(int fd, int timeout_ms)
     return (select(fd + 1, &rfds, NULL, NULL, &tv));
 }
 
+static OSNetInfo *bind_udp(const char *ip, int ipv6, unsigned short *port_out)
+{
+    char portstr[8];
+    int port;
+    OSNetInfo *ni;
+
+    *port_out = 0;
+    for (port = 20000; port < 21000; port++) {
+        snprintf(portstr, sizeof(portstr), "%d", port);
+        ni = OS_Bindportudp(portstr, ip, ipv6);
+        if (ni && ni->status >= 0 && ni->fdcnt >= 1) {
+            *port_out = (unsigned short)port;
+            return (ni);
+        }
+        close_ni(ni);
+    }
+    return (NULL);
+}
+
 static int send_udp(const char *ip, unsigned short port, const char *msg)
 {
     int fd;
@@ -134,8 +142,9 @@ static int test_local_ipv4(void)
     struct sockaddr_storage ss;
     char buf[64];
     int n;
+    unsigned short port;
 
-    ni = OS_Bindportudp("0", "127.0.0.1", OS_BIND_IPV6_DEFAULT);
+    ni = bind_udp("127.0.0.1", OS_BIND_IPV6_DEFAULT, &port);
     if (!ni || ni->status < 0 || ni->fdcnt != 1) {
         fprintf(stderr, "FAIL: bind 127.0.0.1\n");
         close_ni(ni);
@@ -154,7 +163,7 @@ static int test_local_ipv4(void)
         return (1);
     }
 
-    if (send_udp("127.0.0.1", sock_port(&ss), "v4") != 0) {
+    if (send_udp("127.0.0.1", port, "v4") != 0) {
         fprintf(stderr, "FAIL: send to 127.0.0.1\n");
         close_ni(ni);
         return (1);
@@ -167,6 +176,9 @@ static int test_local_ipv4(void)
     }
 
     n = recv(ni->fds[0], buf, sizeof(buf) - 1, 0);
+    if (n >= 0) {
+        buf[n] = '\0';
+    }
     if (n < 2 || strncmp(buf, "v4", 2) != 0) {
         fprintf(stderr, "FAIL: IPv4 payload\n");
         close_ni(ni);
@@ -174,7 +186,7 @@ static int test_local_ipv4(void)
     }
 
     if (ipv6_loopback_ok()) {
-        if (send_udp("::1", sock_port(&ss), "v6") == 0) {
+        if (send_udp("::1", port, "v6") == 0) {
             if (udp_ready(ni->fds[0], 200) > 0) {
                 fprintf(stderr, "FAIL: IPv4 local_ip accepted IPv6 traffic\n");
                 close_ni(ni);
@@ -193,13 +205,14 @@ static int test_local_ipv6(void)
     struct sockaddr_storage ss;
     char buf[64];
     int n;
+    unsigned short port;
 
     if (!ipv6_loopback_ok()) {
         printf("SKIP: no IPv6 loopback for ::1 bind\n");
         return (0);
     }
 
-    ni = OS_Bindportudp("0", "::1", OS_BIND_IPV6_DEFAULT);
+    ni = bind_udp("::1", OS_BIND_IPV6_DEFAULT, &port);
     if (!ni || ni->status < 0 || ni->fdcnt != 1) {
         fprintf(stderr, "FAIL: bind ::1\n");
         close_ni(ni);
@@ -218,7 +231,7 @@ static int test_local_ipv6(void)
         return (1);
     }
 
-    if (send_udp("::1", sock_port(&ss), "v6") != 0) {
+    if (send_udp("::1", port, "v6") != 0) {
         fprintf(stderr, "FAIL: send to ::1\n");
         close_ni(ni);
         return (1);
@@ -231,13 +244,16 @@ static int test_local_ipv6(void)
     }
 
     n = recv(ni->fds[0], buf, sizeof(buf) - 1, 0);
+    if (n >= 0) {
+        buf[n] = '\0';
+    }
     if (n < 2 || strncmp(buf, "v6", 2) != 0) {
         fprintf(stderr, "FAIL: IPv6 payload\n");
         close_ni(ni);
         return (1);
     }
 
-    if (send_udp("127.0.0.1", sock_port(&ss), "v4") == 0) {
+    if (send_udp("127.0.0.1", port, "v4") == 0) {
         if (udp_ready(ni->fds[0], 200) > 0) {
             fprintf(stderr, "FAIL: IPv6 local_ip accepted IPv4 traffic\n");
             close_ni(ni);
@@ -255,8 +271,9 @@ static int test_wildcard(void)
     struct sockaddr_storage ss;
     char buf[64];
     int n;
+    unsigned short port;
 
-    ni = OS_Bindportudp("0", NULL, OS_BIND_IPV6_DEFAULT);
+    ni = bind_udp(NULL, OS_BIND_IPV6_DEFAULT, &port);
     if (!ni || ni->status < 0 || ni->fdcnt < 1) {
         fprintf(stderr, "FAIL: wildcard bind\n");
         close_ni(ni);
@@ -268,7 +285,7 @@ static int test_wildcard(void)
         return (1);
     }
 
-    if (send_udp("127.0.0.1", sock_port(&ss), "v4") != 0) {
+    if (send_udp("127.0.0.1", port, "v4") != 0) {
         fprintf(stderr, "FAIL: send IPv4 to wildcard\n");
         close_ni(ni);
         return (1);
@@ -281,6 +298,9 @@ static int test_wildcard(void)
     }
 
     n = recv(ni->fds[0], buf, sizeof(buf) - 1, 0);
+    if (n >= 0) {
+        buf[n] = '\0';
+    }
     if (n < 2 || strncmp(buf, "v4", 2) != 0) {
         fprintf(stderr, "FAIL: wildcard IPv4 payload\n");
         close_ni(ni);
@@ -291,7 +311,7 @@ static int test_wildcard(void)
         int i;
         int got = 0;
 
-        if (send_udp("::1", sock_port(&ss), "v6") != 0) {
+        if (send_udp("::1", port, "v6") != 0) {
             fprintf(stderr, "FAIL: send IPv6 to wildcard\n");
             close_ni(ni);
             return (1);
@@ -300,6 +320,9 @@ static int test_wildcard(void)
         for (i = 0; i < ni->fdcnt; i++) {
             if (udp_ready(ni->fds[i], 300) > 0) {
                 n = recv(ni->fds[i], buf, sizeof(buf) - 1, 0);
+                if (n >= 0) {
+                    buf[n] = '\0';
+                }
                 if (n >= 2 && strncmp(buf, "v6", 2) == 0) {
                     got = 1;
                     break;
@@ -322,8 +345,9 @@ static int test_ipv6_no_wildcard(void)
 {
     OSNetInfo *ni;
     struct sockaddr_storage ss;
+    unsigned short port;
 
-    ni = OS_Bindportudp("0", NULL, OS_BIND_IPV6_NO);
+    ni = bind_udp(NULL, OS_BIND_IPV6_NO, &port);
     if (!ni || ni->status < 0 || ni->fdcnt != 1) {
         fprintf(stderr, "FAIL: ipv6=no wildcard bind\n");
         close_ni(ni);
@@ -343,7 +367,7 @@ static int test_ipv6_no_wildcard(void)
     }
 
     if (ipv6_loopback_ok()) {
-        if (send_udp("::1", sock_port(&ss), "v6") == 0) {
+        if (send_udp("::1", port, "v6") == 0) {
             if (udp_ready(ni->fds[0], 200) > 0) {
                 fprintf(stderr, "FAIL: ipv6=no accepted IPv6 traffic\n");
                 close_ni(ni);
@@ -352,7 +376,7 @@ static int test_ipv6_no_wildcard(void)
         }
     }
 
-    if (send_udp("127.0.0.1", sock_port(&ss), "v4") != 0) {
+    if (send_udp("127.0.0.1", port, "v4") != 0) {
         fprintf(stderr, "FAIL: send IPv4 to ipv6=no wildcard\n");
         close_ni(ni);
         return (1);
@@ -372,8 +396,9 @@ static int test_local_ip_ignores_ipv6(void)
 {
     OSNetInfo *ni;
     struct sockaddr_storage ss;
+    unsigned short port;
 
-    ni = OS_Bindportudp("0", "127.0.0.1", OS_BIND_IPV6_YES);
+    ni = bind_udp("127.0.0.1", OS_BIND_IPV6_YES, &port);
     if (!ni || ni->status < 0 || ni->fdcnt != 1) {
         fprintf(stderr, "FAIL: local_ip with ipv6=yes\n");
         close_ni(ni);
@@ -397,7 +422,7 @@ static int test_local_ip_ignores_ipv6(void)
         return (0);
     }
 
-    ni = OS_Bindportudp("0", "::1", OS_BIND_IPV6_NO);
+    ni = bind_udp("::1", OS_BIND_IPV6_NO, &port);
     if (!ni || ni->status < 0 || ni->fdcnt != 1) {
         fprintf(stderr, "FAIL: local_ip with ipv6=no\n");
         close_ni(ni);


### PR DESCRIPTION


- `OS_Bindport` now treats a numeric `<local_ip>` as that address only. Family comes from the address (`getaddrinfo` + `AI_NUMERICHOST`); `<ipv6>` is ignored when `<local_ip>` is set. An IPv4 `local_ip` is no longer mapped onto a dual-stack IPv6 socket (`AI_V4MAPPED`), which is what made `netstat` show `udp6` for `192.168.x.x:1514`.
- With no `<local_ip>`, default bind is unchanged (Linux dual-stack wildcard). `<ipv6>no</ipv6>` binds IPv4-only (`0.0.0.0`). `<ipv6>` defaults remain unset (`OS_BIND_IPV6_DEFAULT`) so existing configs do not become IPv4-only.
- Adds `src/tests/regressions/issue_1611_local_ip_bind.c`. CHANGELOG is left for the release pass.



closes issue #1611